### PR TITLE
Add floating stats card with totals and highlight-aware metrics

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -20,6 +20,7 @@
     import { AppController } from "./appController";
     import CloneStemmaModal from "./components/clone_stemma_modal/CloneStemmaModal.svelte";
     import SettingsModal from "./components/settings_modal/SettingsModal.svelte";
+    import StatsCard from "./components/stats_card/StatsCard.svelte";
     import { SettingsStorage } from "./settingsStroage";
     import { LocalizedError, t } from "./i18n";
     import { jwtDecode } from "jwt-decode";
@@ -52,6 +53,7 @@
     let error: Error;
     let settingsStorage: SettingsStorage;
     let settings: Settings = DEFAULT_SETTINGS;
+    let highlightVersion = 0;
 
     let controller = new AppController(stemma_backend_url);
 
@@ -187,7 +189,12 @@
         viewMode={settings.viewMode}
         on:personSelected={(e) => personSelectionModal.showPersonDetails({ description: e.detail, pin: pinnedPeople.isPinned(e.detail.id) })}
         on:familySelected={(e) => familySelectionModal.showExistingFamily(e.detail)}
+        on:highlightChanged={() => highlightVersion++}
     />
+
+    {#if !isWorking && stemma && stemmaIndex && highlight}
+        <StatsCard {stemma} {stemmaIndex} {highlight} {highlightVersion} />
+    {/if}
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -137,12 +137,14 @@
                 if (node.type == "person") {
                     highlight.pushPerson(denormalizeId(node.id));
                     renderFullStemma();
+                    dispatch("highlightChanged");
                     d3.select(this).select("circle").attr("r", hoveredPersonR);
                     d3.select(this).select("text").attr("font-weight", "bold");
                 }
                 if (node.type == "family") {
                     highlight.pushFamily(denormalizeId(node.id));
                     renderFullStemma();
+                    dispatch("highlightChanged");
                     d3.select(this).select("circle").attr("r", hoveredFamilyR);
                 }
             })
@@ -150,6 +152,7 @@
                 if (isDragging) return;
                 highlight.pop();
                 renderFullStemma();
