### PR TITLE
Cache d3 node positions per stemma in localStorage

### DIFF
--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -9,6 +9,7 @@
     import {
         configureSimulation,
         resetSessionPositions,
+        setActiveLayoutCache,
         initChart,
         makeDrag,
         makeNodesAndRelations,
@@ -19,6 +20,7 @@
         denormalizeId,
     } from "../graphTools";
     import { computeInitialLayout } from "../initialLayout";
+    import { NodeLayoutCache } from "../nodeLayoutCache";
     import { PinnedPeopleStorage } from "../pinnedPeopleStorage";
 
     const dispatch = createEventDispatcher();
@@ -39,8 +41,17 @@
     let svg;
     let isDragging = false;
     let pendingMouseLeave = false;
+    let layoutCache: NodeLayoutCache | null = null;
+    let layoutCacheStemmaId: string | null = null;
 
     $: if (svg && stemma) {
+        if (layoutCacheStemmaId !== currentStemmaId) {
+            if (layoutCache) layoutCache.save();
+            layoutCache = new NodeLayoutCache(currentStemmaId);
+            layoutCache.load();
+            layoutCacheStemmaId = currentStemmaId;
+        }
+        setActiveLayoutCache(layoutCache);
         resetSessionPositions(currentStemmaId);
         let people, families;
 
@@ -126,10 +137,15 @@
 
     let simulation;
     function reconfigureGraph(nodes, relations, initialPositions) {
+        const fullyCached =
+            !!layoutCache && nodes.length > 0 && layoutCache.coverage(nodes.map((n) => n.id)) === 1;
+
         if (!simulation) simulation = configureSimulation(svg, nodes, relations, window.innerWidth, window.innerHeight);
         else updateSimulation(simulation, nodes, relations);
 
         mergeData(svg, nodes, relations, window.innerWidth, window.innerHeight, initialPositions, pinnedPeople);
+
+        if (fullyCached) simulation.alphaTarget(0).alpha(0);
 
         svg.select("g.main")
             .selectAll("g")

--- a/frontend/src/graphTools.js
+++ b/frontend/src/graphTools.js
@@ -54,12 +54,17 @@ export function initChart(svgSelector) {
 
 let sessionPositions = new Map()
 let cachedStemmaId = null
+let activeLayoutCache = null
 
 export function resetSessionPositions(stemmaId) {
     if (cachedStemmaId !== stemmaId) {
         sessionPositions = new Map()
         cachedStemmaId = stemmaId
     }
+}
+
+export function setActiveLayoutCache(cache) {
+    activeLayoutCache = cache || null
 }
 
 export function configureSimulation(svg, nodes, relations, width, height) {
@@ -82,6 +87,7 @@ export function configureSimulation(svg, nodes, relations, width, height) {
                 .selectAll("g")
                 .attr("transform", (d) => {
                     sessionPositions.set(d.id, [d.x, d.y])
+                    if (activeLayoutCache) activeLayoutCache.set(d.id, d.x, d.y, d.vx ?? 0, d.vy ?? 0)
                     return "translate(" + d.x + "," + d.y + ")"
                 });
 
@@ -90,6 +96,9 @@ export function configureSimulation(svg, nodes, relations, width, height) {
                 .attr("y1", (d) => d.source.y)
                 .attr("x2", (d) => d.target.x)
                 .attr("y2", (d) => d.target.y);
+        })
+        .on("end", () => {
+            if (activeLayoutCache) activeLayoutCache.save()
         });
 }
 
@@ -156,11 +165,17 @@ export function mergeData(svg, nodes, relations, width, height, initialPositions
 
     nodes.forEach(n => {
         let pos;
+        let vel;
         if (!ignoreCache) {
             if (n.type === "person" && pinnedPeople) {
                 const personId = denormalizeId(n.id);
                 const pinned = pinnedPeople.getPosition(personId);
                 if (pinned) pos = pinned;
+            }
+            if (!pos && activeLayoutCache && activeLayoutCache.has(n.id)) {
+                const cached = activeLayoutCache.get(n.id);
+                pos = [cached.x, cached.y];
+                vel = [cached.vx, cached.vy];
             }
             if (!pos && sessionPositions.has(n.id)) {
                 pos = sessionPositions.get(n.id);
@@ -175,6 +190,10 @@ export function mergeData(svg, nodes, relations, width, height, initialPositions
 
         n.x = pos[0];
         n.y = pos[1];
+        if (vel) {
+            n.vx = vel[0];
+            n.vy = vel[1];
+        }
     })
 
     svg.select("g.main")

--- a/frontend/src/nodeLayoutCache.test.ts
+++ b/frontend/src/nodeLayoutCache.test.ts
@@ -1,0 +1,88 @@
+import { NodeLayoutCache } from "./nodeLayoutCache";
+
+describe("NodeLayoutCache", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test("load on missing storage leaves cache empty", () => {
+        const cache = new NodeLayoutCache("stemma-1");
+        cache.load();
+        expect(cache.has("n1")).toBe(false);
+        expect(cache.get("n1")).toBeNull();
+    });
+
+    test("set/get round-trip and survives reload after save", () => {
+        const cache = new NodeLayoutCache("stemma-1");
+        cache.load();
+        cache.set("n1", 10, 20, 0.5, -0.25);
+        cache.save();
+
+        expect(cache.get("n1")).toEqual({ x: 10, y: 20, vx: 0.5, vy: -0.25 });
+
+        const reloaded = new NodeLayoutCache("stemma-1");
+        reloaded.load();
+        expect(reloaded.get("n1")).toEqual({ x: 10, y: 20, vx: 0.5, vy: -0.25 });
+    });
+
+    test("debounced save flushes after the timer fires", () => {
+        const cache = new NodeLayoutCache("stemma-1");
+        cache.load();
+        cache.set("n1", 1, 2);
+        expect(localStorage.getItem("nodeLayout.stemma-1")).toBeNull();
+
+        jest.advanceTimersByTime(500);
+
+        const reloaded = new NodeLayoutCache("stemma-1");
+        reloaded.load();
+        expect(reloaded.get("n1")).toEqual({ x: 1, y: 2, vx: 0, vy: 0 });
+    });
+
+    test("two stemmas keep separate caches", () => {
+        const a = new NodeLayoutCache("stemma-a");
+        const b = new NodeLayoutCache("stemma-b");
+        a.set("n1", 1, 1);
+        b.set("n1", 9, 9);
+        a.save();
+        b.save();
+
+        const ra = new NodeLayoutCache("stemma-a");
+        ra.load();
+        const rb = new NodeLayoutCache("stemma-b");
+        rb.load();
+        expect(ra.get("n1")?.x).toBe(1);
+        expect(rb.get("n1")?.x).toBe(9);
+    });
+
+    test("coverage reports fraction of cached node ids", () => {
+        const cache = new NodeLayoutCache("stemma-1");
+        cache.load();
+        cache.set("n1", 0, 0);
+        cache.set("n2", 0, 0);
+        expect(cache.coverage(["n1", "n2", "n3", "n4"])).toBe(0.5);
+        expect(cache.coverage([])).toBe(0);
+    });
+
+    test("entries without numeric x/y are skipped on load", () => {
+        localStorage.setItem(
+            "nodeLayout.stemma-1",
+            JSON.stringify({ items: { n1: { x: "bad", y: 0 }, n2: { x: 5, y: 6 } } })
+        );
+        const cache = new NodeLayoutCache("stemma-1");
+        cache.load();
+        expect(cache.has("n1")).toBe(false);
+        expect(cache.get("n2")).toEqual({ x: 5, y: 6, vx: 0, vy: 0 });
+    });
+
+    test("ignores corrupted localStorage payload", () => {
+        localStorage.setItem("nodeLayout.stemma-1", "not-json");
+        const cache = new NodeLayoutCache("stemma-1");
+        cache.load();
+        expect(cache.has("n1")).toBe(false);
+    });
+});

--- a/frontend/src/nodeLayoutCache.ts
+++ b/frontend/src/nodeLayoutCache.ts
@@ -1,0 +1,82 @@
+export type CachedNodeState = {
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+};
+
+const SAVE_DEBOUNCE_MS = 500;
+
+export class NodeLayoutCache {
+    private storageKey: string;
+    private items: Map<string, CachedNodeState>;
+    private saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(stemmaId: string) {
+        this.storageKey = `nodeLayout.${stemmaId}`;
+        this.items = new Map();
+    }
+
+    load() {
+        this.items = new Map();
+        const raw = localStorage.getItem(this.storageKey);
+        if (!raw) return;
+        try {
+            const parsed = JSON.parse(raw);
+            const items = parsed?.items;
+            if (!items || typeof items !== "object") return;
+            for (const [id, entry] of Object.entries(items)) {
+                if (!entry || typeof entry !== "object") continue;
+                const e = entry as Partial<CachedNodeState>;
+                if (typeof e.x !== "number" || typeof e.y !== "number") continue;
+                this.items.set(id, {
+                    x: e.x,
+                    y: e.y,
+                    vx: typeof e.vx === "number" ? e.vx : 0,
+                    vy: typeof e.vy === "number" ? e.vy : 0,
+                });
+            }
+        } catch {
+            // ignore corrupted storage
+        }
+    }
+
+    save() {
+        if (this.saveTimer != null) {
+            clearTimeout(this.saveTimer);
+            this.saveTimer = null;
+        }
+        const items: Record<string, CachedNodeState> = {};
+        for (const [id, state] of this.items.entries()) {
+            items[id] = state;
+        }
+        localStorage.setItem(this.storageKey, JSON.stringify({ items }));
+    }
+
+    has(nodeId: string): boolean {
+        return this.items.has(nodeId);
+    }
+
+    get(nodeId: string): CachedNodeState | null {
+        return this.items.get(nodeId) ?? null;
+    }
+
+    set(nodeId: string, x: number, y: number, vx = 0, vy = 0) {
+        this.items.set(nodeId, { x, y, vx, vy });
+        this.scheduleSave();
+    }
+
+    coverage(nodeIds: string[]): number {
+        if (nodeIds.length === 0) return 0;
+        const hits = nodeIds.reduce((n, id) => n + (this.items.has(id) ? 1 : 0), 0);
+        return hits / nodeIds.length;
+    }
+
+    private scheduleSave() {
+        if (this.saveTimer != null) return;
+        this.saveTimer = setTimeout(() => {
+            this.saveTimer = null;
+            this.save();
+        }, SAVE_DEBOUNCE_MS);
+    }
+}


### PR DESCRIPTION
## Summary
- New `NodeLayoutCache` persists each d3 node's `x/y/vx/vy` to `localStorage`, keyed per stemma id, with debounced writes during simulation and a final flush on `end`.
- `FullStemma` swaps the active cache when the current stemma changes and feeds it into `mergeData` so previously seen layouts restore instantly.
- When every node in the incoming graph is already cached, the simulation is dampened to `alpha(0)` to avoid a re-stabilization wobble after reload.

## Test plan
- [x] `npm test` (frontend Jest, 59 tests pass) — new `nodeLayoutCache.test.ts` covers load/save round-trip, debounce, per-stemma isolation, coverage math, and corrupted-payload handling.
- [x] `npm run check` (svelte-check, 0 errors)
- [ ] Manual: open a stemma, drag a few nodes, reload — nodes should appear at the saved positions with no visible re-layout pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)