### PR TITLE
Persist auth token in localStorage to skip re-sign-in across tabs

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -22,13 +22,11 @@
     import SettingsModal from "./components/settings_modal/SettingsModal.svelte";
     import { SettingsStorage } from "./settingsStroage";
     import { LocalizedError, t } from "./i18n";
-    import { jwtDecode } from "jwt-decode";
+    import { loadCredential, saveCredential } from "./credentialStorage";
     import { onMount } from "svelte";
 
     export let google_client_id;
     export let stemma_backend_url;
-
-    const CREDENTIAL_KEY = "stemma_credential";
 
     let addStemmaModal;
     let cloneStemmaModal;
@@ -77,7 +75,7 @@
     }
 
     function handleSignIn(user: User) {
-        sessionStorage.setItem(CREDENTIAL_KEY, user.id_token);
+        saveCredential(user.id_token);
 
         let urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has("inviteToken")) {
@@ -100,16 +98,9 @@
             return;
         }
 
-        try {
-            const credential = sessionStorage.getItem(CREDENTIAL_KEY);
-            if (credential) {
-                const decoded: any = jwtDecode(credential);
-                if (decoded.exp * 1000 > Date.now()) {
-                    handleSignIn({ id_token: credential });
-                }
-            }
-        } catch (e) {
-            sessionStorage.removeItem(CREDENTIAL_KEY);
+        const cached = loadCredential();
+        if (cached) {
+            handleSignIn({ id_token: cached.token });
         }
     });
 

--- a/frontend/src/credentialStorage.test.ts
+++ b/frontend/src/credentialStorage.test.ts
@@ -1,0 +1,74 @@
+import { clearCredential, loadCredential, saveCredential } from "./credentialStorage";
+
+function makeToken(expSeconds: number): string {
+    const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString("base64url");
+    return `${header}.${payload}.`;
+}
+
+describe("credentialStorage", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    test("returns null when nothing is stored", () => {
+        expect(loadCredential()).toBeNull();
+    });
+
+    test("saveCredential persists token and exposes expiry", () => {
+        const expSeconds = Math.floor(Date.now() / 1000) + 3600;
+        const token = makeToken(expSeconds);
+
+        const saved = saveCredential(token);
+
+        expect(saved).not.toBeNull();
+        expect(saved!.token).toBe(token);
+        expect(saved!.expiresAt).toBe(expSeconds * 1000);
+        expect(localStorage.getItem("stemma_credential")).toBe(token);
+    });
+
+    test("loadCredential returns the stored token while it is fresh", () => {
+        const expSeconds = Math.floor(Date.now() / 1000) + 3600;
+        const token = makeToken(expSeconds);
+        saveCredential(token);
+
+        const loaded = loadCredential();
+
+        expect(loaded).not.toBeNull();
+        expect(loaded!.token).toBe(token);
+        expect(loaded!.expiresAt).toBe(expSeconds * 1000);
+    });
+
+    test("loadCredential discards tokens that are already expired", () => {
+        const token = makeToken(Math.floor(Date.now() / 1000) - 60);
+        localStorage.setItem("stemma_credential", token);
+
+        expect(loadCredential()).toBeNull();
+        expect(localStorage.getItem("stemma_credential")).toBeNull();
+    });
+
+    test("loadCredential discards tokens that fall inside the safety buffer", () => {
+        const now = Date.now();
+        const token = makeToken(Math.floor((now + 30_000) / 1000));
+        localStorage.setItem("stemma_credential", token);
+
+        expect(loadCredential(now)).toBeNull();
+        expect(localStorage.getItem("stemma_credential")).toBeNull();
+    });
+
+    test("loadCredential clears unparseable tokens", () => {
+        localStorage.setItem("stemma_credential", "not-a-jwt");
+
+        expect(loadCredential()).toBeNull();
+        expect(localStorage.getItem("stemma_credential")).toBeNull();
+    });
+
+    test("clearCredential removes the stored token", () => {
+        const token = makeToken(Math.floor(Date.now() / 1000) + 3600);
+        saveCredential(token);
+
+        clearCredential();
+
+        expect(localStorage.getItem("stemma_credential")).toBeNull();
+    });
+});

--- a/frontend/src/credentialStorage.ts
+++ b/frontend/src/credentialStorage.ts
@@ -1,0 +1,56 @@
+import { jwtDecode } from "jwt-decode";
+
+const STORAGE_KEY = "stemma_credential";
+const EXPIRY_BUFFER_MS = 60_000;
+
+export type StoredCredential = {
+    token: string;
+    expiresAt: number;
+};
+
+function decodeExpiry(token: string): number | null {
+    const decoded = jwtDecode<{ exp?: number }>(token);
+    if (!decoded || typeof decoded.exp !== "number") return null;
+    return decoded.exp * 1000;
+}
+
+export function loadCredential(now: number = Date.now()): StoredCredential | null {
+    let token: string | null;
+    try {
+        token = localStorage.getItem(STORAGE_KEY);
+    } catch {
+        return null;
+    }
+    if (!token) return null;
+
+    try {
+        const expiresAt = decodeExpiry(token);
+        if (expiresAt === null || expiresAt - EXPIRY_BUFFER_MS <= now) {
+            clearCredential();
+            return null;
+        }
+        return { token, expiresAt };
+    } catch {
+        clearCredential();
+        return null;
+    }
+}
+
+export function saveCredential(token: string): StoredCredential | null {
+    try {
+        const expiresAt = decodeExpiry(token);
+        if (expiresAt === null) return null;
+        localStorage.setItem(STORAGE_KEY, token);
+        return { token, expiresAt };
+    } catch {
+        return null;
+    }
+}
+
+export function clearCredential(): void {
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // ignore storage errors
+    }
+}


### PR DESCRIPTION
## Summary
- Move Google ID token persistence from `sessionStorage` to `localStorage` so opening a fresh tab/browser within the token lifetime no longer prompts the user to sign in again.
- Add `credentialStorage` helper that loads/saves the token and proactively clears expired (with a 60 s safety buffer) or unparseable tokens.
- Drop the inline `jwt-decode` usage and ad-hoc try/catch from `App.svelte` — the helper now owns expiry handling.

## Test plan
- [x] `npm test` (frontend) — new `credentialStorage.test.ts` covers fresh, expired, near-expiry, and malformed tokens (12 suites / 38 tests pass).
- [x] `npm run check` — svelte-check clean.
- [ ] Manual: sign in, close the tab, reopen — app loads without the Google prompt.
- [ ] Manual: sign in, wait until the cached token expires (or clear it), reload — `Authenticate` falls through to Google One Tap with `auto_select: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)