### PR TITLE
Align edit buttons in stemma list dropdown

### DIFF
--- a/e2e/tests/dropdown_align.spec.ts
+++ b/e2e/tests/dropdown_align.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+const NAMES = ["A", "A very long stemma name that should ellipsize quite far", "Middle"];
+
+test("stemma dropdown buttons line up", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.locator("#navbarDropdownMenuLink")).toBeVisible();
+  // Wait for initial load (creates a default stemma) to finish.
+  await expect(page.locator(".dropdown-menu .stemma-row")).toHaveCount(1, { timeout: 30_000 });
+
+  for (const name of NAMES) {
+    await page.locator("#navbarDropdownMenuLink").click();
+    await page.locator(".dropdown-menu a.dropdown-item", { hasText: /Create new|Создать нов/ }).click();
+    const modal = page.locator(".modal.show", { hasText: /Add new family tree|Добавить новую родословную/ });
+    await expect(modal).toBeVisible();
+    await modal.locator("#stemmaNameInput").fill(name);
+    await modal.getByRole("button", { name: /^Add$|^Добавить$/ }).click();
+    await expect(modal).toBeHidden();
+  }
+
+  await page.locator("#navbarDropdownMenuLink").click();
+  const rows = page.locator(".dropdown-menu .stemma-row");
+  await expect(rows).toHaveCount(NAMES.length + 1, { timeout: 30_000 });
+
+  const renameRights: number[] = [];
+  const lastRights: number[] = [];
+  const rowCount = await rows.count();
+  for (let i = 0; i < rowCount; i++) {
+    const row = rows.nth(i);
+    const actions = row.locator(".stemma-action");
+    expect(await actions.count()).toBe(2);
+    const renameBox = await actions.nth(0).boundingBox();
+    const lastBox = await actions.nth(1).boundingBox();
+    expect(renameBox).not.toBeNull();
+    expect(lastBox).not.toBeNull();
+    renameRights.push(Math.round(renameBox!.x + renameBox!.width));
+    lastRights.push(Math.round(lastBox!.x + lastBox!.width));
+  }
+
+  console.log("rename right edges:", renameRights);
+  console.log("last-button right edges:", lastRights);
+
+  for (const r of renameRights) expect(Math.abs(r - renameRights[0])).toBeLessThanOrEqual(1);
+  for (const r of lastRights) expect(Math.abs(r - lastRights[0])).toBeLessThanOrEqual(1);
+
+  await page.screenshot({ path: "test-results/dropdown-en.png", fullPage: false });
+});

--- a/frontend/src/components/Navbar.svelte
+++ b/frontend/src/components/Navbar.svelte
@@ -56,32 +56,39 @@
                             <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                                 {#each ownedStemmas as s}
                                     <li>
-                                        <div class="d-flex flex-row mt-1 me-1">
+                                        <div class="stemma-row d-flex flex-row align-items-center mt-1 me-1">
                                             <a
-                                                class="dropdown-item {s.id == currentStemmaId ? 'active' : ''}  {disabled ? 'd-none' : ''}"
+                                                class="dropdown-item stemma-name {s.id == currentStemmaId ? 'active' : ''}  {disabled ? 'd-none' : ''}"
                                                 href="/"
                                                 on:click|preventDefault={() => dispatch("selectStemma", s.id)}>{s.name}</a
                                             >
                                             <button
                                                 type="button"
-                                                class="btn btn-outline-secondary btn-sm ms-1 {disabled ? 'd-none' : ''}"
+                                                class="btn btn-outline-secondary btn-sm ms-1 stemma-action {disabled ? 'd-none' : ''}"
                                                 aria-label={$t("stemma.rename")}
                                                 on:click={() => dispatch("renameStemma", s)}><i class="bi bi-pencil"></i></button
                                             >
                                             {#if s.id != currentStemmaId && s.removable}
                                                 <button
                                                     type="button"
-                                                    class="btn btn-danger btn-sm ms-1 {disabled ? 'd-none' : ''}"
+                                                    class="btn btn-danger btn-sm ms-1 stemma-action {disabled ? 'd-none' : ''}"
                                                     aria-label={$t("common.delete")}
                                                     on:click={(e) => dispatch("removeStemma", s)}><i class="bi bi-trash"></i></button
                                                 >
                                             {:else if s.id == currentStemmaId}
                                                 <button
                                                     type="button"
-                                                    class="btn btn-primary btn-sm ms-1 {disabled ? 'd-none' : ''}"
+                                                    class="btn btn-primary btn-sm ms-1 stemma-action {disabled ? 'd-none' : ''}"
                                                     aria-label={$t("stemma.clone")}
                                                     on:click={(e) => dispatch("cloneStemma", s.id)}><i class="bi bi-subtract"></i></button
                                                 >
+                                            {:else}
+                                                <button
+                                                    type="button"
+                                                    tabindex="-1"
+                                                    aria-hidden="true"
+                                                    class="btn btn-sm ms-1 stemma-action stemma-action-placeholder"
+                                                ><i class="bi bi-trash"></i></button>
                                             {/if}
                                         </div>
                                     </li>
@@ -152,5 +159,22 @@
     .lang-switch:focus-visible {
         color: rgba(255, 255, 255, 0.75);
         text-decoration: none;
+    }
+
+    .stemma-row .stemma-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .stemma-row .stemma-action {
+        flex: 0 0 auto;
+    }
+
+    .stemma-action-placeholder {
+        visibility: hidden;
+        pointer-events: none;
     }
 </style>


### PR DESCRIPTION
## Summary
- Closes #100
- Make the stemma name link `flex-grow` with ellipsis so the rename/delete/clone buttons line up in a consistent column across all rows regardless of name length
- For rows that have no delete/clone (non-current + non-removable), render an invisible placeholder button so the rename column doesn't shift

## Test plan
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm test` (frontend Jest) — 14 suites, 59 tests pass
- [x] New Playwright regression test `e2e/tests/dropdown_align.spec.ts` creates short/medium/long-named stemmas, opens the dropdown, asserts the right-edges of rename and last-action buttons match within ±1px across all rows — passes
- [x] Visual check via Playwright screenshot: pencil buttons aligned at the same x across rows; delete/clone buttons aligned at the same x across rows; long names ellipsize within their slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)