### PR TITLE
Pop deferred hover highlight after a drag ends

### DIFF
--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -42,6 +42,7 @@
 
     let svg;
     let isDragging = false;
+    let pendingMouseLeave = false;
 
     $: if (svg && stemma) {
         loadCoordinates(currentStemmaId);
@@ -133,7 +134,10 @@
         svg.select("g.main")
             .selectAll("g")
             .on("mouseenter", function (event, node) {
-                if (isDragging) return;
+                if (isDragging) {
+                    pendingMouseLeave = false;
+                    return;
+                }
                 if (node.type == "person") {
                     highlight.pushPerson(denormalizeId(node.id));
                     renderFullStemma();
@@ -149,7 +153,10 @@
                 }
             })
             .on("mouseleave", (_event, node) => {
-                if (isDragging) return;
+                if (isDragging) {
+                    pendingMouseLeave = true;
+                    return;
+                }
                 highlight.pop();
                 renderFullStemma();
                 dispatch("highlightChanged");
@@ -167,7 +174,23 @@
             });
 
         renderChart(svg, highlight, stemmaIndex);
-        makeDrag(svg, simulation, currentStemmaId, () => isDragging = true, () => isDragging = false);
+        makeDrag(
+            svg,
+            simulation,
+            currentStemmaId,
+            () => {
+                isDragging = true;
+            },
+            () => {
+                isDragging = false;
+                if (pendingMouseLeave) {
+                    pendingMouseLeave = false;
+                    highlight.pop();
+                    renderFullStemma();
+                    dispatch("highlightChanged");
+                }
+            }
+        );
     }
 
     onMount(() => {


### PR DESCRIPTION
## Summary
- `FullStemma.svelte` early-returned from `mouseleave` while `isDragging` was true. If the cursor left the dragged node mid-drag (common because d3 captures pointer events), no further `mouseleave` fired after release and the lineage `pushPerson`/`pushFamily` from the original `mouseenter` was never popped — leaving the node visually highlighted with nothing pinned.
- Track a `pendingMouseLeave` flag when a leave is suppressed during a drag; clear it if the cursor re-enters a node mid-drag; replay the pop + re-render in the drag-end callback.

Closes #85

## Test plan
- [x] `npm run check` clean
- [x] `npm test` (frontend Jest suites) passes
- [ ] Manual: with no pinned people, drag a node and release with the cursor off any node — highlighting should clear
- [ ] Manual: drag and release with the cursor still over the dragged node — highlighting should remain
- [ ] Manual: pinned-node highlighting behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)