### PR TITLE
Use cockroachdb SQLAlchemy dialect for runtime engines

### DIFF
--- a/backend_py/pyproject.toml
+++ b/backend_py/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
     "sqlalchemy>=2.0",
+    "sqlalchemy-cockroachdb>=2.0",
     "psycopg[binary]>=3.2",
     "pydantic>=2.9",
     "cryptography>=43",

--- a/backend_py/src/stemma/apps/bootstrap.py
+++ b/backend_py/src/stemma/apps/bootstrap.py
@@ -43,7 +43,7 @@ def jdbc_to_sqlalchemy_url(jdbc_url: str, user: str, password: str) -> str:
         if stripped.startswith(prefix):
             stripped = stripped.removeprefix(prefix)
             break
-    return f"postgresql+psycopg://{user}:{password}@{stripped}"
+    return f"cockroachdb+psycopg://{user}:{password}@{stripped}"
 
 
 def engine_from_env(*, pool_pre_ping: bool = False, pool_recycle: int = -1) -> Engine:

--- a/backend_py/uv.lock
+++ b/backend_py/uv.lock
@@ -751,6 +751,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy-cockroachdb"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/46/1462dd4734c58e04b754db71a9607de6d748dedea86e30007b5ae7b4e3db/sqlalchemy_cockroachdb-2.0.4.tar.gz", hash = "sha256:f66354d2b93da89cb4524c5b78a44d0cf5a8943d328b7f0aee4aa1dfc6178b65", size = 31803, upload-time = "2026-04-23T18:12:28.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/f1/e08ec3fc57b6f890e8f6eb16734c4865626635f4863cc2fe7d259699ce7b/sqlalchemy_cockroachdb-2.0.4-py3-none-any.whl", hash = "sha256:0804306a733a1fe09b2d496eadf8bf35d878862b6138e69175136fa2ca0ce5d0", size = 22726, upload-time = "2026-04-23T18:12:26.936Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -774,6 +786,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "sqlalchemy" },
+    { name = "sqlalchemy-cockroachdb" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -796,6 +809,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9" },
     { name = "python-dateutil", specifier = ">=2.9" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "sqlalchemy-cockroachdb", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 


### PR DESCRIPTION
## Summary
- The previous secrets-at-runtime fix unblocked the migration Lambda enough to reach the database, but it then crashed on SQLAlchemy dialect init: production runs CockroachDB and the vanilla `postgresql+psycopg` dialect can't parse the `CockroachDB CCL v25.4.8 ...` version string.
- Add `sqlalchemy-cockroachdb` and emit `cockroachdb+psycopg://` URLs from `jdbc_to_sqlalchemy_url`. The dialect inherits from the PG dialect (still uses psycopg3) but overrides version detection, so connection init no longer asserts.
- Tests construct engines directly from the testcontainer URL and don't go through `jdbc_to_sqlalchemy_url`, so they remain on the plain `postgresql` dialect and continue to pass.

## Test plan
- [x] `uv run pytest -q` in `backend_py/` (41 passed)
- [ ] CD succeeds against CockroachDB Cloud — Migration Lambda completes without `AssertionError: Could not determine version from string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)