### PR TITLE
Support per-user rename of shared stemmas

### DIFF
--- a/backend_py/src/stemma/apis/request_handler.py
+++ b/backend_py/src/stemma/apis/request_handler.py
@@ -12,6 +12,7 @@ from stemma.domain.requests import (
     DeleteStemmaRequest,
     GetStemmaRequest,
     ListDescribeStemmasRequest,
+    RenameStemmaRequest,
     Request,
     UpdateFamilyRequest,
     UpdatePersonRequest,
@@ -63,6 +64,8 @@ class RequestHandler:
                 return self._update_person(user, request)
             case CloneStemmaRequest():
                 return self._clone_stemma(user, request)
+            case RenameStemmaRequest():
+                return self._rename_stemma(user, request)
 
     def _list_describe_stemmas(self, user: User, request: ListDescribeStemmasRequest) -> OwnedStemmas:
         existing = self._storage.list_owned_stemmas(user.user_id)
@@ -134,3 +137,6 @@ class RequestHandler:
         cloned = self._storage.clone_stemma(user.user_id, request.stemma_id, request.stemma_name)
         owned = self._storage.list_owned_stemmas(user.user_id)
         return CloneResult(created_stemma=cloned, stemmas=owned)
+
+    def _rename_stemma(self, user: User, request: RenameStemmaRequest) -> StemmaDescription:
+        return self._storage.rename_stemma(user.user_id, request.stemma_id, request.new_name)

--- a/backend_py/src/stemma/domain/requests.py
+++ b/backend_py/src/stemma/domain/requests.py
@@ -101,6 +101,13 @@ class CloneStemmaRequest:
 
 
 @dataclass(frozen=True, config=DOMAIN_CONFIG)
+class RenameStemmaRequest:
+    stemma_id: str
+    new_name: str
+    type: Literal["RenameStemmaRequest"] = "RenameStemmaRequest"
+
+
+@dataclass(frozen=True, config=DOMAIN_CONFIG)
 class DeletePersonRequest:
     stemma_id: str
     person_id: str
@@ -126,6 +133,7 @@ Request = Annotated[
     | DeleteStemmaRequest
     | ListDescribeStemmasRequest
     | CloneStemmaRequest
+    | RenameStemmaRequest
     | DeletePersonRequest
     | UpdatePersonRequest,
     Discriminator("type"),

--- a/backend_py/src/stemma/storage/schema.py
+++ b/backend_py/src/stemma/storage/schema.py
@@ -17,6 +17,8 @@ stemma a user owns by querying gsi1pk = USER#<user_id>.
 SK_PROFILE = "PROFILE"
 SK_META = "META"
 
+ATTR_DISPLAY_NAME = "display_name"
+
 STEMMA_PK_PREFIX = "STEMMA#"
 PERSON_PREFIX = "PERSON#"
 FAMILY_PREFIX = "FAMILY#"

--- a/backend_py/src/stemma/storage/storage_service.py
+++ b/backend_py/src/stemma/storage/storage_service.py
@@ -25,6 +25,7 @@ from stemma.services.kinship import FamilyLink, kinsmen_families, members_of
 from stemma.services.stemma_dfs import has_cycles
 from stemma.storage.effects import ChownEffect
 from stemma.storage.schema import (
+    ATTR_DISPLAY_NAME,
     FAMILY_OWNER_PREFIX,
     FAMILY_PREFIX,
     GSI1_INDEX_NAME,
@@ -111,19 +112,33 @@ class StorageService:
             IndexName=GSI1_INDEX_NAME,
             KeyConditionExpression=Key("gsi1pk").eq(user_gsi_pk(user_id)),
         ).get("Items", [])
-        stemma_ids = [parse_id_after_prefix(row["gsi1sk"], STEMMA_PK_PREFIX) for row in owner_rows]
-        if not stemma_ids:
+        if not owner_rows:
             return []
         descriptions: list[StemmaDescription] = []
-        for sid in stemma_ids:
+        for row in owner_rows:
+            sid = parse_id_after_prefix(row["gsi1sk"], STEMMA_PK_PREFIX)
             meta = self._table.get_item(Key={"pk": stemma_pk(sid), "sk": SK_META}).get("Item")
             if meta is None:
                 continue
             owners_count = self._count_stemma_owners(sid)
+            display_name = row.get(ATTR_DISPLAY_NAME) or meta["name"]
             descriptions.append(
-                StemmaDescription(id=sid, name=meta["name"], removable=owners_count == 1)
+                StemmaDescription(id=sid, name=display_name, removable=owners_count == 1)
             )
         return descriptions
+
+    def rename_stemma(self, user_id: str, stemma_id: str, new_name: str) -> StemmaDescription:
+        snapshot = self._load_snapshot(stemma_id)
+        self._require_stemma_access(snapshot, user_id)
+        self._table.update_item(
+            Key={"pk": stemma_pk(stemma_id), "sk": stemma_owner_sk(user_id)},
+            UpdateExpression="SET #n = :n",
+            ExpressionAttributeNames={"#n": ATTR_DISPLAY_NAME},
+            ExpressionAttributeValues={":n": new_name},
+        )
+        return StemmaDescription(
+            id=stemma_id, name=new_name, removable=len(snapshot.stemma_owners) == 1
+        )
 
     def remove_stemma(self, user_id: str, stemma_id: str) -> None:
         snapshot = self._load_snapshot(stemma_id)

--- a/backend_py/tests/test_rest_app.py
+++ b/backend_py/tests/test_rest_app.py
@@ -60,6 +60,36 @@ def test_create_family_returns_stemma_with_family_and_people(
     assert names == ["Jane", "John", "Josh"]
 
 
+def test_rename_stemma_updates_only_callers_display_name(
+    storage: StorageService, users: UserService
+) -> None:
+    client = _client(storage, users)
+    headers = {"Authorization": "Bearer user@example.com"}
+    listed = client.post(
+        "/stemma",
+        headers=headers,
+        json={"type": "ListDescribeStemmasRequest", "defaultStemmaName": "Original"},
+    ).json()
+    stemma_id = listed["stemmas"][0]["id"]
+
+    response = client.post(
+        "/stemma",
+        headers=headers,
+        json={"type": "RenameStemmaRequest", "stemmaId": stemma_id, "newName": "My label"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["type"] == "StemmaDescription"
+    assert body["name"] == "My label"
+
+    re_listed = client.post(
+        "/stemma",
+        headers=headers,
+        json={"type": "ListDescribeStemmasRequest", "defaultStemmaName": "Unused"},
+    ).json()
+    assert re_listed["stemmas"][0]["name"] == "My label"
+
+
 def test_missing_authorization_header_returns_401(
     storage: StorageService, users: UserService
 ) -> None:

--- a/backend_py/tests/test_storage_service.py
+++ b/backend_py/tests/test_storage_service.py
@@ -326,6 +326,36 @@ def test_can_remove_stemma_if_only_owner(storage: StorageService) -> None:
     assert storage.list_owned_stemmas(user.user_id) == []
 
 
+def test_rename_stemma_only_affects_caller(storage: StorageService) -> None:
+    creator = storage.get_or_create_user("creator@test.com")
+    accessor = storage.get_or_create_user("accessor@test.com")
+    sid = storage.create_stemma(creator.user_id, "shared name")
+    _, fam = storage.create_family(creator.user_id, sid, family(create_jane)(create_jill))
+    jill = fam.children[0]
+    storage.chown(accessor.user_id, sid, jill)
+
+    storage.rename_stemma(accessor.user_id, sid, "my private name")
+
+    assert [s.name for s in storage.list_owned_stemmas(creator.user_id)] == ["shared name"]
+    assert [s.name for s in storage.list_owned_stemmas(accessor.user_id)] == ["my private name"]
+
+
+def test_rename_stemma_overwrites_previous_override(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "first")
+    storage.rename_stemma(user.user_id, sid, "second")
+    storage.rename_stemma(user.user_id, sid, "third")
+    assert [s.name for s in storage.list_owned_stemmas(user.user_id)] == ["third"]
+
+
+def test_rename_stemma_denied_if_not_owner(storage: StorageService) -> None:
+    creator = storage.get_or_create_user("creator@test.com")
+    other = storage.get_or_create_user("other@test.com")
+    sid = storage.create_stemma(creator.user_id, "shared")
+    with pytest.raises(AccessToStemmaDenied):
+        storage.rename_stemma(other.user_id, sid, "hijack")
+
+
 def test_can_clone_stemma(storage: StorageService) -> None:
     user = storage.get_or_create_user("user1@test.com")
     sid = storage.create_stemma(user.user_id, "original stemma")

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@
     import AboutModal from "./components/about/About.svelte";
     import { AppController } from "./appController";
     import CloneStemmaModal from "./components/clone_stemma_modal/CloneStemmaModal.svelte";
+    import RenameStemmaModal from "./components/rename_stemma_modal/RenameStemmaModal.svelte";
     import SettingsModal from "./components/settings_modal/SettingsModal.svelte";
     import StatsCard from "./components/stats_card/StatsCard.svelte";
     import { SettingsStorage } from "./settingsStroage";
@@ -31,6 +32,7 @@
 
     let addStemmaModal;
     let cloneStemmaModal;
+    let renameStemmaModal;
     let removeStemmaModal;
     let familySelectionModal;
     let personSelectionModal;
@@ -112,6 +114,7 @@
     <AddStemmaModal bind:this={addStemmaModal} on:stemmaAdded={(e) => controller.addStemma(e.detail)} />
     <RemoveStemmaModal bind:this={removeStemmaModal} on:stemmaRemoved={(e) => controller.removeStemma(e.detail)} />
     <CloneStemmaModal bind:this={cloneStemmaModal} on:stemmaCloned={(e) => controller.cloneStemma(e.detail.name, e.detail.stemmaId)} />
+    <RenameStemmaModal bind:this={renameStemmaModal} on:stemmaRenamed={(e) => controller.renameStemma(e.detail.stemmaId, e.detail.name)} />
     <SettingsModal
         bind:this={settingsModal}
         on:settingsChanged={(e) => {
@@ -146,6 +149,7 @@
         on:selectStemma={(e) => controller.selectStemma(e.detail)}
         on:createNewStemma={() => addStemmaModal.promptNewStemma()}
         on:cloneStemma={(e) => cloneStemmaModal.promptStemmaClone(e.detail)}
+        on:renameStemma={(e) => renameStemmaModal.promptStemmaRename(e.detail.id, e.detail.name)}
         on:createNewFamily={() => familySelectionModal.promptNewFamily()}
         on:removeStemma={(e) => removeStemmaModal.askForConfirmation(e.detail)}
         on:invite={() => inviteModal.showInvintation()}

--- a/frontend/src/appController.ts
+++ b/frontend/src/appController.ts
@@ -136,6 +136,23 @@ export class AppController {
             .finally(() => this.isWorking.set(false))
     }
 
+    renameStemma(stemmaId: string, newName: string) {
+        this.isWorking.set(true)
+        this.err.set(null)
+        this.model
+            .renameStemma(stemmaId, newName)
+            .then((updated) => {
+                this.ownedStemmas.update((stemmas) =>
+                    stemmas.map((s) => (s.id === updated.id ? updated : s))
+                )
+            })
+            .catch(err => {
+                this.err.set(err)
+                console.error('Err when renaming stemma: ', err.stack);
+            })
+            .finally(() => this.isWorking.set(false))
+    }
+
     addStemma(stemmaName: string) {
         this.isWorking.set(true)
         this.err.set(null)

--- a/frontend/src/components/Navbar.svelte
+++ b/frontend/src/components/Navbar.svelte
@@ -62,6 +62,12 @@
                                                 href="/"
                                                 on:click|preventDefault={() => dispatch("selectStemma", s.id)}>{s.name}</a
                                             >
+                                            <button
+                                                type="button"
+                                                class="btn btn-outline-secondary btn-sm ms-1 {disabled ? 'd-none' : ''}"
+                                                aria-label={$t("stemma.rename")}
+                                                on:click={() => dispatch("renameStemma", s)}><i class="bi bi-pencil"></i></button
+                                            >
                                             {#if s.id != currentStemmaId && s.removable}
                                                 <button
                                                     type="button"

--- a/frontend/src/components/rename_stemma_modal/RenameStemmaModal.svelte
+++ b/frontend/src/components/rename_stemma_modal/RenameStemmaModal.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+    import { createEventDispatcher } from "svelte";
+    import { onMount } from "svelte";
+    import * as bootstrap from "bootstrap";
+    import { t } from "../../i18n";
+
+    const dispatch = createEventDispatcher();
+
+    let modalEl;
+    let input;
+    let renamedStemmaId;
+
+    onMount(() => {
+        modalEl.addEventListener("shown.bs.modal", () => input.focus());
+    });
+
+    function handleRenameClick() {
+        bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+        let name = input.value;
+        input.value = "";
+        dispatch("stemmaRenamed", { stemmaId: renamedStemmaId, name: name });
+    }
+
+    export function promptStemmaRename(stemmaId: string, currentName: string) {
+        renamedStemmaId = stemmaId;
+        if (input) input.value = currentName;
+        bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+</script>
+
+<div
+    class="modal fade"
+    id="renameStemmaModal"
+    data-bs-backdrop="static"
+    data-bs-keyboard="false"
+    tabindex="-1"
+    aria-labelledby="renameStemmaLabel"
+    aria-hidden="true"
+    bind:this={modalEl}
+>
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="renameStemmaLabel">{$t("stemma.renameTitle")}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <label for="renameStemmaInput" class="form-label">{$t("stemma.nameLabel")}</label>
+                <input class="form-control" id="renameStemmaInput" bind:this={input} />
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
+                <button type="button" class="btn btn-primary" on:click={handleRenameClick}>{$t("stemma.rename")}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -136,6 +136,10 @@ export const en: Record<string, string> = {
     'stemma.cloneTitle': 'Clone family tree',
     'stemma.clone': 'Clone',
 
+    // Rename stemma modal
+    'stemma.renameTitle': 'Rename family tree',
+    'stemma.rename': 'Rename',
+
     // Family details modal
     'family.compositionTitle': 'Family composition',
     'family.selectMemberTitle': 'Select family member',
@@ -268,6 +272,10 @@ export const ru: Record<string, string> = {
     // Clone stemma modal
     'stemma.cloneTitle': 'Клонировать родословную',
     'stemma.clone': 'Клонировать',
+
+    // Rename stemma modal
+    'stemma.renameTitle': 'Переименовать родословную',
+    'stemma.rename': 'Переименовать',
 
     // Family details modal
     'family.compositionTitle': 'Состав семьи',

--- a/frontend/src/model.ts
+++ b/frontend/src/model.ts
@@ -38,6 +38,7 @@ export type UpdateFamilyRequest = { type: "UpdateFamilyRequest", stemmaId: strin
 export type BearInvitationRequest = { type: "BearInvitationRequest", encodedToken: string }
 export type CloneStemmaRequest = { type: "CloneStemmaRequest", stemmaId: string, stemmaName: string }
 export type ListDescribeStemmasRequest = { type: "ListDescribeStemmasRequest", defaultStemmaName: string }
+export type RenameStemmaRequest = { type: "RenameStemmaRequest", stemmaId: string, newName: string }
 
 type Request =
     | CreateFamilyRequest
@@ -52,6 +53,7 @@ type Request =
     | DeletePersonRequest
     | UpdatePersonRequest
     | CloneStemmaRequest
+    | RenameStemmaRequest
 
 
 //responses
@@ -187,6 +189,10 @@ export class Model {
 
     async cloneStemma(stemmaId: string, name: string): Promise<CloneResult> {
         return this.send<CloneResult>({ type: "CloneStemmaRequest", stemmaId, stemmaName: name }, null)
+    }
+
+    async renameStemma(stemmaId: string, newName: string): Promise<StemmaDescription> {
+        return this.send<StemmaDescription>({ type: "RenameStemmaRequest", stemmaId, newName }, null)
     }
 
     private async send<R extends StemmaResponse>(request: Request, stemmaIndex: StemmaIndex | null): Promise<R> {


### PR DESCRIPTION
## Summary
- Each user can rename any stemma they have access to; the override is stored as `display_name` on their per-user `OWNER#STEMMA#<uid>` row.
- `list_owned_stemmas` reads the override from the GSI projection and falls back to the shared META `name`, so co-owners keep seeing the original name (or their own override).
- New `RenameStemmaModal` + pencil button on every entry in the Navbar dropdown; wired through `Model.renameStemma` and `AppController.renameStemma`. New `stemma.rename` / `stemma.renameTitle` keys in en + ru.

Closes #88

## Test plan
- [x] `uv run pytest` (48 passed) — includes 3 new storage tests (per-user isolation, overwrite, access-denied) + 1 REST test
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `npm test` (59 passed)
- [x] `npm run check`
- [ ] Manual: rename a stemma, share via invite link, confirm the second account still sees the original name and can set its own override

🤖 Generated with [Claude Code](https://claude.com/claude-code)