### PR TITLE
Scope SVG marker IDs so arrow heads render (#105)

### DIFF
--- a/e2e/tests/_seeded.ts
+++ b/e2e/tests/_seeded.ts
@@ -1,0 +1,11 @@
+import { expect, type Page } from "@playwright/test";
+
+export const SEEDED_STEMMA_COUNT = 2;
+
+export async function waitForFirstLoginSeeded(page: Page) {
+  await expect(page.locator("#navbarDropdownMenuLink")).toBeVisible();
+  await expect(page.locator(".dropdown-menu .stemma-row")).toHaveCount(
+    SEEDED_STEMMA_COUNT,
+    { timeout: 30_000 },
+  );
+}

--- a/e2e/tests/arrows.spec.ts
+++ b/e2e/tests/arrows.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { waitForFirstLoginSeeded } from "./_seeded";
+
+test("relationship arrows are rendered on a populated stemma", async ({ page }) => {
+  await page.goto("/");
+  await waitForFirstLoginSeeded(page);
+
+  const svg = page.locator("svg#chart");
+  await expect(svg).toBeVisible();
+  await expect(svg.locator("line")).not.toHaveCount(0, { timeout: 30_000 });
+
+  await expect(svg.locator('defs marker[id^="arrow-to-family-"]')).toHaveCount(1);
+  await expect(svg.locator('defs marker[id^="arrow-to-person-"]')).toHaveCount(1);
+  await expect(svg.locator("line:not([marker-end])")).toHaveCount(0);
+
+  // Each line's url(#...) must resolve inside the same SVG; a marker hidden in
+  // another SVG won't render even if the lookup succeeds.
+  const refIssues = await svg.locator("line").evaluateAll((nodes) =>
+    nodes.flatMap((node) => {
+      const ref = node.getAttribute("marker-end") ?? "";
+      const match = ref.match(/^url\(#(.+)\)$/);
+      if (!match) return [{ ref, problem: "no-url" }];
+      const target = document.getElementById(match[1]);
+      if (!target) return [{ ref, problem: "missing" }];
+      if (!node.ownerSVGElement?.contains(target)) {
+        return [{ ref, problem: "wrong-svg", parentSvg: target.closest("svg")?.id ?? null }];
+      }
+      return [];
+    }),
+  );
+  expect(refIssues).toEqual([]);
+});

--- a/e2e/tests/dropdown_align.spec.ts
+++ b/e2e/tests/dropdown_align.spec.ts
@@ -1,14 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { SEEDED_STEMMA_COUNT, waitForFirstLoginSeeded } from "./_seeded";
 
 const NAMES = ["A", "A very long stemma name that should ellipsize quite far", "Middle"];
 
 test("stemma dropdown buttons line up", async ({ page }) => {
   await page.goto("/");
-
-  await expect(page.locator("#navbarDropdownMenuLink")).toBeVisible();
-  // Wait for first-login seeding (My Stemma + European Kings) to finish.
-  const seededCount = 2;
-  await expect(page.locator(".dropdown-menu .stemma-row")).toHaveCount(seededCount, { timeout: 30_000 });
+  await waitForFirstLoginSeeded(page);
 
   for (const name of NAMES) {
     await page.locator("#navbarDropdownMenuLink").click();
@@ -22,7 +19,7 @@ test("stemma dropdown buttons line up", async ({ page }) => {
 
   await page.locator("#navbarDropdownMenuLink").click();
   const rows = page.locator(".dropdown-menu .stemma-row");
-  await expect(rows).toHaveCount(NAMES.length + seededCount, { timeout: 30_000 });
+  await expect(rows).toHaveCount(NAMES.length + SEEDED_STEMMA_COUNT, { timeout: 30_000 });
 
   const renameRights: number[] = [];
   const lastRights: number[] = [];

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -39,6 +39,7 @@
     export let viewMode: ViewMode;
 
     let svg;
+    let markers;
     let isDragging = false;
     let pendingMouseLeave = false;
     let layoutCache: NodeLayoutCache | null = null;
@@ -73,7 +74,7 @@
     }
 
     function renderFullStemma() {
-        renderChart(svg, highlight, stemmaIndex);
+        renderChart(svg, highlight, stemmaIndex, markers);
 
         d3.selectAll("path.pin").remove();
         d3.select("g.main")
@@ -189,7 +190,7 @@
                 }
             });
 
-        renderChart(svg, highlight, stemmaIndex);
+        renderChart(svg, highlight, stemmaIndex, markers);
         makeDrag(
             svg,
             simulation,
@@ -210,7 +211,7 @@
     }
 
     onMount(() => {
-        svg = initChart("#chart");
+        ({ svg, markers } = initChart("#chart"));
         svg.call(zoomHandler);
     });
 </script>

--- a/frontend/src/components/about/About.svelte
+++ b/frontend/src/components/about/About.svelte
@@ -25,7 +25,7 @@
             .attr("width", "100%")
             .attr("height", "100%");
 
-        addArrowMarkers(svg);
+        const markers = addArrowMarkers(svg);
 
         const parentsY = 40;
         const familyY = 110;
@@ -42,7 +42,7 @@
             .attr("x2", familyX).attr("y2", familyY)
             .attr("stroke", relationsColor)
             .attr("stroke-width", familyRelationWidth)
-            .attr("marker-end", "url(#arrow-to-family)");
+            .attr("marker-end", markers.family);
 
         // Parent-right → family link
         svg.append("line")
@@ -50,7 +50,7 @@
             .attr("x2", familyX).attr("y2", familyY)
             .attr("stroke", relationsColor)
             .attr("stroke-width", familyRelationWidth)
-            .attr("marker-end", "url(#arrow-to-family)");
+            .attr("marker-end", markers.family);
 
         // Family → child link
         svg.append("line")
@@ -58,7 +58,7 @@
             .attr("x2", childX).attr("y2", childY)
             .attr("stroke", relationsColor)
             .attr("stroke-width", childRelationWidth)
-            .attr("marker-end", "url(#arrow-to-person)");
+            .attr("marker-end", markers.person);
 
         // Parent-left node
         svg.append("circle")

--- a/frontend/src/components/misc/VisualPersonDescription.svelte
+++ b/frontend/src/components/misc/VisualPersonDescription.svelte
@@ -10,12 +10,13 @@
     export let stemmaIndex: StemmaIndex;
 
     let svg;
+    let markers;
     let width, height;
     let nodes, relations;
     let sim;
 
     onMount(() => {
-        svg = initChart(`#${chartId}`);
+        ({ svg, markers } = initChart(`#${chartId}`));
     });
 
     $: {
@@ -39,7 +40,7 @@
             sim = configureSimulation(svg, nodes, relations, width, height);
             mergeData(svg, nodes, relations, width, height, null, null, true);
             makeDrag(svg, sim, null);
-            renderChart(svg, new HighlightAll(), stemmaIndex);
+            renderChart(svg, new HighlightAll(), stemmaIndex, markers);
         }
     }
 </script>

--- a/frontend/src/graphStyles.js
+++ b/frontend/src/graphStyles.js
@@ -26,13 +26,21 @@ export function personColor(generationRatio) {
     return d3.interpolatePlasma(generationRatio);
 }
 
-// Add arrow marker defs to an SVG selection
+// Marker IDs must be unique document-wide; `url(#id)` resolves to the
+// first matching element in tree order, and if that element sits inside
+// a hidden subtree the browser won't render it.
+let _markerScope = 0;
+
 export function addArrowMarkers(svg) {
+    const scope = ++_markerScope;
+    const familyId = `arrow-to-family-${scope}`;
+    const personId = `arrow-to-person-${scope}`;
+
     let defs = svg.select("defs");
     if (defs.empty()) defs = svg.append("defs");
 
     defs.append("marker")
-        .attr("id", "arrow-to-family")
+        .attr("id", familyId)
         .attr("viewBox", "0 0 10 6")
         .attr("refX", 16)
         .attr("refY", 3)
@@ -45,7 +53,7 @@ export function addArrowMarkers(svg) {
         .attr("d", arrowPath);
 
     defs.append("marker")
-        .attr("id", "arrow-to-person")
+        .attr("id", personId)
         .attr("viewBox", "0 0 10 6")
         .attr("refX", 26)
         .attr("refY", 3)
@@ -56,4 +64,6 @@ export function addArrowMarkers(svg) {
         .style("fill", relationsColor)
         .append("path")
         .attr("d", arrowPath);
+
+    return { family: `url(#${familyId})`, person: `url(#${personId})` };
 }

--- a/frontend/src/graphTools.js
+++ b/frontend/src/graphTools.js
@@ -43,12 +43,11 @@ export function makeNodesAndRelations(people, families) {
 
 export function initChart(svgSelector) {
     let svg = d3.select(svgSelector);
-    addArrowMarkers(svg);
-
+    const markers = addArrowMarkers(svg);
 
     svg.append("g").attr("class", "main");
 
-    return svg
+    return { svg, markers };
 }
 
 
@@ -221,7 +220,7 @@ export function mergeData(svg, nodes, relations, width, height, initialPositions
         );
 }
 
-export function renderChart(svg, highlight, stemmaIndex) {
+export function renderChart(svg, highlight, stemmaIndex, markers) {
     function getNodeColor(node) {
         if (node.type == "person") {
             let d = stemmaIndex.lineage(denormalizeId(node.id)).generation / stemmaIndex.maxGeneration();
@@ -250,8 +249,8 @@ export function renderChart(svg, highlight, stemmaIndex) {
     }
 
     function markerEnd(line) {
-        if (line.type == "familyToChild") return "url(#arrow-to-person)";
-        else return "url(#arrow-to-family)";
+        if (line.type == "familyToChild") return markers.person;
+        else return markers.family;
     }
 
     svg.selectAll("line")


### PR DESCRIPTION
## Summary
- Marker IDs (`arrow-to-family` / `arrow-to-person`) were hardcoded and identical across three SVGs (main chart, About modal preview, person preview). `url(#id)` resolves the first match in tree order — the About modal lives under `display:none`, so the chart's lines pointed at an unrenderable element and arrowheads disappeared.
- `addArrowMarkers` now mints per-call unique IDs (`arrow-to-{family,person}-N`) and returns ready-to-use `url(#...)` strings. `initChart` exposes them, `renderChart` takes them as a `markers` parameter, and the About preview uses what `addArrowMarkers` returns instead of hardcoded URLs.
- New `e2e/tests/arrows.spec.ts` asserts each `<line>` in `svg#chart` has a `marker-end` whose `url(#...)` target lives in the same SVG — so a re-introduced duplicate-ID collision would fail CI immediately.
- Extracted `e2e/tests/_seeded.ts` with `waitForFirstLoginSeeded(page)` so the new test and the existing `dropdown_align.spec.ts` share the "wait for the two seeded stemmas" snippet.

## Test plan
- [x] `npm test` + `npm run check` (frontend, from `frontend/`)
- [x] `npm test` (e2e, from `e2e/`) — `arrows.spec.ts`, `dropdown_align.spec.ts`, `smoke.spec.ts` all pass; visually confirmed arrows render on European Kings
- [ ] After deploy, verify a fresh login shows arrows on the seeded European Kings stemma without hovering anything

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)