+                dispatch("highlightChanged");
             })
             .on("click", (event, node) => {
                 if (node.type == "person") {

--- a/frontend/src/components/stats_card/StatsCard.svelte
+++ b/frontend/src/components/stats_card/StatsCard.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+    import type { Stemma } from "../../model";
+    import { StemmaIndex } from "../../stemmaIndex";
+    import { HiglightLineages } from "../../highlight";
+    import { t } from "../../i18n";
+
+    export let stemma: Stemma;
+    export let stemmaIndex: StemmaIndex;
+    export let highlight: HiglightLineages;
+    export let highlightVersion: number;
+
+    type Stats = {
+        active: boolean;
+        people: number;
+        families: number;
+        depth: number;
+    };
+
+    function totalStats(): Stats {
+        return {
+            active: false,
+            people: stemma.people.length,
+            families: stemma.families.length,
+            depth: stemma.people.length ? stemmaIndex.maxGeneration() + 1 : 0,
+        };
+    }
+
+    function highlightedStats(): Stats {
+        const peopleIds = highlight.highlightedPeopleIds();
+        const familyIds = highlight.highlightedFamilyIds();
+
+        let minGen = Infinity;
+        let maxGen = -Infinity;
+        peopleIds.forEach((id) => {
+            const g = stemmaIndex.lineage(id).generation;
+            if (g < minGen) minGen = g;
+            if (g > maxGen) maxGen = g;
+        });
+
+        const depth = peopleIds.size ? maxGen - minGen + 1 : 0;
+
+        return {
+            active: true,
+            people: peopleIds.size,
+            families: familyIds.size,
+            depth,
+        };
+    }
+
+    $: stats =
+        stemma && stemmaIndex && highlight && highlightVersion >= 0
+            ? highlight.isActive()
+                ? highlightedStats()
+                : totalStats()
+            : null;
+</script>
+
+{#if stats}
+    <aside class="stats-card" class:active={stats.active} aria-live="polite">
+        <div class="title">
+            {stats.active ? $t("stats.highlighted") : ""}
+        </div>
+        <div class="row">
+            <span class="label">{$t("stats.people")}</span>
+            <span class="value">{stats.people}</span>
+        </div>
+        <div class="row">
+            <span class="label">{$t("stats.families")}</span>
+            <span class="value">{stats.families}</span>
+        </div>
+        <div class="row">
+            <span class="label">{$t("stats.depth")}</span>
+            <span class="value">{stats.depth}</span>
+        </div>
+    </aside>
+{/if}
+
+<style>
+    .stats-card {
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        z-index: 1000;
+        padding: 10px 14px;
+        min-width: 140px;
+        background: rgba(33, 37, 41, 0.72);
+        color: rgba(255, 255, 255, 0.88);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 6px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        line-height: 1.55;
+        backdrop-filter: blur(4px);
+        -webkit-backdrop-filter: blur(4px);
+        pointer-events: none;
+        transition: border-color 120ms ease, background 120ms ease;
+        user-select: none;
+    }
+
+    .stats-card.active {
+        border-color: rgba(255, 196, 0, 0.55);
+        background: rgba(33, 37, 41, 0.82);
+    }
+
+    .title {
+        min-height: 14px;
+        font-size: 10px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(255, 196, 0, 0.75);
+        margin-bottom: 4px;
+    }
+
+    .row {
+        display: flex;
+        justify-content: space-between;
+        gap: 14px;
+    }
+
+    .label {
+        color: rgba(255, 255, 255, 0.55);
+    }
+
+    .value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+    }
+</style>

--- a/frontend/src/highlight.test.ts
+++ b/frontend/src/highlight.test.ts
@@ -48,4 +48,25 @@ describe("HiglightLineages", () => {
         highlight.pop();
         expect(highlight.personIsHighlighted("3")).toBe(false);
     });
+
+    test("reports inactive when nothing is selected", () => {
+        const index = new StemmaIndex(stemma);
+        const highlight = new HiglightLineages(index, []);
+        expect(highlight.isActive()).toBe(false);
+        expect(highlight.highlightedPeopleIds().size).toBe(0);
+        expect(highlight.highlightedFamilyIds().size).toBe(0);
+    });
+
+    test("exposes highlighted people and families for active lineage", () => {
+        const index = new StemmaIndex(stemma);
+        const highlight = new HiglightLineages(index, ["1"]);
+        expect(highlight.isActive()).toBe(true);
+        const people = highlight.highlightedPeopleIds();
+        const families = highlight.highlightedFamilyIds();
+        expect(people.has("1")).toBe(true);
+        expect(people.has("2")).toBe(true);
+        expect(people.has("3")).toBe(false);
+        expect(families.has("f1")).toBe(true);
+        expect(families.has("f2")).toBe(false);
+    });
 });

--- a/frontend/src/highlight.ts
+++ b/frontend/src/highlight.ts
@@ -70,6 +70,18 @@ export class HiglightLineages implements Highlight {
         return !this.lineagesData.length || this.allFamilies.has(familyId) || this.allMariages.has(familyId) || this.allUncleFamilies.has(familyId)
     }
 
+    isActive(): boolean {
+        return this.lineagesData.length > 0
+    }
+
+    highlightedPeopleIds(): Set<string> {
+        return this.allPeople
+    }
+
+    highlightedFamilyIds(): Set<string> {
+        return new Set([...this.allFamilies, ...this.allMariages, ...this.allUncleFamilies])
+    }
+
     pushPerson(personId: string) {
         this.lineagesData.push(this.personToLineageData(personId))
         this.remakeCashes()

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -157,6 +157,12 @@ export const en: Record<string, string> = {
 
     // Remove stemma modal
     'removeStemma.title': 'Delete {name}?',
+
+    // Stats card
+    'stats.people': 'people',
+    'stats.families': 'families',
+    'stats.depth': 'depth',
+    'stats.highlighted': 'highlighted',
 };
 
 export const ru: Record<string, string> = {
@@ -284,6 +290,12 @@ export const ru: Record<string, string> = {
 
     // Remove stemma modal
     'removeStemma.title': 'Удалить {name}?',
+
+    // Stats card
+    'stats.people': 'людей',
+    'stats.families': 'семей',
+    'stats.depth': 'глубина',
+    'stats.highlighted': 'подсвечено',
 };
 
 const dictionaries: Record<Locale, Record<string, string>> = { en, ru };


### PR DESCRIPTION
Shows people, families and depth for the whole tree, or for the currently highlighted lineage when hovering/pinning. FullStemma dispatches highlightChanged after each push/pop so the in-place HighlightLineages mutations propagate through a bumped version counter in App.svelte.