### PR TITLE
Migrate storage from CockroachDB to DynamoDB

### DIFF
--- a/.claude/skills/stemma-migration/SKILL.md
+++ b/.claude/skills/stemma-migration/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: stemma-migration
+description: Workflow + reference for one-off corrections to the production Stemma DynamoDB table. Use when the user asks to fix, rename, re-parent, batch-update, add, remove, or inspect items (users, stemmas, persons, families, ownership) in the live DB — anything that cannot be done through the UI. Also covers bulk imports from a JSON file.
+---
+
+# Stemma DynamoDB migrations
+
+One-off corrections to the live single-table DynamoDB store. Migrations are run
+from a local workstation through SSO-issued credentials — Lambda is never
+involved.
+
+## When to apply
+
+- Field-level fixes: "rename stemma X to Y", "set birth_date on person N",
+  "remove stale family", "transfer ownership of stemma S from A to B".
+- Structural fixes: re-parenting, splitting/merging families, deduping persons.
+- Bulk imports of a JSON file of pre-shaped items.
+- Inspecting items the UI does not expose (owner rows, GSI projections,
+  orphaned references).
+
+For business-logic changes that should go through `RequestHandler.handle`, add a
+new `Request` dataclass + handler branch instead — do not migrate around the API.
+
+## AWS access
+
+Production uses AWS Identity Center (SSO). One-time setup:
+
+```sh
+aws configure sso
+# Prompts (values come from your Identity Center portal / admin):
+#   SSO session name        — any label, e.g. "stemma"
+#   SSO start URL           — your organisation's Identity Center start URL
+#   SSO region              — region where the SSO directory lives (often us-east-1)
+#   Account + role          — pick from the list shown
+#   CLI default Region      — eu-central-1 for this project
+#   Profile name            — auto-suggested, accept or customize
+```
+
+Refresh the SSO session whenever it expires (~8 h):
+
+```sh
+aws sso login --profile <profile>
+AWS_PROFILE=<profile> aws sts get-caller-identity   # sanity check before any write
+```
+
+Discover the DynamoDB table name (CloudFormation generates it; never hardcode):
+
+```sh
+AWS_PROFILE=<profile> aws dynamodb list-tables --region eu-central-1
+# look for stemma-app-StemmaTable-XXXXX
+```
+
+## Schema (single table)
+
+Authoritative encoders: `backend_py/src/stemma/storage/schema.py`.
+
+| Item            | `pk`                  | `sk`                              | Extra attrs                                          |
+|-----------------|-----------------------|-----------------------------------|------------------------------------------------------|
+| User PROFILE    | `USER#EMAIL#<email>`  | `PROFILE`                         | `user_id`, `email`                                   |
+| Stemma META     | `STEMMA#<sid>`        | `META`                            | `name`                                               |
+| Person          | `STEMMA#<sid>`        | `PERSON#<pid>`                    | `name`, optional `birth_date`, `death_date`, `bio`   |
+| Family          | `STEMMA#<sid>`        | `FAMILY#<fid>`                    | `parents` (list of pids), `children` (list of pids)  |
+| Stemma owner    | `STEMMA#<sid>`        | `OWNER#STEMMA#<uid>`              | `gsi1pk = USER#<uid>`, `gsi1sk = STEMMA#<sid>`       |
+| Person owner    | `STEMMA#<sid>`        | `OWNER#PERSON#<pid>#<uid>`        | —                                                    |
+| Family owner    | `STEMMA#<sid>`        | `OWNER#FAMILY#<fid>#<uid>`        | —                                                    |
+
+GSI `UserStemmasIndex` is `(gsi1pk, gsi1sk)`. IDs are `uuid4().hex` (32 lowercase
+hex chars). Dates are ISO strings (`YYYY-MM-DD`).
+
+## Workflow
+
+1. **Read first.** Query/GetItem the items you'll touch. Never `Scan` the whole
+   table for a production fix — it's expensive and easy to misuse.
+2. **Back up the affected stemma** with `scripts/dump_stemma.py` before any
+   destructive change; restore with `scripts/apply_seed.py` if needed.
+3. **Write the change as a script** by copying `scripts/migration_template.py`.
+   Place new migration scripts outside git (the data they read often is PII).
+4. **Two phases**: `--dry-run` prints the plan and exits; the default run
+   prints the plan, asks confirmation, then writes.
+5. **Print AWS caller identity** before any write (the template does this).
+6. **Prefer `put_item` over `update_item`** for one-off fixes — read the whole
+   item, modify in memory, put back. Simpler and overwrite-by-default is fine.
+
+## Scripts in this skill
+
+`.claude/skills/stemma-migration/scripts/`:
+
+- **`apply_seed.py`** — apply a JSON array of pre-shaped items. Optional
+  idempotency marker (`SYSTEM`/`MIGRATION_COMPLETE`) so re-runs are no-ops.
+  Supports `--dry-run`, `--force`, `--yes`, prints caller identity + breakdown.
+- **`dump_stemma.py`** — export every item belonging to one stemma to a JSON
+  file. Use before any destructive change as a rollback artifact.
+- **`migration_template.py`** — starter for ad-hoc fixes. Fill in `plan()`,
+  which returns a list of `(key, new_item_or_None)` pairs; the harness handles
+  identity print, dry-run, confirmation, and `batch_writer` writes.
+
+Run pattern (no project venv needed — scripts only depend on `boto3`):
+
+```sh
+AWS_PROFILE=<profile> uvx --with boto3 python \
+  .claude/skills/stemma-migration/scripts/<script>.py \
+  --table stemma-app-StemmaTable-XXXXX --region eu-central-1 --dry-run
+```
+
+Or, if you're already in `backend_py/` with `uv sync` done:
+
+```sh
+AWS_PROFILE=<profile> uv run python \
+  ../.claude/skills/stemma-migration/scripts/<script>.py …
+```
+
+## Common queries
+
+```python
+from boto3.dynamodb.conditions import Key
+
+# All items in a stemma:
+items = table.query(KeyConditionExpression=Key("pk").eq(f"STEMMA#{sid}"))["Items"]
+
+# Just the family rows:
+items = table.query(
+    KeyConditionExpression=Key("pk").eq(f"STEMMA#{sid}") & Key("sk").begins_with("FAMILY#")
+)["Items"]
+
+# Stemmas a user owns (via GSI):
+rows = table.query(
+    IndexName="UserStemmasIndex",
+    KeyConditionExpression=Key("gsi1pk").eq(f"USER#{uid}"),
+)["Items"]
+
+# Look up an existing user by email (do this before minting a new user_id):
+profile = table.get_item(
+    Key={"pk": f"USER#EMAIL#{email}", "sk": "PROFILE"}
+).get("Item")
+```
+
+For larger reads (>1 MB), see the `_query_all` pagination loop in
+`backend_py/src/stemma/storage/storage_service.py`.
+
+## Gotchas
+
+- **Never mint a new `user_id` for an email that already has a PROFILE.** A
+  wrong `user_id` orphans every stemma that user owns. Always look up the
+  existing PROFILE first and reuse its `user_id`.
+- **GSI fields** (`gsi1pk`, `gsi1sk`) belong only on `OWNER#STEMMA#…` rows. Do
+  not add them to `OWNER#PERSON#…` or `OWNER#FAMILY#…` rows.
+- **`Family.parents` / `Family.children`** are stored as ordered lists.
+  Preserve order when rewriting.
+- **Removing a person** also requires rewriting every family that referenced
+  them, and possibly deleting families that drop below two participants.
+  `StorageService.remove_person` is the canonical recipe — mirror its logic.
+- **Cycle check** lives in `stemma.services.stemma_dfs.has_cycles`. For any
+  change that re-shapes the tree, simulate the planned snapshot and call
+  `has_cycles` before writing — otherwise the DB ends up structurally invalid
+  in a way the normal API would have refused.
+- **Idempotency**: `batch_writer.put_item` overwrites by default, so re-running
+  a put-only migration is naturally safe. Deletes are not — guard with a
+  dry-run that prints what will go.
+- **PII** lives in this table (real emails, biographies). Don't paste raw rows
+  into long-lived chat transcripts. Keep migration scripts and any data files
+  they read outside git.

