### PR TITLE
Fetch JDBC and invite secrets at runtime via Secrets Manager

### DIFF
--- a/backend_py/src/stemma/apps/bootstrap.py
+++ b/backend_py/src/stemma/apps/bootstrap.py
@@ -1,10 +1,31 @@
 import base64
+import json
 import os
 from pathlib import Path
 
 from sqlalchemy import Engine, create_engine
 
 _COCKROACH_CERT_PATH = Path("/tmp/cockroach-proud-gnoll.crt")
+
+
+def populate_env_from_secrets() -> None:
+    secret_names = [
+        name
+        for name in (
+            os.environ.get("STEMMA_DB_SECRET_NAME"),
+            os.environ.get("STEMMA_INVITE_SECRET_NAME"),
+        )
+        if name
+    ]
+    if not secret_names:
+        return
+    import boto3  # pyright: ignore[reportMissingImports]  # provided by Lambda runtime
+
+    client = boto3.client("secretsmanager")
+    for name in secret_names:
+        payload = json.loads(client.get_secret_value(SecretId=name)["SecretString"])
+        for key, value in payload.items():
+            os.environ.setdefault(key, value)
 
 
 def write_root_cert() -> None:

--- a/backend_py/src/stemma/apps/lambda_main.py
+++ b/backend_py/src/stemma/apps/lambda_main.py
@@ -5,7 +5,7 @@ import os
 from functools import cache
 
 from stemma.apis.request_handler import RequestHandler
-from stemma.apps.bootstrap import engine_from_env, write_root_cert
+from stemma.apps.bootstrap import engine_from_env, populate_env_from_secrets, write_root_cert
 from stemma.domain.codec import decode_request, encode_error, encode_response
 from stemma.domain.errors import RequestDeserializationProblem, StemmaError, UnknownError
 from stemma.services.user_service import UserService
@@ -17,6 +17,7 @@ logger.setLevel(logging.INFO)
 
 @cache
 def _build() -> tuple[RequestHandler, UserService]:
+    populate_env_from_secrets()
     write_root_cert()
     engine = engine_from_env(pool_pre_ping=True, pool_recycle=300)
     storage = StorageService(engine)

--- a/backend_py/src/stemma/apps/migration_main.py
+++ b/backend_py/src/stemma/apps/migration_main.py
@@ -1,6 +1,6 @@
 import logging
 
-from stemma.apps.bootstrap import engine_from_env, migrations_dir, write_root_cert
+from stemma.apps.bootstrap import engine_from_env, migrations_dir, populate_env_from_secrets, write_root_cert
 from stemma.storage.migrations import run_migrations
 
 logger = logging.getLogger(__name__)
@@ -8,6 +8,7 @@ logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event: dict, context: object) -> str:
+    populate_env_from_secrets()
     write_root_cert()
     engine = engine_from_env()
     run_migrations(engine, migrations_dir())

--- a/template.yaml
+++ b/template.yaml
@@ -12,11 +12,8 @@ Globals:
       - arm64
     Environment:
       Variables:
-        JDBC_URL: "{{resolve:secretsmanager:prod/jdbc:SecretString:JDBC_URL}}"
-        JDBC_USER: "{{resolve:secretsmanager:prod/jdbc:SecretString:JDBC_USER}}"
-        JDBC_PASSWORD: "{{resolve:secretsmanager:prod/jdbc:SecretString:JDBC_PASSWORD}}"
-        JDBC_CERT: "{{resolve:secretsmanager:prod/jdbc:SecretString:JDBC_CERT}}"
-        INVITE_SECRET: "{{resolve:secretsmanager:prod/invite:SecretString:INVITE_SECRET}}"
+        STEMMA_DB_SECRET_NAME: "prod/jdbc"
+        STEMMA_INVITE_SECRET_NAME: "prod/invite"
         GOOGLE_CLIENT_ID: !Sub "${googleAuthClientId}"
     Layers:
       - !Ref MyLayer
@@ -201,6 +198,10 @@ Resources:
       Policies:
         - S3FullAccessPolicy:
             BucketName: stemma-app-backend-assets
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:prod/jdbc-*"
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:prod/invite-*"
   MigrationFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -212,6 +213,11 @@ Resources:
       Environment:
         Variables:
           STEMMA_MIGRATIONS_DIR: /var/task/migrations
+      Policies:
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:prod/jdbc-*"
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:prod/invite-*"
 
 Outputs:
   ApiEndpoint:


### PR DESCRIPTION
## Summary
- Deploy run 25912862538 failed at `Deploy backend` with `Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit`. The CFN validation error then dumped the whole resolved env-var dictionary — including `INVITE_SECRET`, `JDBC_PASSWORD` and the multi-KB `JDBC_CERT` PEM — into the deploy log. That run has been deleted.
- Root cause: `template.yaml` resolved every secret inline with `{{resolve:secretsmanager:prod/jdbc:SecretString:JDBC_CERT}}` etc. The expansion put the entire cert into the Lambda env (4 KB+ → over the limit) and made the secret part of the CFN template, which CFN echoes back verbatim in error messages.
- Fix: pass only the secret *names* (`STEMMA_DB_SECRET_NAME=prod/jdbc`, `STEMMA_INVITE_SECRET_NAME=prod/invite`) as env vars. Each Lambda fetches and unpacks the JSON secret at cold-start via boto3; Secrets Manager decrypts via KMS using the function's IAM role. The cert/credentials never appear in the CFN template, the change set, or any error messages.
- IAM: scoped `AWSSecretsManagerGetSecretValuePolicy` per secret on both `StemmaFunction` and `MigrationFunction`.
- Local dev / e2e are unaffected — neither secret-name env var is set there, so `populate_env_from_secrets()` is a no-op and the existing JDBC_* env vars continue to be honored.

**Note**: the leaked cert was rotated-out-of-band? If not, the JDBC root cert in `prod/jdbc` should be considered exposed (it appeared in a public GitHub Actions log) and rotated.

## Test plan
- [x] `uv run pyright src/stemma/apps/...` clean
- [x] `uv run pytest -q` — 41/41 pass
- [x] `sam validate` — template valid
- [ ] After merge: next `Deploy to AWS` run completes `sam deploy` without 4 KB env error; Lambdas successfully fetch secrets at first invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)