### PR TITLE
Reduce cold-start and first-load latency (#90)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,16 +58,31 @@ jobs:
           STEMMA_BACKEND_URL: ${{ secrets.STEMMA_BACKEND_URL }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
 
-      - name: Upload to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'eu-central-1'
-          SOURCE_DIR: 'frontend/public'
+      - name: Hash frontend bundles
+        working-directory: frontend
+        run: node scripts/hash-build.mjs
+
+      - name: Upload hashed bundles to S3
+        run: |
+          aws s3 sync frontend/public/build s3://${{ secrets.AWS_S3_BUCKET }}/build \
+            --exclude "*" \
+            --include "bundle-*.js" --include "bundle-*.css" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --delete
+
+      - name: Upload static assets to S3
+        run: |
+          aws s3 sync frontend/public s3://${{ secrets.AWS_S3_BUCKET }} \
+            --exclude "index.html" \
+            --exclude "build/bundle-*.js" --exclude "build/bundle-*.css" \
+            --cache-control "public, max-age=86400" \
+            --delete
+
+      - name: Upload index.html to S3
+        run: |
+          aws s3 cp frontend/public/index.html s3://${{ secrets.AWS_S3_BUCKET }}/index.html \
+            --cache-control "no-cache" \
+            --content-type "text/html"
 
       - name: Invalidate CloudFront
         uses: chetan/invalidate-cloudfront-action@v2

--- a/backend_py/src/stemma/apps/lambda_main.py
+++ b/backend_py/src/stemma/apps/lambda_main.py
@@ -1,15 +1,21 @@
-import base64
-import json
-import logging
-import os
-from functools import cache
+import time
 
-from stemma.apis.request_handler import RequestHandler
-from stemma.apps.bootstrap import dynamo_table_from_env, populate_env_from_secrets
-from stemma.domain.codec import decode_request, encode_error, encode_response
-from stemma.domain.errors import RequestDeserializationProblem, StemmaError, UnknownError
-from stemma.services.user_service import UserService
-from stemma.storage.storage_service import StorageService
+_LAMBDA_INIT_START = time.perf_counter()
+
+import base64  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import os  # noqa: E402
+from functools import cache  # noqa: E402
+
+from stemma.apis.request_handler import RequestHandler  # noqa: E402
+from stemma.apps.bootstrap import dynamo_table_from_env, populate_env_from_secrets  # noqa: E402
+from stemma.domain.codec import decode_request, encode_error, encode_response  # noqa: E402
+from stemma.domain.errors import RequestDeserializationProblem, StemmaError, UnknownError  # noqa: E402
+from stemma.services.user_service import UserService  # noqa: E402
+from stemma.storage.storage_service import StorageService  # noqa: E402
+
+_IMPORTS_DONE = time.perf_counter()
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -19,11 +25,24 @@ logger.setLevel(logging.INFO)
 def _build() -> tuple[RequestHandler, UserService]:
     # Cached so warm Lambda invocations reuse the table client + handler instead
     # of rebuilding (and rehitting Secrets Manager) on every request.
+    build_start = time.perf_counter()
     populate_env_from_secrets()
+    secrets_done = time.perf_counter()
     table = dynamo_table_from_env()
+    table_done = time.perf_counter()
     storage = StorageService(table)
     users = UserService(storage, os.environ["INVITE_SECRET"])
-    return RequestHandler(storage, users), users
+    handler = RequestHandler(storage, users)
+    services_done = time.perf_counter()
+    logger.info(
+        "cold_start_phases imports_ms=%.1f secrets_ms=%.1f dynamo_ms=%.1f services_ms=%.1f init_total_ms=%.1f",
+        (_IMPORTS_DONE - _LAMBDA_INIT_START) * 1000,
+        (secrets_done - build_start) * 1000,
+        (table_done - secrets_done) * 1000,
+        (services_done - table_done) * 1000,
+        (services_done - _LAMBDA_INIT_START) * 1000,
+    )
+    return handler, users
 
 
 def lambda_handler(event: dict, context: object) -> str:

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,12 +7,15 @@
 
 	<title>project stemma</title>
 
+	<link rel="preconnect" href="https://accounts.google.com">
 	<link rel='icon' type='image/webp' href='assets/favicon.webp'>
 	<link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css" />
 	<link rel="stylesheet" href="vendor/bootstrap-icons/font/bootstrap-icons.css">
 	<link rel='stylesheet' href='build/bundle.css'>
 	<link rel="stylesheet" href="global.css" />
 
+	<script>window.__gsiReady = new Promise(function (r) { window.__gsiResolve = r; });</script>
+	<script async src="https://accounts.google.com/gsi/client" onload="window.__gsiResolve()"></script>
 	<script async src='build/bundle.js'></script>
 </head>
 

--- a/frontend/scripts/hash-build.mjs
+++ b/frontend/scripts/hash-build.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Renames build/bundle.js and build/bundle.css to include a content hash, then
+// updates public/index.html to reference the hashed filenames. Run after a
+// production rollup build so CloudFront can cache the bundle indefinitely
+// (`Cache-Control: immutable`) and a redeploy is picked up by clients without
+// a manual invalidation.
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, renameSync, readdirSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+const buildDir = "public/build";
+const htmlPath = "public/index.html";
+
+function purgeOldHashed(prefix, ext) {
+    for (const name of readdirSync(buildDir)) {
+        if (name.startsWith(`${prefix}-`) && name.endsWith(ext)) {
+            unlinkSync(join(buildDir, name));
+        }
+    }
+}
+
+function hashFile(name) {
+    const filePath = join(buildDir, name);
+    const content = readFileSync(filePath);
+    const hash = createHash("sha256").update(content).digest("hex").slice(0, 12);
+    const dot = name.lastIndexOf(".");
+    const newName = `${name.slice(0, dot)}-${hash}${name.slice(dot)}`;
+    purgeOldHashed(name.slice(0, dot), name.slice(dot));
+    renameSync(filePath, join(buildDir, newName));
+    return newName;
+}
+
+const jsName = hashFile("bundle.js");
+const cssName = hashFile("bundle.css");
+
+let html = readFileSync(htmlPath, "utf8");
+html = html.replace(/build\/bundle(-[a-f0-9]+)?\.js/g, `build/${jsName}`);
+html = html.replace(/build\/bundle(-[a-f0-9]+)?\.css/g, `build/${cssName}`);
+writeFileSync(htmlPath, html);
+
+console.log(`hashed bundle: ${jsName}, ${cssName}`);

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -11,11 +11,15 @@
 
     onMount(() => {
         mounted = true;
+        const ready = window.__gsiReady;
+        if (ready && typeof ready.then === "function") {
+            ready.then(() => {
+                gsiLoaded = true;
+            });
+        } else if (window.google && window.google.accounts) {
+            gsiLoaded = true;
+        }
     });
-
-    function gsiLoad() {
-        gsiLoaded = true;
-    }
 
     function handleCredentialResponse(response) {
         let decoded = jwtDecode(response.credential);
@@ -45,7 +49,6 @@
 </script>
 
 <svelte:head>
-    <script defer async src="https://accounts.google.com/gsi/client" on:load={gsiLoad}></script>
     <meta name="google-signin-client_id" content={google_client_id} />
 </svelte:head>
 


### PR DESCRIPTION
Closes #90.

## Summary
- **Lambda cold-start instrumentation** — `lambda_main.py` now emits a single `cold_start_phases imports_ms=… secrets_ms=… dynamo_ms=… services_ms=… init_total_ms=…` log line per cold start. Pair with the CloudWatch `REPORT Init Duration` line; the gap between `init_total_ms` and `REPORT Init Duration` is Python runtime + interpreter startup outside our reach.
- **Frontend bundle hashing + immutable caching** — A post-build `scripts/hash-build.mjs` hashes `bundle.js`/`bundle.css` and rewrites `public/index.html`. Run in CD only — `npm run build` and the e2e devstack keep plain filenames so local dev isn't disrupted. CD now uses native `aws s3` commands with differentiated `Cache-Control`: hashed bundles `public, max-age=31536000, immutable`; vendor/static `public, max-age=86400`; `index.html` `no-cache`. CloudFront `/*` invalidation is kept as the deploy-time safety net.
- **Google Identity preload** — The GSI script moves out of `Authenticate.svelte` and into `index.html`'s `<head>`, behind a `preconnect` to `accounts.google.com` and a `window.__gsiReady` promise. The script now downloads in parallel with the bundle instead of waiting for the component to mount.

Investigation report at the top of the issue thread captures the rationale; this PR lands the two cheapest wins (frontend hashing + preload) plus the instrumentation needed to justify the next round of backend changes (deferring `boto3.dynamodb.conditions.Key` import, lazy `pydantic.TypeAdapter` init, Lambda memory bump). Those are deliberately follow-ups so we measure first.

## Test plan
- [x] `uv run pytest` — 48 passed
- [x] `uv run ruff check` — clean
- [x] `uv run pyright` — 0 errors
- [x] `npm test` (frontend) — 59 passed
- [x] `npm run check` — 0 errors, 0 warnings
- [x] Verified `npm run build` + `node scripts/hash-build.mjs` produces `bundle-<hash>.js` / `bundle-<hash>.css` and rewrites `index.html`
- [ ] After merge: capture `cold_start_phases` lines from CloudWatch and post the p50/p95 numbers (per issue acceptance criteria)
- [ ] After merge: verify on a fresh CloudFront fetch that hashed bundles return `Cache-Control: public, max-age=31536000, immutable` and `index.html` returns `Cache-Control: no-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)