--- a/.claude/skills/stemma-migration/scripts/apply_seed.py
+++ b/.claude/skills/stemma-migration/scripts/apply_seed.py
@@ -1,0 +1,128 @@
+"""Apply a JSON array of pre-shaped DynamoDB items to a Stemma table.
+
+Items in the file must already match the single-table schema (pk, sk, attrs).
+The script does not validate item shape — it just writes them.
+
+If the file ends with a ``SYSTEM``/``MIGRATION_COMPLETE`` marker, the script
+treats it as a one-shot seed: subsequent invocations short-circuit unless
+``--force`` is passed. Without that marker the script always writes.
+
+Usage:
+    aws sso login --profile <profile>
+    AWS_PROFILE=<profile> python apply_seed.py \\
+        --table stemma-app-StemmaTable-XXXXX \\
+        --region eu-central-1 \\
+        --seed path/to/items.json \\
+        --dry-run
+
+    # then drop --dry-run to apply.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+import boto3
+
+SEED_MARKER_KEY: dict[str, str] = {"pk": "SYSTEM", "sk": "MIGRATION_COMPLETE"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.seed.exists():
+        print(f"ERROR: seed file not found: {args.seed}", file=sys.stderr)
+        return 2
+
+    items: list[dict] = json.loads(args.seed.read_text())
+    size_kb = args.seed.stat().st_size / 1024
+
+    print(f"Seed file:    {args.seed}")
+    print(f"Items:        {len(items):,}  ({size_kb:.1f} KB)")
+    print(f"Target table: {args.table}")
+    print(f"Region:       {args.region}")
+    if args.endpoint:
+        print(f"Endpoint:     {args.endpoint}")
+    print(f"Caller:       {_caller_identity(args.region)}")
+
+    table = _table(args.region, args.endpoint, args.table)
+    try:
+        existing_marker = table.get_item(Key=SEED_MARKER_KEY).get("Item")
+    except Exception as exc:
+        print(f"ERROR: cannot reach table {args.table!r}: {exc}", file=sys.stderr)
+        return 3
+
+    if existing_marker:
+        version = existing_marker.get("version")
+        print(f"\nMarker present — table already seeded (version={version}).")
+        if not args.force:
+            print("Use --force to re-apply (overwrites items; does not delete extras).")
+            return 0
+        print("--force: re-applying anyway.")
+
+    if args.dry_run:
+        _show_breakdown(items)
+        print("\n--dry-run: no items written.")
+        return 0
+
+    if not args.yes:
+        reply = input(
+            f"\nWrite {len(items):,} items to {args.table!r} in {args.region}? [y/N] "
+        ).strip().lower()
+        if reply not in {"y", "yes"}:
+            print("Aborted.")
+            return 1
+
+    with table.batch_writer() as batch:
+        for item in items:
+            batch.put_item(Item=item)
+    print(f"\nDone. Wrote {len(items):,} items.")
+    return 0
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--table", required=True, help="DynamoDB table name")
+    p.add_argument("--region", default="eu-central-1", help="AWS region (default: eu-central-1)")
+    p.add_argument("--endpoint", help="DynamoDB endpoint URL (for DynamoDB Local)")
+    p.add_argument("--seed", required=True, type=Path, help="Path to JSON array of items")
+    p.add_argument("--dry-run", action="store_true", help="Print plan, do not write")
+    p.add_argument("--yes", action="store_true", help="Skip interactive confirmation")
+    p.add_argument("--force", action="store_true", help="Re-apply even if marker is present")
+    return p.parse_args(argv)
+
+
+def _table(region: str, endpoint: str | None, name: str):
+    kwargs: dict = {"region_name": region}
+    if endpoint:
+        kwargs["endpoint_url"] = endpoint
+    return boto3.resource("dynamodb", **kwargs).Table(name)
+
+
+def _caller_identity(region: str) -> str:
+    try:
+        ident = boto3.client("sts", region_name=region).get_caller_identity()
+        return f"account={ident['Account']}  arn={ident['Arn']}"
+    except Exception as exc:
+        return f"(could not resolve: {exc})"
+
+
+def _show_breakdown(items: list[dict]) -> None:
+    kinds: Counter[str] = Counter()
+    for it in items:
+        sk = it["sk"]
+        if sk in {"PROFILE", "META", "MIGRATION_COMPLETE"}:
+            kinds[sk] += 1
+        else:
+            kinds[sk.split("#")[0] + "#…"] += 1
+    print("\nBreakdown:")
+    for k, v in sorted(kinds.items()):
+        print(f"  {k:24s} {v:>5}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/stemma-migration/scripts/dump_stemma.py
+++ b/.claude/skills/stemma-migration/scripts/dump_stemma.py
@@ -1,0 +1,79 @@
+"""Export every item belonging to one stemma to a JSON file.
+
+Useful before any destructive change — apply_seed.py can restore the dump.
+
+Usage:
+    aws sso login --profile <profile>
+    AWS_PROFILE=<profile> python dump_stemma.py \\
+        --table stemma-app-StemmaTable-XXXXX \\
+        --stemma <stemma_uuid_hex> \\
+        --out backup.json
+
+The output is a JSON array of items in the exact shape apply_seed.py expects.
+``Decimal`` attributes (DynamoDB's default for numbers) are emitted as plain
+int/float so the file is human-readable and round-trips through apply_seed.py.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--table", required=True, help="DynamoDB table name")
+    p.add_argument("--region", default="eu-central-1", help="AWS region")
+    p.add_argument("--endpoint", help="DynamoDB endpoint URL (for DynamoDB Local)")
+    p.add_argument("--stemma", required=True, help="Stemma id (just the uuid hex, no STEMMA# prefix)")
+    p.add_argument("--out", type=Path, required=True, help="Output JSON path")
+    args = p.parse_args(argv)
+
+    kwargs: dict = {"region_name": args.region}
+    if args.endpoint:
+        kwargs["endpoint_url"] = args.endpoint
+    table = boto3.resource("dynamodb", **kwargs).Table(args.table)
+
+    print(f"Caller:  {_caller_identity(args.region)}", file=sys.stderr)
+    print(f"Table:   {args.table}  ({args.region})", file=sys.stderr)
+    print(f"Stemma:  {args.stemma}", file=sys.stderr)
+
+    pk = f"STEMMA#{args.stemma}"
+    items: list[dict] = []
+    kw: dict = {"KeyConditionExpression": Key("pk").eq(pk)}
+    while True:
+        response = table.query(**kw)
+        items.extend(response.get("Items", []))
+        last = response.get("LastEvaluatedKey")
+        if not last:
+            break
+        kw["ExclusiveStartKey"] = last
+
+    args.out.write_text(json.dumps(items, ensure_ascii=False, default=_jsonable))
+    print(f"Wrote {len(items):,} items to {args.out}", file=sys.stderr)
+    return 0 if items else 4
+
+
+def _jsonable(obj: object) -> object:
+    if isinstance(obj, Decimal):
+        return int(obj) if obj == obj.to_integral_value() else float(obj)
+    raise TypeError(f"not json-serializable: {type(obj).__name__}")
+
+
+def _caller_identity(region: str) -> str:
+    try:
+        ident = boto3.client("sts", region_name=region).get_caller_identity()
+        return f"account={ident['Account']}  arn={ident['Arn']}"
+    except Exception as exc:
+        return f"(could not resolve: {exc})"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/stemma-migration/scripts/migration_template.py
+++ b/.claude/skills/stemma-migration/scripts/migration_template.py
@@ -1,0 +1,108 @@
+"""Template for an ad-hoc Stemma DynamoDB migration.
+
+Copy this file, rename after the fix (e.g. ``rename_my_stemma.py``), then fill
+in ``plan(table)`` so it returns a list of ``(key, new_item_or_None)`` pairs:
+
+- ``(key, dict)``  → ``put_item`` the dict (overwrites in place)
+- ``(key, None)``  → ``delete_item`` the key
+
+The harness prints caller identity, target table, the plan, and asks for
+confirmation before writing. Use ``--dry-run`` to preview without writing.
+
+Read the items you intend to change with ``GetItem`` or ``Query`` first; never
+``Scan`` for a production fix.
+
+Schema reference: ``backend_py/src/stemma/storage/schema.py``.
+"""
+from __future__ import annotations
+
+import argparse
+
+import boto3
+from boto3.dynamodb.conditions import Key  # noqa: F401  (typically used in plan())
+
+Change = tuple[dict, dict | None]
+
+
+def plan(table) -> list[Change]:
+    """Return the list of (key, new_item_or_None) pairs.
+
+    Replace this body with the migration's read + transform logic.
+    """
+    # ----------------------------- examples -----------------------------
+    #
+    # Rename a stemma:
+    #     sid = "0123456789abcdef0123456789abcdef"
+    #     key = {"pk": f"STEMMA#{sid}", "sk": "META"}
+    #     item = table.get_item(Key=key)["Item"]
+    #     item["name"] = "New name"
+    #     return [(key, item)]
+    #
+    # Delete a stray family + its owner rows:
+    #     sid, fid = "...", "..."
+    #     fkey = {"pk": f"STEMMA#{sid}", "sk": f"FAMILY#{fid}"}
+    #     owners = table.query(
+    #         KeyConditionExpression=Key("pk").eq(f"STEMMA#{sid}")
+    #             & Key("sk").begins_with(f"OWNER#FAMILY#{fid}#"),
+    #     )["Items"]
+    #     return [(fkey, None)] + [({"pk": o["pk"], "sk": o["sk"]}, None) for o in owners]
+    #
+    # ---------------------------------------------------------------------
+    raise NotImplementedError("fill in plan()")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--table", required=True, help="DynamoDB table name")
+    p.add_argument("--region", default="eu-central-1", help="AWS region")
+    p.add_argument("--endpoint", help="DynamoDB endpoint URL (for DynamoDB Local)")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--yes", action="store_true")
+    args = p.parse_args(argv)
+
+    session = boto3.session.Session(region_name=args.region)
+    res_kwargs: dict = {}
+    if args.endpoint:
+        res_kwargs["endpoint_url"] = args.endpoint
+    table = session.resource("dynamodb", **res_kwargs).Table(args.table)
+
+    ident = session.client("sts").get_caller_identity()
+    print(f"Caller: account={ident['Account']}  arn={ident['Arn']}")
+    print(f"Table:  {args.table}  ({args.region})")
+
+    changes = plan(table)
+    print(f"\nPlan: {len(changes)} change(s)")
+    for key, new in changes[:10]:
+        marker = "DELETE" if new is None else "PUT   "
+        print(f"  {marker}  {key}")
+    if len(changes) > 10:
+        print(f"  … and {len(changes) - 10} more")
+
+    if args.dry_run:
+        print("\n--dry-run: no items written.")
+        return 0
+
+    if not changes:
+        print("Nothing to do.")
+        return 0
+
+    if not args.yes:
+        reply = input(f"\nApply {len(changes)} change(s) to {args.table!r}? [y/N] ").strip().lower()
+        if reply not in {"y", "yes"}:
+            print("Aborted.")
+            return 1
+
+    with table.batch_writer() as batch:
+        for key, new in changes:
+            if new is None:
+                batch.delete_item(Key=key)
+            else:
+                batch.put_item(Item=new)
+    print(f"\nDone — {len(changes)} writes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ Optional / context-dependent:
 - `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` — Standard boto3 config. For Lambda, the runtime injects these; for local use any non-empty values when pointed at DynamoDB Local.
 - `E2E_AUTH_BYPASS` — When `"1"`, the REST server accepts any bearer token (e2e use only).
 
+One-off corrections to the production DynamoDB table go through the `stemma-migration` skill (see `.claude/skills/stemma-migration/`).
+
 Lambda-only (set in `template.yaml` Globals or by `bootstrap`):
 - `STEMMA_INVITE_SECRET_NAME` — Secrets Manager ID fetched at cold start; its JSON contents populate `INVITE_SECRET` via `os.environ.setdefault`.
 


### PR DESCRIPTION
## Summary
- Full backend rewrite from Scala to Python (FastAPI + boto3 + pydantic, managed with `uv`), shipped as a Python 3.13 arm64 Lambda with a shared layer.
- Switch storage from CockroachDB (SQLAlchemy/JDBC) to DynamoDB on-demand, single-table layout with one GSI (`UserStemmasIndex`).
- Wire format moves to internally-tagged unions; central dispatch via `RequestHandler.handle` over a typed `Request`/`Response` union (pydantic `TypeAdapter`).
- Build/deploy tooling: SAM template + Makefile assemble Lambda artifacts and the shared layer from `backend_py/`; CI runs `uv run pytest` / frontend / e2e; CD does `uv export` → `sam build`/`deploy` → frontend upload → CloudFront invalidation.
- Frontend Dependabot patches + bump CI Node to 22.
- Add `stemma-migration` Claude skill (`.claude/skills/stemma-migration/`) for one-off DynamoDB corrections that can't go through the API — workflow guide, schema cheat sheet, plus three production-ready scripts (`apply_seed.py`, `dump_stemma.py`, `migration_template.py`) with dry-run + caller-identity print.

## Test plan
- [ ] CI: `uv run pytest` green in `backend_py/` (41 tests)
- [ ] CI: frontend Jest + `npm run check` green
- [ ] CI: e2e Playwright run via `scripts/devstack.mjs` green
- [ ] Manual: deploy to a non-prod stack, sign in via Google, create + edit a stemma, verify list/clone/remove operations
- [ ] Verify `STEMMA_INVITE_SECRET_NAME` Secrets Manager lookup populates `INVITE_SECRET` on cold start
- [ ] Smoke-test the migration skill scripts (`apply_seed.py --help`, `dump_stemma.py --help`, `migration_template.py --help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)