### PR TITLE
Floating tree stats card with highlight-aware metrics

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -161,7 +161,7 @@ export const en: Record<string, string> = {
     // Stats card
     'stats.people': 'people',
     'stats.families': 'families',
-    'stats.depth': 'depth',
+    'stats.depth': 'generations',
     'stats.highlighted': 'highlighted',
 };
 
@@ -294,7 +294,7 @@ export const ru: Record<string, string> = {
     // Stats card
     'stats.people': 'людей',
     'stats.families': 'семей',
-    'stats.depth': 'глубина',
+    'stats.depth': 'поколений',
     'stats.highlighted': 'подсвечено',
 };
 


### PR DESCRIPTION
## Summary

- New floating `StatsCard` overlay (`frontend/src/components/stats_card/StatsCard.svelte`) showing people / families / generations counts in the bottom-right corner.
- When a lineage highlight is active, the card switches to a tinted state and reports metrics for the highlighted subset (people, families, generation span).
- Compact 120px monospace table layout with backdrop blur; sits above the canvas without blocking interactions (`pointer-events: none`).
- Adds `stats.people` / `stats.families` / `stats.depth` / `stats.highlighted` i18n keys in both `en` and `ru`. The "depth" metric is labeled **generations** / **поколений** since it counts spanned generations (`maxGen - minGen + 1`), not depth from a root.
- Small `highlight.ts` helpers (`highlightedPeopleIds`, `highlightedFamilyIds`, `isActive`) with unit tests.

## Test plan

- [ ] `cd frontend && npm run check` — passes (0 errors)
- [ ] `cd frontend && npm test` — Jest unit tests for `highlight.ts` pass
- [ ] Manually verify in dev (`npm run dev`):
  - [ ] Card appears bottom-right and shows correct totals for a tree
  - [ ] Selecting a person activates highlight → card tints and switches to highlighted-subset metrics
  - [ ] Clearing the highlight returns the card to totals
  - [ ] Labels render correctly in both EN and RU locales