### PR TITLE
Accept manylinux_2_28 wheels in SAM layer build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ build-MyLayer:
 	pip install \
 		-r backend_py/requirements.txt \
 		--target $(ARTIFACTS_DIR)/python \
+		--platform manylinux_2_28_aarch64 \
 		--platform manylinux2014_aarch64 \
 		--implementation cp \
 		--python-version 3.13 \


### PR DESCRIPTION
## Summary
- Follow-up to #78. Deploy to AWS still failed on master (run 25912554867) at the `Build SAM` step: `Could not find a version that satisfies the requirement greenlet==3.5.0`.
- Root cause: `pip install --platform manylinux2014_aarch64 --only-binary=:all:` only matches wheels tagged ≤ `manylinux_2_17`. `greenlet 3.5.0` is the version `uv` resolved, but its only aarch64 wheel is tagged `manylinux_2_24_aarch64.manylinux_2_28_aarch64`.
- Fix: pass `--platform manylinux_2_28_aarch64` *in addition to* the existing `manylinux2014_aarch64` so pip accepts newer wheels while still allowing older ones (cffi, watchfiles, etc.) that only ship the legacy tag.
- AWS Lambda Python 3.13 runs on Amazon Linux 2023 (glibc 2.34), so `manylinux_2_28` is well within the runtime's compatibility range.

Locally verified with `pip download -r requirements.txt --platform manylinux_2_28_aarch64 --platform manylinux2014_aarch64 --python-version 3.13 --implementation cp --only-binary=:all:` — all 53 packages resolve.

## Test plan
- [ ] After merge, the next `Deploy to AWS` run gets past `Build SAM` and runs `sam deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)