### PR TITLE
Exclude project from uv-exported requirements.txt

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Export backend requirements
         working-directory: backend_py
-        run: uv export --no-dev --no-hashes --format requirements.txt -o requirements.txt
+        run: uv export --no-dev --no-hashes --no-emit-project --format requirements.txt -o requirements.txt
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2


### PR DESCRIPTION
## Summary
- Deploy to AWS failed on master (run 25911339416) because `sam build` couldn't install `backend_py/requirements.txt`: pip reported `does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found` on a `/tmp/tmpXXXX` path.
- Root cause: `uv export` in `.github/workflows/cd.yml` emitted the local `stemma-backend` project as a requirement entry. `build-MyLayer` then ran `pip install -r requirements.txt --target ... --only-binary=:all:`, which is fine for wheels but choked on the local source entry.
- Fix: add `--no-emit-project` to the `uv export` invocation so only third-party deps end up in the layer. The function source is already copied into each artifact by `build-StemmaFunction` / `build-MigrationFunction`.

## Test plan
- [ ] After merge, the next `Deploy to AWS` run completes the `Build SAM` step and proceeds to `sam deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)