### PR TITLE
Migrate Svelte components to runes mode

### DIFF
--- a/.claude/skills/frontend-style/SKILL.md
+++ b/.claude/skills/frontend-style/SKILL.md
@@ -494,20 +494,24 @@ this.others.set(others);
 
 # Svelte-specific (Svelte 5, runes)
 
-> Note: parts of `frontend/` are still written in legacy mode (`runes: false`, `$:` reactivity, `export let`, `createEventDispatcher`). When **writing new components or refactoring existing ones**, use the runes-mode patterns below. Match the surrounding file's style when making small in-place edits to legacy components — do not partially migrate.
+The entire `frontend/` codebase uses Svelte 5 runes mode (`runes: true` in `rollup.config.js` and `svelte.config.js`). Do not use legacy patterns (`export let`, `$:`, `createEventDispatcher`, `on:event` directives). Third-party legacy Svelte packages are compiled with a separate plugin instance that keeps `runes: false` — do not add `<svelte:options runes={...} />` to project files.
 
 * **State is `$state`.** Component-local mutable data goes through `$state(...)`. Don't use plain `let foo = ...` for things you mutate; the reactivity won't fire.
-* **Derived data is `$derived`.** Replaces `$:` reactive declarations. Keep derivations pure — no side effects.
-* **Side effects are `$effect`.** Replaces `onMount` / `$:` blocks that perform side effects (DOM init, store subscriptions, third-party setup). Return a teardown function from `$effect` instead of `onDestroy`.
-* **Props are `$props`.** Replaces `export let`. Destructure with defaults: `let { stemma, onSelect = () => {} }: Props = $props();`. Declare the `Props` type as a `type` alias at the top of the script.
-* **Two-way binding is `$bindable`.** Mark a prop `$bindable()` only when the parent legitimately needs to write back; otherwise prefer callback props.
-* **Events are callback props, not `createEventDispatcher`.** Pass `onSomething: (payload: T) => void` props instead of dispatching events. They're typed, traceable through "go to definition", and don't need `bubbles`/`cancelable` ceremony.
-* **Children are snippets.** Replaces slots — declare `children?: Snippet` (or named snippets) in props and render with `{@render children?.()}`. Use snippet parameters to pass data into a render slot.
-* **Components are still boundaries.** They own DOM access, `bootstrap.Modal` calls, snippet rendering, and store subscriptions. Keep business logic out of `<script>` blocks; put it in a sibling `.ts` module so it can be unit-tested. If a component's `<script>` has logic worth testing, that's a signal to extract it (this is exactly why `appController.ts`, `personSelectionRules.ts`, `stemmaErrorMapping.ts`, etc. are separate modules).
-* **Module-scoped helpers** still go in `<script context="module">` — that mechanism is unchanged.
+* **Derived data is `$derived`.** Use `$derived(expr)` for single-expression derivations and `$derived.by(() => { ...; return value })` for multi-step ones. Keep derivations pure — no side effects.
+* **Side effects are `$effect`.** Use for DOM init, store subscriptions, third-party setup. Return a teardown function from `$effect` instead of `onDestroy`. `$effect` runs after mount — if logic must run synchronously during initialization, call it directly or use `$derived`.
+* **Props are `$props`.** Declare a `Props` type alias, then destructure: `let { foo, bar = defaultValue }: Props = $props();`. Always declare the `Props` type explicitly at the top of the script.
+* **Two-way binding is `$bindable`.** Mark a prop `$bindable()` only when the parent legitimately needs to write back (e.g. `FamilyGeneration`'s `selectedPeople`); otherwise prefer callback props.
+* **Events are callback props.** Pass `onSomething: (payload: T) => void` props instead of dispatching events. Call them directly: `onSomething?.(payload)`. The parent passes them as `onSomething={(p) => ...}`. They're typed, traceable through "go to definition", and don't need `bubbles`/`cancelable` ceremony.
+* **DOM event handlers** use `oneventname` attributes (`onclick`, `onkeydown`, etc.) instead of `on:event` directives. For `preventDefault`, wrap inline: `onclick={(e) => { e.preventDefault(); fn(); }}`.
+* **Custom DOM events** (e.g. from `@imask/svelte` which fires `accept`/`complete` via `el.dispatchEvent`) cannot use `on:` or `on*` attributes. Register them via `$effect` with `addEventListener`/`removeEventListener` and return the teardown.
+* **Legacy third-party component events** (e.g. `svelte-select` using `createEventDispatcher`) are consumed with `on:select`, `on:clear` etc. — the `on:` directive is still valid for receiving events dispatched by legacy-mode components.
+* **Slots from legacy components** (e.g. `svelte-select`) are still filled with `<svelte:fragment slot="...">` — the slot mechanism is backward-compatible.
+* **Exported functions** (imperative component API exposed via `bind:this`) use the plain `export function` syntax. They are accessible on the bound component instance as before.
+* **Module-scoped declarations** go in `<script module lang="ts">` (the `module` attribute replaces the deprecated `context="module"` form).
 * **Stores** still work (`writable`, `readable`) and `$store` auto-subscription is unchanged, but for new state that lives inside a single component prefer `$state`. Cross-component state can use either — pick one consistently per concern.
+* **Components are still boundaries.** They own DOM access, `bootstrap.Modal` calls, and store subscriptions. Keep business logic out of `<script>` blocks; put it in a sibling `.ts` module so it can be unit-tested (see `appController.ts`, `personSelectionRules.ts`, etc.).
 
-**Bad example**: legacy patterns in new code
+**Bad example**: legacy patterns
 ```svelte
 <script lang="ts">
     import { createEventDispatcher, onMount } from "svelte";
@@ -518,6 +522,7 @@ this.others.set(others);
     onMount(() => { /* ... */ });
     function pin() { pinned = true; dispatch("pinned", { id: stemma.id }); }
 </script>
+<button on:click={pin}>Pin</button>
 ```
 
 **Good example**: runes + callback props
@@ -525,9 +530,9 @@ this.others.set(others);
 <script lang="ts">
     type Props = {
         stemma: Stemma;
-        onPinned: (payload: { id: string }) => void;
+        onpinned: (payload: { id: string }) => void;
     };
-    let { stemma, onPinned }: Props = $props();
+    let { stemma, onpinned }: Props = $props();
 
     let pinned = $state(false);
     const peopleCount = $derived(stemma.people.length);
@@ -539,9 +544,10 @@ this.others.set(others);
 
     function pin() {
         pinned = true;
-        onPinned({ id: stemma.id });
+        onpinned({ id: stemma.id });
     }
 </script>
+<button onclick={pin}>Pin</button>
 ```
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Stemma is a collaborative family tree editor. Multiple users build shared geneal
   - `src/stemma/storage/` — DynamoDB single-table schema (`schema.py`: key encoders) and `StorageService` (boto3 Table-resource-backed).
   - `src/stemma/apis/request_handler.py` — Central dispatcher: takes a `User` + parsed `Request`, returns a `Response`.
   - `src/stemma/apps/` — Transport adapters: `rest_main`/`rest_app` (local Uvicorn server on :8090), `lambda_main` (HTTP API handler), and `bootstrap` (Secrets Manager + DynamoDB Table construction).
-- `frontend/` — Svelte 5 (legacy mode, `runes: false`) + TypeScript UI (Rollup bundler).
+- `frontend/` — Svelte 5 (runes mode) + TypeScript UI (Rollup bundler).
 - `e2e/` — Playwright end-to-end tests with full local stack orchestration (`scripts/devstack.mjs`).
 - `template.yaml` / `samconfig.toml` — AWS SAM infrastructure (Python 3.13 arm64 Lambda + shared layer + DynamoDB table).
 - `Makefile` — `sam build` hooks that assemble the Lambda artifacts and shared layer from `backend_py/`.
@@ -118,7 +118,7 @@ Lambda-only (set in `template.yaml` Globals or by `bootstrap`):
 - The local REST server has a **2-second artificial delay** on every request (`DEFAULT_REQUEST_DELAY_SECONDS` in `apps/rest_app.py`); it is **not** applied in Lambda.
 - E2E tests run serially (`workers: 1`, `fullyParallel: false`) because they share a single table.
 - The Playwright config auto-launches the full stack via `webServer.command` — no manual setup needed for `npm test` in `e2e/`.
-- Svelte is in **legacy mode** (`runes: false`). Use `mount()` from `svelte`; do not introduce runes.
+- Svelte runs in **runes mode** (`runes: true`). Use `$state`, `$derived`, `$effect`, `$props`, and callback props. Do not use `export let`, `$:`, or `createEventDispatcher`.
 - Storage methods that target a specific person/family take `stemma_id` alongside the entity id — items are keyed by `STEMMA#<sid>`, so the stemma id is part of every DynamoDB key.
 - `bootstrap.populate_env_from_secrets()` uses `os.environ.setdefault`, so secrets do not overwrite values that were already exported — useful for local override but be aware in debugging.
 - DynamoDB has no schema for non-key attributes; field rename/split migrations are scan-and-rewrite scripts rather than SQL migrations.

--- a/frontend/rollup.config.js
+++ b/frontend/rollup.config.js
@@ -76,10 +76,18 @@ export default {
             preventAssignment: true,
         }),
         svelte({
+            include: /^(?!.*node_modules).*\.svelte$/,
             preprocess: sveltePreprocess({
                 sourceMap: !production,
                 style: less(),
             }),
+            compilerOptions: {
+                dev: !production,
+                runes: true
+            }
+        }),
+        svelte({
+            include: /node_modules.*\.svelte$/,
             compilerOptions: {
                 dev: !production,
                 runes: false

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -25,37 +25,41 @@
     import { SettingsStorage } from "./settingsStroage";
     import { LocalizedError, t } from "./i18n";
     import { loadCredential, saveCredential } from "./credentialStorage";
-    import { onMount } from "svelte";
+    import { onMount, untrack } from "svelte";
 
-    export let google_client_id;
-    export let stemma_backend_url;
+    type Props = {
+        google_client_id: string;
+        stemma_backend_url: string;
+    };
 
-    let addStemmaModal;
-    let cloneStemmaModal;
-    let renameStemmaModal;
-    let removeStemmaModal;
-    let familySelectionModal;
-    let personSelectionModal;
-    let stemmaChart;
-    let inviteModal;
-    let aboutModal;
-    let settingsModal;
+    let { google_client_id, stemma_backend_url }: Props = $props();
 
-    let signedIn = false;
+    let addStemmaModal = $state<ReturnType<typeof AddStemmaModal>>(null);
+    let cloneStemmaModal = $state<ReturnType<typeof CloneStemmaModal>>(null);
+    let renameStemmaModal = $state<ReturnType<typeof RenameStemmaModal>>(null);
+    let removeStemmaModal = $state<ReturnType<typeof RemoveStemmaModal>>(null);
+    let familySelectionModal = $state<ReturnType<typeof FamilySelectionModal>>(null);
+    let personSelectionModal = $state<ReturnType<typeof PersonSelectionModal>>(null);
+    let stemmaChart = $state<ReturnType<typeof FullStemma>>(null);
+    let inviteModal = $state<ReturnType<typeof InviteModal>>(null);
+    let aboutModal = $state<ReturnType<typeof AboutModal>>(null);
+    let settingsModal = $state<ReturnType<typeof SettingsModal>>(null);
 
-    let ownedStemmas: StemmaDescription[];
-    let currentStemmaId: string;
-    let stemma: Stemma;
-    let stemmaIndex: StemmaIndex;
-    let highlight: HiglightLineages;
-    let pinnedPeople: PinnedPeopleStorage;
-    let isWorking: boolean;
-    let error: Error;
-    let settingsStorage: SettingsStorage;
-    let settings: Settings = DEFAULT_SETTINGS;
-    let highlightVersion = 0;
+    let signedIn = $state(false);
 
-    let controller = new AppController(stemma_backend_url);
+    let ownedStemmas = $state<StemmaDescription[]>(null);
+    let currentStemmaId = $state<string>(null);
+    let stemma = $state<Stemma>(null);
+    let stemmaIndex = $state<StemmaIndex>(null);
+    let highlight = $state<HiglightLineages>(null);
+    let pinnedPeople = $state<PinnedPeopleStorage>(null);
+    let isWorking = $state<boolean>(false);
+    let error = $state<Error>(null);
+    let settingsStorage = $state<SettingsStorage>(null);
+    let settings = $state<Settings>(DEFAULT_SETTINGS);
+    let highlightVersion = $state(0);
+
+    const controller = new AppController(untrack(() => stemma_backend_url));
 
     controller.currentStemmaId.subscribe((s) => (currentStemmaId = s));
     controller.stemma.subscribe((s) => (stemma = s));
@@ -67,7 +71,7 @@
     controller.err.subscribe((e) => (error = e));
     controller.settingsStorage.subscribe((ss) => {
         settingsStorage = ss;
-        if (settingsStorage) settings = ss.get();
+        if (ss) settings = ss.get();
     });
     controller.invitationToken.subscribe((it) => {
         if (inviteModal) inviteModal.setInviteLink(it);
@@ -81,9 +85,9 @@
     function handleSignIn(user: User) {
         saveCredential(user.id_token);
 
-        let urlParams = new URLSearchParams(window.location.search);
+        const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has("inviteToken")) {
-            let token = urlParams.get("inviteToken");
+            const token = urlParams.get("inviteToken");
             urlParams.delete("inviteToken");
             window.history.pushState({}, document.title, window.location.pathname);
 
@@ -107,19 +111,18 @@
             handleSignIn({ id_token: cached.token });
         }
     });
-
 </script>
 
 {#if signedIn}
-    <AddStemmaModal bind:this={addStemmaModal} on:stemmaAdded={(e) => controller.addStemma(e.detail)} />
-    <RemoveStemmaModal bind:this={removeStemmaModal} on:stemmaRemoved={(e) => controller.removeStemma(e.detail)} />
-    <CloneStemmaModal bind:this={cloneStemmaModal} on:stemmaCloned={(e) => controller.cloneStemma(e.detail.name, e.detail.stemmaId)} />
-    <RenameStemmaModal bind:this={renameStemmaModal} on:stemmaRenamed={(e) => controller.renameStemma(e.detail.stemmaId, e.detail.name)} />
+    <AddStemmaModal bind:this={addStemmaModal} onstemmaAdded={(name) => controller.addStemma(name)} />
+    <RemoveStemmaModal bind:this={removeStemmaModal} onstemmaRemoved={(id) => controller.removeStemma(id)} />
+    <CloneStemmaModal bind:this={cloneStemmaModal} onstemmaCloned={(p) => controller.cloneStemma(p.name, p.stemmaId)} />
+    <RenameStemmaModal bind:this={renameStemmaModal} onstemmaRenamed={(p) => controller.renameStemma(p.stemmaId, p.name)} />
     <SettingsModal
         bind:this={settingsModal}
-        on:settingsChanged={(e) => {
-            settings = e.detail;
-            settingsStorage.store(settings);
+        onsettingsChanged={(s) => {
+            settings = s;
+            settingsStorage.store(s);
         }}
     />
 
@@ -127,18 +130,18 @@
         bind:this={familySelectionModal}
         {stemma}
         {stemmaIndex}
-        on:familyAdded={(e) => controller.createFamily(e.detail.parents, e.detail.children)}
-        on:familyUpdated={(e) => controller.updateFamily(e.detail.familyId, e.detail.parents, e.detail.children)}
-        on:familyRemoved={(e) => controller.removeFamily(e.detail)}
+        onfamilyAdded={(p) => controller.createFamily(p.parents, p.children)}
+        onfamilyUpdated={(p) => controller.updateFamily(p.familyId, p.parents, p.children)}
+        onfamilyRemoved={(id) => controller.removeFamily(id)}
     />
 
     <PersonSelectionModal
         bind:this={personSelectionModal}
-        on:personRemoved={(e) => controller.removePerson(e.detail)}
-        on:personUpdated={(e) => controller.updatePerson(e.detail.id, e.detail.description, e.detail.pin)}
+        onpersonRemoved={(id) => controller.removePerson(id)}
+        onpersonUpdated={(p) => controller.updatePerson(p.id, p.description, p.pin)}
     />
 
-    <InviteModal bind:this={inviteModal} {stemma} {stemmaIndex} on:invite={(e) => controller.createInvitationToken(e.detail.personId, e.detail.email)} />
+    <InviteModal bind:this={inviteModal} {stemma} {stemmaIndex} oninvite={(p) => controller.createInvitationToken(p.personId, p.email)} />
     <AboutModal bind:this={aboutModal} />
 
     <Navbar
@@ -146,16 +149,16 @@
         {currentStemmaId}
         disabled={isWorking}
         people={stemma ? stemma.people : []}
-        on:selectStemma={(e) => controller.selectStemma(e.detail)}
-        on:createNewStemma={() => addStemmaModal.promptNewStemma()}
-        on:cloneStemma={(e) => cloneStemmaModal.promptStemmaClone(e.detail)}
-        on:renameStemma={(e) => renameStemmaModal.promptStemmaRename(e.detail.id, e.detail.name)}
-        on:createNewFamily={() => familySelectionModal.promptNewFamily()}
-        on:removeStemma={(e) => removeStemmaModal.askForConfirmation(e.detail)}
-        on:invite={() => inviteModal.showInvintation()}
-        on:about={() => aboutModal.show()}
-        on:settings={() => settingsModal.show()}
-        on:zoomToPerson={(e) => stemmaChart.zoomToNode(e.detail)}
+        onselectStemma={(id) => controller.selectStemma(id)}
+        oncreateNewStemma={() => addStemmaModal.promptNewStemma()}
+        oncloneStemma={(id) => cloneStemmaModal.promptStemmaClone(id)}
+        onrenameStemma={(s) => renameStemmaModal.promptStemmaRename(s.id, s.name)}
+        oncreateNewFamily={() => familySelectionModal.promptNewFamily()}
+        onremoveStemma={(s) => removeStemmaModal.askForConfirmation(s)}
+        oninvite={() => inviteModal.showInvintation()}
+        onabout={() => aboutModal.show()}
+        onsettings={() => settingsModal.show()}
+        onzoomToPerson={(id) => stemmaChart.zoomToNode(id)}
     />
 
     {#if error}
@@ -182,9 +185,9 @@
         {highlight}
         {pinnedPeople}
         viewMode={settings.viewMode}
-        on:personSelected={(e) => personSelectionModal.showPersonDetails({ description: e.detail, pin: pinnedPeople.isPinned(e.detail.id) })}
-        on:familySelected={(e) => familySelectionModal.showExistingFamily(e.detail)}
-        on:highlightChanged={() => highlightVersion++}
+        onpersonSelected={(p) => personSelectionModal.showPersonDetails({ description: p, pin: pinnedPeople.isPinned(p.id) })}
+        onfamilySelected={(f) => familySelectionModal.showExistingFamily(f)}
+        onhighlightChanged={() => highlightVersion++}
     />
 
     {#if !isWorking && stemma && stemmaIndex && highlight}
@@ -193,7 +196,7 @@
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            <Authenticate {google_client_id} on:signIn={(e) => handleSignIn(e.detail)} />
+            <Authenticate {google_client_id} onsignIn={(user) => handleSignIn(user)} />
         </div>
     </div>
 {/if}

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,51 +1,56 @@
-<script>
-    import { createEventDispatcher } from "svelte";
+<script lang="ts">
     import { jwtDecode } from "jwt-decode";
     import { onMount } from "svelte";
 
-    const dispatch = createEventDispatcher();
+    type Props = {
+        google_client_id: string;
+        onsignIn?: (user: { name: string; image_url: string; id_token: string }) => void;
+    };
 
-    export let google_client_id;
+    let { google_client_id, onsignIn }: Props = $props();
 
-    let gsiLoaded, mounted;
+    let gsiLoaded = $state(false);
+    let mounted = $state(false);
 
     onMount(() => {
         mounted = true;
-        const ready = window.__gsiReady;
+        const ready = (window as any).__gsiReady;
         if (ready && typeof ready.then === "function") {
             ready.then(() => {
                 gsiLoaded = true;
             });
-        } else if (window.google && window.google.accounts) {
+        } else if ((window as any).google && (window as any).google.accounts) {
             gsiLoaded = true;
         }
     });
 
-    function handleCredentialResponse(response) {
-        let decoded = jwtDecode(response.credential);
+    function handleCredentialResponse(response: any) {
+        const decoded = jwtDecode<{ given_name: string; picture: string }>(response.credential);
 
-        dispatch("signIn", {
+        onsignIn?.({
             name: decoded.given_name,
             image_url: decoded.picture,
             id_token: response.credential,
         });
     }
 
-    $: if (gsiLoaded && mounted) {
-        google.accounts.id.initialize({
-            client_id: google_client_id,
-            callback: handleCredentialResponse,
-            auto_select: true,
-        });
-        google.accounts.id.prompt((notification) => {
-            if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
-                google.accounts.id.renderButton(
-                    document.getElementById("signin"),
-                    { theme: "outline", size: "large"  }
-                );
-            }
-        });
-    }
+    $effect(() => {
+        if (gsiLoaded && mounted) {
+            (window as any).google.accounts.id.initialize({
+                client_id: google_client_id,
+                callback: handleCredentialResponse,
+                auto_select: true,
+            });
+            (window as any).google.accounts.id.prompt((notification: any) => {
+                if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                    (window as any).google.accounts.id.renderButton(
+                        document.getElementById("signin"),
+                        { theme: "outline", size: "large" }
+                    );
+                }
+            });
+        }
+    });
 </script>
 
 <svelte:head>

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -4,7 +4,6 @@
     import { ViewMode } from "../model";
     import { StemmaIndex } from "../stemmaIndex";
     import { onMount } from "svelte";
-    import { createEventDispatcher } from "svelte";
     import { HiglightLineages } from "../highlight";
     import {
         configureSimulation,
@@ -23,55 +22,77 @@
     import { NodeLayoutCache } from "../nodeLayoutCache";
     import { PinnedPeopleStorage } from "../pinnedPeopleStorage";
 
-    const dispatch = createEventDispatcher();
+    type Props = {
+        stemma: Stemma;
+        currentStemmaId: string;
+        stemmaIndex: StemmaIndex;
+        highlight: HiglightLineages;
+        pinnedPeople: PinnedPeopleStorage;
+        hidden: boolean;
+        viewMode: ViewMode;
+        onpersonSelected?: (person: any) => void;
+        onfamilySelected?: (family: any) => void;
+        onhighlightChanged?: () => void;
+    };
+
+    let {
+        stemma,
+        currentStemmaId,
+        stemmaIndex,
+        highlight,
+        pinnedPeople,
+        hidden,
+        viewMode,
+        onpersonSelected,
+        onfamilySelected,
+        onhighlightChanged,
+    }: Props = $props();
 
     const hoveredPersonR = 25;
     const hoveredFamilyR = 10;
     const pin =
         "M4.146.146A.5.5 0 0 1 4.5 0h7a.5.5 0 0 1 .5.5c0 .68-.342 1.174-.646 1.479-.126.125-.25.224-.354.298v4.431l.078.048c.203.127.476.314.751.555C12.36 7.775 13 8.527 13 9.5a.5.5 0 0 1-.5.5h-4v4.5c0 .276-.224 1.5-.5 1.5s-.5-1.224-.5-1.5V10h-4a.5.5 0 0 1-.5-.5c0-.973.64-1.725 1.17-2.189A5.921 5.921 0 0 1 5 6.708V2.277a2.77 2.77 0 0 1-.354-.298C4.342 1.674 4 1.179 4 .5a.5.5 0 0 1 .146-.354z";
 
-    export let stemma: Stemma;
-    export let currentStemmaId: string;
-    export let stemmaIndex: StemmaIndex;
-    export let highlight: HiglightLineages;
-    export let pinnedPeople: PinnedPeopleStorage;
-    export let hidden: boolean;
-    export let viewMode: ViewMode;
-
-    let svg;
-    let markers;
+    let svg = $state<any>(null);
+    let markers: any = null;
     let isDragging = false;
     let pendingMouseLeave = false;
     let layoutCache: NodeLayoutCache | null = null;
     let layoutCacheStemmaId: string | null = null;
+    let simulation: any = null;
 
-    $: if (svg && stemma) {
-        if (layoutCacheStemmaId !== currentStemmaId) {
-            if (layoutCache) layoutCache.save();
-            layoutCache = new NodeLayoutCache(currentStemmaId);
-            layoutCache.load();
-            layoutCacheStemmaId = currentStemmaId;
+    $effect(() => {
+        if (svg && stemma) {
+            if (layoutCacheStemmaId !== currentStemmaId) {
+                if (layoutCache) layoutCache.save();
+                layoutCache = new NodeLayoutCache(currentStemmaId);
+                layoutCache.load();
+                layoutCacheStemmaId = currentStemmaId;
+            }
+            setActiveLayoutCache(layoutCache);
+            resetSessionPositions(currentStemmaId);
+
+            let people: any[], families: any[];
+
+            if (viewMode == ViewMode.ALL) {
+                people = stemma.people;
+                families = stemma.families;
+            } else if (viewMode == ViewMode.EDITABLE_ONLY) {
+                people = stemma.people.filter((p) => !p.readOnly);
+                families = stemma.families.filter((f) => !f.readOnly);
+            }
+
+            const [nodes, relations] = makeNodesAndRelations(people, families);
+            const initialPositions = computeInitialLayout(stemmaIndex, people, families, window.innerWidth, window.innerHeight);
+            reconfigureGraph(nodes, relations, initialPositions);
         }
-        setActiveLayoutCache(layoutCache);
-        resetSessionPositions(currentStemmaId);
-        let people, families;
+    });
 
-        if (viewMode == ViewMode.ALL) {
-            people = stemma.people;
-            families = stemma.families;
-        } else if (viewMode == ViewMode.EDITABLE_ONLY) {
-            people = stemma.people.filter((p) => !p.readOnly);
-            families = stemma.families.filter((f) => !f.readOnly);
+    $effect(() => {
+        if (highlight && pinnedPeople && stemmaIndex && svg) {
+            renderFullStemma();
         }
-
-        let [nodes, relations] = makeNodesAndRelations(people, families);
-        let initialPositions = computeInitialLayout(stemmaIndex, people, families, window.innerWidth, window.innerHeight);
-        reconfigureGraph(nodes, relations, initialPositions);
-    }
-
-    $: if (highlight && pinnedPeople && stemmaIndex && svg) {
-        renderFullStemma();
-    }
+    });
 
     function renderFullStemma() {
         renderChart(svg, highlight, stemmaIndex, markers);
@@ -120,10 +141,10 @@
     });
 
     export function zoomToNode(id: string) {
-        let scaleZoom = 2;
-        let node = d3.select("#" + normalizeId("person", id));
+        const scaleZoom = 2;
+        const node = d3.select("#" + normalizeId("person", id));
         if (node.size()) {
-            let nodeDatum = node.datum();
+            const nodeDatum = node.datum() as any;
 
             svg.transition()
                 .duration(750)
@@ -136,8 +157,7 @@
         }
     }
 
-    let simulation;
-    function reconfigureGraph(nodes, relations, initialPositions) {
+    function reconfigureGraph(nodes: any[], relations: any[], initialPositions: any) {
         const fullyCached =
             !!layoutCache && nodes.length > 0 && layoutCache.coverage(nodes.map((n) => n.id)) === 1;
 
@@ -150,7 +170,7 @@
 
         svg.select("g.main")
             .selectAll("g")
-            .on("mouseenter", function (event, node) {
+            .on("mouseenter", function (event: any, node: any) {
                 if (isDragging) {
                     pendingMouseLeave = false;
                     return;
@@ -158,35 +178,35 @@
                 if (node.type == "person") {
                     highlight.pushPerson(denormalizeId(node.id));
                     renderFullStemma();
-                    dispatch("highlightChanged");
+                    onhighlightChanged?.();
                     d3.select(this).select("circle").attr("r", hoveredPersonR);
                     d3.select(this).select("text").attr("font-weight", "bold");
                 }
                 if (node.type == "family") {
                     highlight.pushFamily(denormalizeId(node.id));
                     renderFullStemma();
-                    dispatch("highlightChanged");
+                    onhighlightChanged?.();
                     d3.select(this).select("circle").attr("r", hoveredFamilyR);
                 }
             })
-            .on("mouseleave", (_event, node) => {
+            .on("mouseleave", (_event: any, _node: any) => {
                 if (isDragging) {
                     pendingMouseLeave = true;
                     return;
                 }
                 highlight.pop();
                 renderFullStemma();
-                dispatch("highlightChanged");
+                onhighlightChanged?.();
             })
-            .on("click", (event, node) => {
+            .on("click", (_event: any, node: any) => {
                 if (node.type == "person") {
-                    let selectedPerson = stemmaIndex.person(denormalizeId(node.id));
-                    dispatch("personSelected", selectedPerson);
+                    const selectedPerson = stemmaIndex.person(denormalizeId(node.id));
+                    onpersonSelected?.(selectedPerson);
                 }
 
                 if (node.type == "family") {
-                    let selectedFamily = stemmaIndex.family(denormalizeId(node.id));
-                    dispatch("familySelected", selectedFamily);
+                    const selectedFamily = stemmaIndex.family(denormalizeId(node.id));
+                    onfamilySelected?.(selectedFamily);
                 }
             });
 
@@ -204,7 +224,7 @@
                     pendingMouseLeave = false;
                     highlight.pop();
                     renderFullStemma();
-                    dispatch("highlightChanged");
+                    onhighlightChanged?.();
                 }
             }
         );

--- a/frontend/src/components/Navbar.svelte
+++ b/frontend/src/components/Navbar.svelte
@@ -1,23 +1,49 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
     import * as bootstrap from "bootstrap";
     import type { StemmaDescription, PersonDescription } from "../model";
     import SearchAutocomplete from "./misc/SearchAutocomplete.svelte";
     import { locale, t } from "../i18n";
 
-    export let ownedStemmas: StemmaDescription[];
-    export let currentStemmaId: string;
-    export let people: PersonDescription[] = [];
-    export let disabled: boolean;
+    type Props = {
+        ownedStemmas: StemmaDescription[];
+        currentStemmaId: string;
+        people?: PersonDescription[];
+        disabled: boolean;
+        onselectStemma?: (id: string) => void;
+        oncreateNewStemma?: () => void;
+        oncloneStemma?: (id: string) => void;
+        onrenameStemma?: (s: StemmaDescription) => void;
+        oncreateNewFamily?: () => void;
+        onremoveStemma?: (s: StemmaDescription) => void;
+        oninvite?: () => void;
+        onabout?: () => void;
+        onsettings?: () => void;
+        onzoomToPerson?: (id: string) => void;
+    };
 
-    let navbarCollapseEl: HTMLElement;
+    let {
+        ownedStemmas,
+        currentStemmaId,
+        people = [],
+        disabled,
+        onselectStemma,
+        oncreateNewStemma,
+        oncloneStemma,
+        onrenameStemma,
+        oncreateNewFamily,
+        onremoveStemma,
+        oninvite,
+        onabout,
+        onsettings,
+        onzoomToPerson,
+    }: Props = $props();
 
-    const dispatch = createEventDispatcher();
+    let navbarCollapseEl = $state<HTMLElement>(null);
 
-    function handlePersonSelect(e: CustomEvent) {
+    function handlePersonSelect(id: string) {
         const instance = bootstrap.Collapse.getInstance(navbarCollapseEl);
         if (instance) instance.hide();
-        dispatch("zoomToPerson", e.detail);
+        onzoomToPerson?.(id);
     }
 </script>
 
@@ -25,12 +51,12 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
             <div class="brand-group">
-                <a class="navbar-brand" href="/" on:click|preventDefault><img src="assets/logo_bw_avg.webp" alt="" width="40" height="40" /> Stemma</a>
+                <a class="navbar-brand" href="/" onclick={(e) => e.preventDefault()}><img src="assets/logo_bw_avg.webp" alt="" width="40" height="40" /> Stemma</a>
                 <button
                     type="button"
                     class="nav-link lang-switch"
                     aria-label={$t('nav.language')}
-                    on:click={() => locale.set($locale === 'en' ? 'ru' : 'en')}
+                    onclick={() => locale.set($locale === 'en' ? 'ru' : 'en')}
                 >
                     {$locale === 'en' ? 'RU' : 'EN'}
                 </button>
@@ -49,7 +75,7 @@
             <div class="collapse navbar-collapse" id="navbarTogglerDemo02" bind:this={navbarCollapseEl}>
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item dropdown {disabled ? 'd-none' : ''}">
-                        <a class="nav-link dropdown-toggle" href="/" on:click|preventDefault id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle" href="/" onclick={(e) => e.preventDefault()} id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             {$t('nav.familyTrees')}
                         </a>
                         {#if ownedStemmas}
@@ -60,27 +86,27 @@
                                             <a
                                                 class="dropdown-item stemma-name {s.id == currentStemmaId ? 'active' : ''}  {disabled ? 'd-none' : ''}"
                                                 href="/"
-                                                on:click|preventDefault={() => dispatch("selectStemma", s.id)}>{s.name}</a
+                                                onclick={(e) => { e.preventDefault(); onselectStemma?.(s.id); }}>{s.name}</a
                                             >
                                             <button
                                                 type="button"
                                                 class="btn btn-outline-secondary btn-sm ms-1 stemma-action {disabled ? 'd-none' : ''}"
                                                 aria-label={$t("stemma.rename")}
-                                                on:click={() => dispatch("renameStemma", s)}><i class="bi bi-pencil"></i></button
+                                                onclick={() => onrenameStemma?.(s)}><i class="bi bi-pencil"></i></button
                                             >
                                             {#if s.id != currentStemmaId && s.removable}
                                                 <button
                                                     type="button"
                                                     class="btn btn-danger btn-sm ms-1 stemma-action {disabled ? 'd-none' : ''}"
                                                     aria-label={$t("common.delete")}
-                                                    on:click={(e) => dispatch("removeStemma", s)}><i class="bi bi-trash"></i></button
+                                                    onclick={() => onremoveStemma?.(s)}><i class="bi bi-trash"></i></button
                                                 >
                                             {:else if s.id == currentStemmaId}
                                                 <button
                                                     type="button"
                                                     class="btn btn-primary btn-sm ms-1 stemma-action {disabled ? 'd-none' : ''}"
                                                     aria-label={$t("stemma.clone")}
-                                                    on:click={(e) => dispatch("cloneStemma", s.id)}><i class="bi bi-subtract"></i></button
+                                                    onclick={() => oncloneStemma?.(s.id)}><i class="bi bi-subtract"></i></button
                                                 >
                                             {:else}
                                                 <button
@@ -98,23 +124,23 @@
                                 </li>
 
                                 <li>
-                                    <a class="dropdown-item  {disabled ? 'd-none' : ''}" href="/" on:click|preventDefault={() => dispatch("createNewStemma")}>{$t('nav.createNew')}</a>
+                                    <a class="dropdown-item  {disabled ? 'd-none' : ''}" href="/" onclick={(e) => { e.preventDefault(); oncreateNewStemma?.(); }}>{$t('nav.createNew')}</a>
                                 </li>
                             </ul>
                         {/if}
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" on:click|preventDefault={() => dispatch("createNewFamily")}
+                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" onclick={(e) => { e.preventDefault(); oncreateNewFamily?.(); }}
                             ><i class="bi bi-people-fill"></i> {$t('nav.addFamily')}</a
                         >
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" on:click|preventDefault={() => dispatch("invite")}
+                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" onclick={(e) => { e.preventDefault(); oninvite?.(); }}
                             ><i class="bi bi-share-fill"></i> {$t('nav.inviteMember')}</a
                         >
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" on:click|preventDefault={() => dispatch("settings")}
+                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" onclick={(e) => { e.preventDefault(); onsettings?.(); }}
                             ><i class="bi bi-gear-fill"></i> {$t('nav.settings')}</a
                         >
                     </li>
@@ -125,11 +151,11 @@
                             <SearchAutocomplete
                                 {people}
                                 {disabled}
-                                on:select={handlePersonSelect}
+                                onselect={handlePersonSelect}
                             />
                         </li>
                         <li class="nav-item">
-                            <a class="nav-item nav-link active" href="/" on:click|preventDefault={() => dispatch("about")}>{$t('nav.about')}</a>
+                            <a class="nav-item nav-link active" href="/" onclick={(e) => { e.preventDefault(); onabout?.(); }}>{$t('nav.about')}</a>
                         </li>
                     </ul>
                 </div>

--- a/frontend/src/components/about/About.svelte
+++ b/frontend/src/components/about/About.svelte
@@ -8,8 +8,8 @@
         personColor, addArrowMarkers
     } from "../../graphStyles";
 
-    let modalEl;
-    let diagramEl: HTMLDivElement;
+    let modalEl = $state<HTMLElement>(null);
+    let diagramEl = $state<HTMLDivElement>(null);
 
     const width = 360;
     const height = 220;
@@ -103,9 +103,11 @@
         label(translate("about.diagram.child"), childX, childY + personR + 18);
     }
 
-    $: if (diagramEl && $t) {
-        renderDiagram($t);
-    }
+    $effect(() => {
+        if (diagramEl && $t) {
+            renderDiagram($t);
+        }
+    });
 
     export function show() {
         bootstrap.Modal.getOrCreateInstance(modalEl).show();

--- a/frontend/src/components/add_stemma_modal/AddStemmaModal.svelte
+++ b/frontend/src/components/add_stemma_modal/AddStemmaModal.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
     import { onMount } from "svelte";
     import * as bootstrap from "bootstrap";
     import { t } from "../../i18n";
 
-    const dispatch = createEventDispatcher();
+    type Props = {
+        onstemmaAdded?: (name: string) => void;
+    };
 
-    let modalEl;
-    let input;
+    let { onstemmaAdded }: Props = $props();
+
+    let modalEl = $state<HTMLElement>(null);
+    let input = $state<HTMLInputElement>(null);
 
     onMount(() => {
         modalEl.addEventListener("shown.bs.modal", () => input.focus());
@@ -15,9 +18,9 @@
 
     function handleAddStemmaClick() {
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-        let name = input.value;
+        const name = input.value;
         input.value = "";
-        dispatch("stemmaAdded", name);
+        onstemmaAdded?.(name);
     }
 
     export function promptNewStemma() {
@@ -47,7 +50,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
-                <button type="button" class="btn btn-primary" on:click={handleAddStemmaClick}>{$t("common.add")}</button>
+                <button type="button" class="btn btn-primary" onclick={handleAddStemmaClick}>{$t("common.add")}</button>
             </div>
         </div>
     </div>

--- a/frontend/src/components/clone_stemma_modal/CloneStemmaModal.svelte
+++ b/frontend/src/components/clone_stemma_modal/CloneStemmaModal.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
     import { onMount } from "svelte";
     import * as bootstrap from "bootstrap";
     import { t } from "../../i18n";
 
-    const dispatch = createEventDispatcher();
+    type Props = {
+        onstemmaCloned?: (payload: { name: string; stemmaId: string }) => void;
+    };
 
-    let modalEl;
-    let input;
-    let clonedStemmaId;
+    let { onstemmaCloned }: Props = $props();
+
+    let modalEl = $state<HTMLElement>(null);
+    let input = $state<HTMLInputElement>(null);
+    let clonedStemmaId = $state<string>(null);
 
     onMount(() => {
         modalEl.addEventListener("shown.bs.modal", () => input.focus());
@@ -16,9 +19,9 @@
 
     function handleCloneStemmaClick() {
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-        let name = input.value;
+        const name = input.value;
         input.value = "";
-        dispatch("stemmaCloned", { name: name, stemmaId: clonedStemmaId });
+        onstemmaCloned?.({ name, stemmaId: clonedStemmaId });
     }
 
     export function promptStemmaClone(stemmaId: string) {
@@ -49,7 +52,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
-                <button type="button" class="btn btn-primary" on:click={handleCloneStemmaClick}>{$t("stemma.clone")}</button>
+                <button type="button" class="btn btn-primary" onclick={handleCloneStemmaClick}>{$t("stemma.clone")}</button>
             </div>
         </div>
     </div>

--- a/frontend/src/components/delete_stemma_modal/RemoveStemmaModal.svelte
+++ b/frontend/src/components/delete_stemma_modal/RemoveStemmaModal.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
     import * as bootstrap from "bootstrap";
     import type { StemmaDescription } from "../../model";
     import { t } from "../../i18n";
 
-    const dispatch = createEventDispatcher();
+    type Props = {
+        onstemmaRemoved?: (id: string) => void;
+    };
 
-    let modalEl;
-    let selectedStemma: StemmaDescription;
+    let { onstemmaRemoved }: Props = $props();
+
+    let modalEl = $state<HTMLElement>(null);
+    let selectedStemma = $state<StemmaDescription>(null);
 
     function handleRemoveStemmaClick() {
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-        dispatch("stemmaRemoved", selectedStemma.id);
+        onstemmaRemoved?.(selectedStemma.id);
     }
 
     export function askForConfirmation(s: StemmaDescription) {
@@ -31,7 +34,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
-                <button type="button" class="btn btn-danger" on:click={(e) => handleRemoveStemmaClick()}>{$t("common.delete")}</button>
+                <button type="button" class="btn btn-danger" onclick={handleRemoveStemmaClick}>{$t("common.delete")}</button>
             </div>
         </div>
     </div>

--- a/frontend/src/components/family_modal/CreateSelectPerson.svelte
+++ b/frontend/src/components/family_modal/CreateSelectPerson.svelte
@@ -1,84 +1,90 @@
 <script lang="ts">
-  import type { Stemma, CreateNewPerson, PersonDescription } from "../../model";
-  import { StemmaIndex } from "../../stemmaIndex";
-  import Select from "svelte-select";
-  import ClearIcon from "../misc/ClearIconTranslated.svelte";
-  import { createEventDispatcher } from "svelte";
-  import PersonSelector from "../misc/PersonSelector.svelte";
-  import { t } from "../../i18n";
-  import { filterEditablePeople } from "../../personSelectionRules";
+    import type { Stemma, CreateNewPerson, PersonDescription } from "../../model";
+    import { StemmaIndex } from "../../stemmaIndex";
+    import Select from "svelte-select";
+    import ClearIcon from "../misc/ClearIconTranslated.svelte";
+    import PersonSelector from "../misc/PersonSelector.svelte";
+    import { t } from "../../i18n";
+    import { filterEditablePeople } from "../../personSelectionRules";
 
-  export let stemmaIndex: StemmaIndex;
-  export let stemma: Stemma;
+    type Props = {
+        stemmaIndex: StemmaIndex;
+        stemma: Stemma;
+        onselected?: (person: CreateNewPerson | PersonDescription) => void;
+    };
 
-  let namesakes: (CreateNewPerson | PersonDescription)[] = [];
-  let selectedPerson: CreateNewPerson | PersonDescription;
-  let peopleNames: string[];
-  let filterText = "";
-  type SelectItem = { label: string; value: string; isCreator?: boolean };
-  let peopleItems: SelectItem[] = [];
-  let selectedItem: SelectItem = null;
+    let { stemmaIndex, stemma, onselected }: Props = $props();
 
-  let dispatch = createEventDispatcher();
+    let namesakes = $state<(CreateNewPerson | PersonDescription)[]>([]);
+    let selectedPerson = $state<CreateNewPerson | PersonDescription>(null);
+    let filterText = $state("");
 
-  function nameChanged(newName: string) {
-    namesakes = [...stemmaIndex.namesakes(newName).filter((p) => !p.readOnly), { type: "CreateNewPerson", name: newName }];
-  }
+    type SelectItem = { label: string; value: string; isCreator?: boolean };
 
-  export function reset() {
-    namesakes = [];
-    selectedPerson = null;
-    filterText = "";
-  }
+    const peopleNames = $derived(
+        stemma ? [...new Set(filterEditablePeople(stemma.people).map((p) => p.name))] : []
+    );
 
-  $: if (stemma) peopleNames = [...new Set(filterEditablePeople(stemma.people).map((p) => p.name))];
-  $: {
-    if (!peopleNames) {
-      peopleItems = [];
-    } else {
-      peopleItems = peopleNames.map((name) => ({ label: name, value: name }));
-      if (filterText && !peopleNames.includes(filterText)) {
-        peopleItems = [
-          ...peopleItems,
-          { label: $t("family.createOption", { name: filterText }), value: filterText, isCreator: true },
-        ];
-      }
+    const peopleItems = $derived.by(() => {
+        const items: SelectItem[] = peopleNames.map((name) => ({ label: name, value: name }));
+        if (filterText && !peopleNames.includes(filterText)) {
+            items.push({
+                label: $t("family.createOption", { name: filterText }),
+                value: filterText,
+                isCreator: true,
+            });
+        }
+        return items;
+    });
+
+    const selectedItem = $derived<SelectItem | null>(
+        selectedPerson ? { label: selectedPerson.name, value: selectedPerson.name } : null
+    );
+
+    function personSelected(p: CreateNewPerson | PersonDescription) {
+        selectedPerson = p;
+        onselected?.(p);
     }
-  }
-  $: selectedItem = selectedPerson
-    ? { label: selectedPerson.name, value: selectedPerson.name }
-    : null;
-  $: if (selectedPerson) dispatch("selected", selectedPerson);
 
-  function handleSelect(e) {
-    const detail = e?.detail as SelectItem | undefined;
-    const value = detail?.value ?? detail?.label ?? "";
-    if (value) nameChanged(value);
-  }
+    function nameChanged(newName: string) {
+        namesakes = [...stemmaIndex.namesakes(newName).filter((p) => !p.readOnly), { type: "CreateNewPerson", name: newName }];
+    }
+
+    export function reset() {
+        namesakes = [];
+        selectedPerson = null;
+        filterText = "";
+    }
+
+    function handleSelect(e: any) {
+        const detail = e?.detail as SelectItem | undefined;
+        const value = detail?.value ?? detail?.label ?? "";
+        if (value) nameChanged(value);
+    }
 </script>
 
 <div class="container h-100">
-  <div class="d-flex flex-column h-100">
-    <div class="flex-shrink-1">
-      <label for="personName" class="form-label">{$t('family.fullName')}</label>
-      <Select
-        id="personName"
-        placeholder={$t('family.namePlaceholder')}
-        items={peopleItems}
-        searchable={true}
-        bind:filterText={filterText}
-        on:select={handleSelect}
-        on:clear={() => reset()}
-        hideEmptyState={true}
-        value={selectedItem}
-      >
-        <svelte:fragment slot="clear-icon">
-          <ClearIcon />
-        </svelte:fragment>
-      </Select>
+    <div class="d-flex flex-column h-100">
+        <div class="flex-shrink-1">
+            <label for="personName" class="form-label">{$t('family.fullName')}</label>
+            <Select
+                id="personName"
+                placeholder={$t('family.namePlaceholder')}
+                items={peopleItems}
+                searchable={true}
+                bind:filterText={filterText}
+                on:select={handleSelect}
+                on:clear={() => reset()}
+                hideEmptyState={true}
+                value={selectedItem}
+            >
+                <svelte:fragment slot="clear-icon">
+                    <ClearIcon />
+                </svelte:fragment>
+            </Select>
+        </div>
+        <div class="flex-grow-1 mt-2 mb-2" style="min-height:400px">
+            <PersonSelector people={namesakes} {stemmaIndex} onselect={personSelected} />
+        </div>
     </div>
-    <div class="flex-grow-1 mt-2 mb-2" style="min-height:400px">
-      <PersonSelector people={namesakes} {stemmaIndex} on:select={(e) => (selectedPerson = e.detail)} />
-    </div>
-  </div>
 </div>

--- a/frontend/src/components/family_modal/FamilyDetailsModal.svelte
+++ b/frontend/src/components/family_modal/FamilyDetailsModal.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
     import type { CreateNewPerson, FamilyDescription, PersonDefinition, PersonDescription } from "../../model";
     import * as bootstrap from "bootstrap";
 
@@ -14,29 +14,30 @@
     import { StemmaIndex } from "../../stemmaIndex";
     import CreateSelectPerson from "./CreateSelectPerson.svelte";
     import FamilyGeneration from "./FamilyGeneration.svelte";
-
-    import { createEventDispatcher } from "svelte";
     import { t } from "../../i18n";
 
-    let modalEl;
-    let mode = "familyComposition";
+    type Props = {
+        stemma: Stemma;
+        stemmaIndex: StemmaIndex;
+        onfamilyAdded?: (payload: { parents: PersonDefinition[]; children: PersonDefinition[] }) => void;
+        onfamilyUpdated?: (payload: { familyId: string; parents: PersonDefinition[]; children: PersonDefinition[] }) => void;
+        onfamilyRemoved?: (familyId: string) => void;
+    };
 
-    let createSelectEl;
+    let { stemma, stemmaIndex, onfamilyAdded, onfamilyUpdated, onfamilyRemoved }: Props = $props();
 
-    let selectParent: boolean;
-    let selected = null;
-    let familyId = null;
+    let modalEl = $state<HTMLElement>(null);
+    let mode = $state("familyComposition");
+    let createSelectEl = $state<ReturnType<typeof CreateSelectPerson>>(null);
+    let selectParent = $state<boolean>(false);
+    let selected = $state<CreateNewPerson | PersonDescription>(null);
+    let familyId = $state<string>(null);
+    let parents = $state<(CreateNewPerson | PersonDescription)[]>([]);
+    let children = $state<(CreateNewPerson | PersonDescription)[]>([]);
+    let readOnly = $state(false);
 
-    let parents: (CreateNewPerson | PersonDescription)[] = [];
-    let children: (CreateNewPerson | PersonDescription)[] = [];
-
-    let selectedParentsCount, selectedChildrenCount;
-    let readOnly: boolean;
-
-    let dispatch = createEventDispatcher();
-
-    export let stemma: Stemma;
-    export let stemmaIndex: StemmaIndex;
+    const selectedParentsCount = $derived(parents.length);
+    const selectedChildrenCount = $derived(children.length);
 
     export function showExistingFamily(details: FamilyDescription) {
         familyId = details.id;
@@ -59,19 +60,16 @@
         mode = "familyComposition";
     }
 
-    function showPersonSelection(isParent) {
+    function showPersonSelection(isParent: boolean) {
         selectParent = isParent;
-
         if (createSelectEl) createSelectEl.reset();
         selected = null;
-
         mode = "personSelection";
     }
 
     function confirmPersonSelection() {
         if (selectParent) parents = [...parents, { ...selected }];
         else children = [...children, { ...selected }];
-
         showFamilyComposition();
     }
 
@@ -81,23 +79,18 @@
     }
 
     function saveFamily() {
-        let pp = parents.map((p) => toPersonDefinition(p));
-        let cc = children.map((c) => toPersonDefinition(c));
+        const pp = parents.map((p) => toPersonDefinition(p));
+        const cc = children.map((c) => toPersonDefinition(c));
 
-        if (familyId == null) dispatch("familyAdded", { parents: pp, children: cc });
-        else dispatch("familyUpdated", { familyId: familyId, parents: pp, children: cc });
+        if (familyId == null) onfamilyAdded?.({ parents: pp, children: cc });
+        else onfamilyUpdated?.({ familyId, parents: pp, children: cc });
 
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
     }
 
     function removeFamily() {
-        dispatch("familyRemoved", familyId);
+        onfamilyRemoved?.(familyId);
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-    }
-
-    $: {
-        selectedParentsCount = parents ? parents.length : 0;
-        selectedChildrenCount = children ? children.length : 0;
     }
 </script>
 
@@ -121,7 +114,7 @@
                     <p class="fs-5">{$t("family.parents")}</p>
                     <FamilyGeneration bind:selectedPeople={parents} {readOnly} />
                     {#if selectedParentsCount < 2 && !readOnly}
-                        <button type="button" class="btn btn-primary btn-sm" on:click={(e) => showPersonSelection(true)}
+                        <button type="button" class="btn btn-primary btn-sm" onclick={() => showPersonSelection(true)}
                             ><i class="bi bi-person-plus-fill"></i> {$t("common.add")}</button
                         >
                     {/if}
@@ -131,27 +124,27 @@
                     <p class="fs-5">{$t("family.children")}</p>
                     <FamilyGeneration bind:selectedPeople={children} {readOnly} />
                     {#if !readOnly}
-                        <button type="button" class="btn btn-primary btn-sm" on:click={(e) => showPersonSelection(false)}
+                        <button type="button" class="btn btn-primary btn-sm" onclick={() => showPersonSelection(false)}
                             ><i class="bi bi-person-plus-fill"></i> {$t("common.add")}</button
                         >
                     {/if}
                 {:else}
-                    <CreateSelectPerson {stemma} {stemmaIndex} bind:this={createSelectEl} on:selected={(e) => (selected = e.detail)} />
+                    <CreateSelectPerson {stemma} {stemmaIndex} bind:this={createSelectEl} onselected={(p) => (selected = p)} />
                 {/if}
             </div>
             {#if !readOnly}
                 <div class="modal-footer">
                     {#if mode == "familyComposition"}
                         {#if familyId != null}
-                            <button type="button" class="btn btn-danger me-auto" on:click={() => removeFamily()}>{$t("common.delete")}</button>
+                            <button type="button" class="btn btn-danger me-auto" onclick={removeFamily}>{$t("common.delete")}</button>
                         {/if}
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
-                        <button type="button" class="btn btn-primary" disabled={selectedParentsCount + selectedChildrenCount < 2} on:click={(e) => saveFamily()}
+                        <button type="button" class="btn btn-primary" disabled={selectedParentsCount + selectedChildrenCount < 2} onclick={saveFamily}
                             >{$t("common.save")}</button
                         >
                     {:else}
-                        <button type="button" class="btn btn-secondary" on:click={(e) => showFamilyComposition()}>{$t("common.back")}</button>
-                        <button type="button" class="btn btn-primary" disabled={selected == null} on:click={(e) => confirmPersonSelection()}>{$t("common.select")}</button>
+                        <button type="button" class="btn btn-secondary" onclick={showFamilyComposition}>{$t("common.back")}</button>
+                        <button type="button" class="btn btn-primary" disabled={selected == null} onclick={confirmPersonSelection}>{$t("common.select")}</button>
                     {/if}
                 </div>
             {/if}

--- a/frontend/src/components/family_modal/FamilyGeneration.svelte
+++ b/frontend/src/components/family_modal/FamilyGeneration.svelte
@@ -1,33 +1,37 @@
 <script lang="ts">
-  import type { CreateNewPerson, PersonDescription } from "../../model";
-  import { t } from "../../i18n";
+    import type { CreateNewPerson, PersonDescription } from "../../model";
+    import { t } from "../../i18n";
 
-  export let selectedPeople: (PersonDescription | CreateNewPerson)[] = [];
-  export let readOnly: boolean;
+    type Props = {
+        selectedPeople?: (PersonDescription | CreateNewPerson)[];
+        readOnly: boolean;
+    };
 
-  function remove(index: number) {
-    selectedPeople = selectedPeople.filter((element, i) => i != index);
-  }
+    let { selectedPeople = $bindable([]), readOnly }: Props = $props();
+
+    function remove(index: number) {
+        selectedPeople = selectedPeople.filter((_, i) => i !== index);
+    }
 </script>
 
 {#if !selectedPeople.length}
-  <p class="text-center text-secondary fs-6">{$t('family.noInfo')}</p>
+    <p class="text-center text-secondary fs-6">{$t('family.noInfo')}</p>
 {:else}
-  <table class="table">
-    <tbody>
-      {#each selectedPeople as p, i}
-        <tr>
-          <th class="align-middle" scope="row">{i + 1}</th>
-          <td class="align-middle">{p.name}</td>
-          <td class="align-middle">
-            {#if !readOnly}
-              <div class="float-end">
-                <button type="button" class="btn btn-sm btn-danger" aria-label={$t("common.delete")} on:click={(e) => remove(i)}><i class="bi bi-trash"></i></button>
-              </div>
-            {/if}
-          </td>
-        </tr>
-      {/each}
-    </tbody>
-  </table>
+    <table class="table">
+        <tbody>
+            {#each selectedPeople as p, i}
+                <tr>
+                    <th class="align-middle" scope="row">{i + 1}</th>
+                    <td class="align-middle">{p.name}</td>
+                    <td class="align-middle">
+                        {#if !readOnly}
+                            <div class="float-end">
+                                <button type="button" class="btn btn-sm btn-danger" aria-label={$t("common.delete")} onclick={() => remove(i)}><i class="bi bi-trash"></i></button>
+                            </div>
+                        {/if}
+                    </td>
+                </tr>
+            {/each}
+        </tbody>
+    </table>
 {/if}

--- a/frontend/src/components/invite_modal/InviteModal.svelte
+++ b/frontend/src/components/invite_modal/InviteModal.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
     export type CreateInviteLink = {
         personId: string;
         email: string;
@@ -10,26 +10,37 @@
     import * as bootstrap from "bootstrap";
     import type { Stemma, PersonDescription } from "../../model";
     import ClearIcon from "../misc/ClearIconTranslated.svelte";
-    import { createEventDispatcher } from "svelte";
     import { StemmaIndex } from "../../stemmaIndex";
     import PersonSelector from "../misc/PersonSelector.svelte";
     import { t } from "../../i18n";
 
-    let modalEl;
+    type Props = {
+        stemmaIndex: StemmaIndex;
+        stemma: Stemma;
+        oninvite?: (payload: CreateInviteLink) => void;
+    };
 
-    export let stemmaIndex: StemmaIndex;
-    export let stemma: Stemma;
+    let { stemmaIndex, stemma, oninvite }: Props = $props();
 
-    let namesakes: PersonDescription[] = [];
-    let selectedPerson: PersonDescription;
+    let modalEl = $state<HTMLElement>(null);
+
+    let namesakes = $state<PersonDescription[]>([]);
+    let selectedPerson = $state<PersonDescription>(null);
     type SelectItem = { label: string; value: string };
-    let peopleNames: string[];
-    let peopleItems: SelectItem[] = [];
-    let selectedItem: SelectItem = null;
-    let email;
-    let inviteLink = "";
+    let email = $state<string>(null);
+    let inviteLink = $state("");
 
-    let dispatch = createEventDispatcher();
+    const peopleNames = $derived(
+        stemma ? [...new Set(stemma.people.map((p) => p.name))] : []
+    );
+
+    const peopleItems = $derived<SelectItem[]>(
+        peopleNames.map((name) => ({ label: name, value: name }))
+    );
+
+    const selectedItem = $derived<SelectItem | null>(
+        selectedPerson ? { label: selectedPerson.name, value: selectedPerson.name } : null
+    );
 
     function nameChanged(newName: string) {
         namesakes = [...stemmaIndex.namesakes(newName).filter((p) => !p.readOnly)];
@@ -51,11 +62,7 @@
         inviteLink = link;
     }
 
-    $: if (stemma) peopleNames = [...new Set(stemma.people.map((p) => p.name))];
-    $: peopleItems = peopleNames ? peopleNames.map((name) => ({ label: name, value: name })) : [];
-    $: selectedItem = selectedPerson ? { label: selectedPerson.name, value: selectedPerson.name } : null;
-
-    function handleSelect(e) {
+    function handleSelect(e: any) {
         const detail = e?.detail as SelectItem | undefined;
         const value = detail?.value ?? detail?.label ?? "";
         if (value) nameChanged(value);
@@ -90,7 +97,7 @@
                             </Select>
                         </div>
                         <div class="flex-grow-1 mt-2" style="min-height:400px">
-                            <PersonSelector people={namesakes} {stemmaIndex} on:select={(e) => (selectedPerson = e.detail)} />
+                            <PersonSelector people={namesakes} {stemmaIndex} onselect={(p) => (selectedPerson = p as PersonDescription)} />
                         </div>
                         <div class="flex-shrink-1 mb-2">
                             <div class="mt-2">
@@ -104,7 +111,7 @@
                                     class="btn btn-outline-primary"
                                     type="button"
                                     disabled={!email || !selectedPerson}
-                                    on:click={(e) => dispatch("invite", { personId: selectedPerson.id, email: email })}>{$t("invite.create")}</button
+                                    onclick={() => oninvite?.({ personId: selectedPerson.id, email })}>{$t("invite.create")}</button
                                 >
                                 <input
                                     type="text"
@@ -120,7 +127,7 @@
                                     type="button"
                                     aria-label="Copy invitation link"
                                     disabled={inviteLink == undefined || !inviteLink.length}
-                                    on:click={() => navigator.clipboard.writeText(inviteLink)}><i class="bi bi-clipboard"></i></button
+                                    onclick={() => navigator.clipboard.writeText(inviteLink)}><i class="bi bi-clipboard"></i></button
                                 >
                             </div>
                         </div>

--- a/frontend/src/components/misc/PersonSelector.svelte
+++ b/frontend/src/components/misc/PersonSelector.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
     import type { CreateNewPerson, PersonDescription } from "../../model";
-    import { createEventDispatcher } from "svelte";
     import VisualPersonDescription from "./VisualPersonDescription.svelte";
     import { StemmaIndex } from "../../stemmaIndex";
     import { t } from "../../i18n";
     import { filterEditablePeople } from "../../personSelectionRules";
 
-    let dispatch = createEventDispatcher();
-    let selectedPerson: CreateNewPerson | PersonDescription;
+    type Props = {
+        people?: (CreateNewPerson | PersonDescription)[];
+        stemmaIndex: StemmaIndex;
+        onselect?: (person: CreateNewPerson | PersonDescription) => void;
+    };
+
+    let { people = [], stemmaIndex, onselect }: Props = $props();
+
+    let selectedPerson = $state<CreateNewPerson | PersonDescription>(null);
+
+    const filteredPeople = $derived(filterEditablePeople(people));
+
+    $effect(() => {
+        if (filteredPeople.length > 0) selectPerson(filteredPeople[0]);
+    });
 
     function tabName(p: PersonDescription | CreateNewPerson, i: number) {
         if ("id" in p) return $t("personSelector.namesake", { index: String(i + 1) });
@@ -16,14 +28,8 @@
 
     function selectPerson(p: PersonDescription | CreateNewPerson) {
         selectedPerson = p;
+        onselect?.(p);
     }
-
-    export let people: (CreateNewPerson | PersonDescription)[] = [];
-    export let stemmaIndex: StemmaIndex;
-
-    $: filteredPeople = filterEditablePeople(people);
-    $: if (filteredPeople) selectedPerson = filteredPeople[0];
-    $: if (selectedPerson) dispatch("select", selectedPerson);
 </script>
 
 {#if filteredPeople && filteredPeople.length}
@@ -37,7 +43,7 @@
                                 class="nav-link {p == selectedPerson ? 'active' : ''}"
                                 aria-current={p == selectedPerson ? "page" : null}
                                 href="/"
-                                on:click|preventDefault={() => selectPerson(p)}>{tabName(p, i)}</a
+                                onclick={(e) => { e.preventDefault(); selectPerson(p); }}>{tabName(p, i)}</a
                             >
                         </li>
                     {/each}

--- a/frontend/src/components/misc/SearchAutocomplete.svelte
+++ b/frontend/src/components/misc/SearchAutocomplete.svelte
@@ -1,29 +1,29 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
     import fuzzysort from "fuzzysort";
     import type { PersonDescription } from "../../model";
     import { t } from "../../i18n";
 
-    export let people: PersonDescription[] = [];
-    export let disabled: boolean = false;
+    type Props = {
+        people?: PersonDescription[];
+        disabled?: boolean;
+        onselect?: (id: string) => void;
+    };
 
-    const dispatch = createEventDispatcher();
+    let { people = [], disabled = false, onselect }: Props = $props();
 
-    let query = "";
-    let activeIndex = -1;
-    let showDropdown = false;
+    let query = $state("");
+    let activeIndex = $state(-1);
+    let showDropdown = $state(false);
     let blurTimeout: ReturnType<typeof setTimeout>;
 
-    $: results = query.length >= 2
-        ? fuzzysort.go(query, people, { key: "name", limit: 8 })
-        : [];
+    const results = $derived(
+        query.length >= 2 ? fuzzysort.go(query, people, { key: "name", limit: 8 }) : []
+    );
 
-    $: if (results.length > 0 && query.length >= 2) {
-        showDropdown = true;
+    $effect(() => {
+        showDropdown = results.length > 0 && query.length >= 2;
         activeIndex = -1;
-    } else {
-        showDropdown = false;
-    }
+    });
 
     function lifespan(p: PersonDescription): string {
         const parts = [p.birthDate || "?", p.deathDate].filter(Boolean);
@@ -31,7 +31,7 @@
     }
 
     function selectPerson(id: string) {
-        dispatch("select", id);
+        onselect?.(id);
         query = "";
         showDropdown = false;
     }
@@ -76,9 +76,9 @@
         placeholder={$t("search.placeholder")}
         bind:value={query}
         {disabled}
-        on:keydown={handleKeydown}
-        on:blur={handleBlur}
-        on:focus={handleFocus}
+        onkeydown={handleKeydown}
+        onblur={handleBlur}
+        onfocus={handleFocus}
     />
     {#if showDropdown && results.length > 0}
         <ul class="dropdown-menu show w-100" style="max-height: 320px; overflow-y: auto">
@@ -87,7 +87,7 @@
                     <button
                         class="dropdown-item {i === activeIndex ? 'active' : ''}"
                         type="button"
-                        on:mousedown|preventDefault={() => selectPerson(result.obj.id)}
+                        onmousedown={(e) => { e.preventDefault(); selectPerson(result.obj.id); }}
                     >
                         <span>{@html result.highlight('<b>', '</b>')}</span>
                         {#if lifespan(result.obj)}

--- a/frontend/src/components/misc/VisualPersonDescription.svelte
+++ b/frontend/src/components/misc/VisualPersonDescription.svelte
@@ -5,23 +5,29 @@
     import { configureSimulation, initChart, makeDrag, makeNodesAndRelations, mergeData, renderChart } from "../../graphTools";
     import { HighlightAll } from "../../highlight";
 
-    export let chartId;
-    export let selectedPerson: PersonDescription | CreateNewPerson;
-    export let stemmaIndex: StemmaIndex;
+    type Props = {
+        chartId: string;
+        selectedPerson: PersonDescription | CreateNewPerson;
+        stemmaIndex: StemmaIndex;
+    };
 
-    let svg;
-    let markers;
-    let width, height;
-    let nodes, relations;
-    let sim;
+    let { chartId, selectedPerson, stemmaIndex }: Props = $props();
+
+    let svg = $state<any>(null);
+    let markers: any = null;
+    let width = $state(0);
+    let height = $state(0);
+    let nodes = $state<any[]>(null);
+    let relations = $state<any[]>(null);
+    let sim: any = null;
 
     onMount(() => {
         ({ svg, markers } = initChart(`#${chartId}`));
     });
 
-    $: {
+    $effect(() => {
         if (svg && selectedPerson) {
-            let relativies, families;
+            let relativies: any[], families: any[];
 
             if ("id" in selectedPerson) {
                 relativies = stemmaIndex.relativies(selectedPerson.id);
@@ -33,16 +39,16 @@
 
             [nodes, relations] = makeNodesAndRelations(relativies, families);
         }
-    }
+    });
 
-    $: {
+    $effect(() => {
         if (width && height && svg && nodes && relations) {
             sim = configureSimulation(svg, nodes, relations, width, height);
             mergeData(svg, nodes, relations, width, height, null, null, true);
             makeDrag(svg, sim, null);
             renderChart(svg, new HighlightAll(), stemmaIndex, markers);
         }
-    }
+    });
 </script>
 
 <div bind:clientWidth={width} bind:clientHeight={height} class="h-100 w-100">

--- a/frontend/src/components/person_details_modal/PersonDetailsModal.svelte
+++ b/frontend/src/components/person_details_modal/PersonDetailsModal.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
     import type { PersonDescription, CreateNewPerson } from "../../model";
     import { imask } from "@imask/svelte";
 
@@ -16,32 +16,39 @@
 
 <script lang="ts">
     import * as bootstrap from "bootstrap";
-    import { createEventDispatcher } from "svelte";
     import { t } from "../../i18n";
 
-    let modalEl;
-    const dispatch = createEventDispatcher();
+    type Props = {
+        onpersonUpdated?: (payload: UpdatePerson) => void;
+        onpersonRemoved?: (id: string) => void;
+    };
 
-    let pinned: boolean;
-    let name: string;
-    let birthDate: Date;
-    let deathDate: Date;
-    let bio: string;
-    let id: string;
-    let readOnly: boolean;
+    let { onpersonUpdated, onpersonRemoved }: Props = $props();
 
-    let birthDateErrString: string;
-    let deathDateErrString: string;
+    let modalEl = $state<HTMLElement>(null);
+    let birthInputEl = $state<HTMLInputElement>(null);
+    let deathInputEl = $state<HTMLInputElement>(null);
+
+    let pinned = $state<boolean>(false);
+    let name = $state<string>("");
+    let birthDate = $state<Date>(null);
+    let deathDate = $state<Date>(null);
+    let bio = $state<string>("");
+    let id = $state<string>("");
+    let readOnly = $state<boolean>(false);
+
+    let birthDateErrString = $state<string>(null);
+    let deathDateErrString = $state<string>(null);
 
     function personUpdated() {
-        dispatch("personUpdated", {
-            id: id,
+        onpersonUpdated?.({
+            id,
             description: {
                 type: "CreateNewPerson",
-                name: name,
+                name,
                 birthDate: dateToIsoLocalTime(birthDate),
                 deathDate: dateToIsoLocalTime(deathDate),
-                bio: bio,
+                bio,
             },
             pin: pinned,
         });
@@ -50,20 +57,19 @@
     }
 
     function personRemoved() {
-        dispatch("personRemoved", id);
-
+        onpersonRemoved?.(id);
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
     }
 
     function dateToIsoLocalTime(d: Date) {
         if (!d) return null;
 
-        let date = d.getDate();
-        let month = d.getMonth() + 1;
-        let year = d.getFullYear();
+        const date = d.getDate();
+        const month = d.getMonth() + 1;
+        const year = d.getFullYear();
 
-        let dateStr = date < 10 ? "0" + date : date.toString();
-        let monthStr = month < 10 ? "0" + month : month.toString();
+        const dateStr = date < 10 ? "0" + date : date.toString();
+        const monthStr = month < 10 ? "0" + month : month.toString();
 
         return `${year}-${monthStr}-${dateStr}`;
     }
@@ -73,10 +79,8 @@
         name = p.description.name;
         birthDate = p.description.birthDate ? new Date(p.description.birthDate) : null;
         deathDate = p.description.deathDate ? new Date(p.description.deathDate) : null;
-        const birthInput = document.getElementById("birthDateInput") as HTMLInputElement | null;
-        if (birthInput) birthInput.value = dateToMaskedDateStr(birthDate) ?? "";
-        const deathInput = document.getElementById("deathDateInput") as HTMLInputElement | null;
-        if (deathInput) deathInput.value = dateToMaskedDateStr(deathDate) ?? "";
+        if (birthInputEl) birthInputEl.value = dateToMaskedDateStr(birthDate) ?? "";
+        if (deathInputEl) deathInputEl.value = dateToMaskedDateStr(deathDate) ?? "";
         bio = p.description.bio;
         pinned = p.pin;
         readOnly = p.description.readOnly;
@@ -87,20 +91,20 @@
         bootstrap.Modal.getOrCreateInstance(modalEl).show();
     }
 
-    function parseMaskedDateStr(str: String) {
-        var [day, month, year] = str.split(".");
+    function parseMaskedDateStr(str: string) {
+        const [day, month, year] = str.split(".");
         return new Date(Number(year), Number(month) - 1, Number(day));
     }
 
     function dateToMaskedDateStr(date: Date) {
         if (!date) return null;
 
-        let day = date.getDate();
-        let month = date.getMonth() + 1;
-        let year = date.getFullYear();
+        const day = date.getDate();
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
 
-        let dayStr = day < 10 ? "0" + day : day.toString();
-        let monthStr = month < 10 ? "0" + month : month.toString();
+        const dayStr = day < 10 ? "0" + day : day.toString();
+        const monthStr = month < 10 ? "0" + month : month.toString();
 
         return [dayStr, monthStr, year.toString()].join(".");
     }
@@ -113,27 +117,46 @@
         parse: parseMaskedDateStr,
     };
 
-    function acceptBirthDate({ detail: maskRef }) {
-        if (!maskRef.unmaskedValue) birthDateErrString = null;
-        else birthDateErrString = $t("person.incompleteDate");
+    function attachMaskedDateListeners(
+        el: HTMLInputElement,
+        setErr: (err: string | null) => void,
+        setDate: (d: Date) => void,
+    ) {
+        function onAccept(e: Event) {
+            const maskRef = (e as CustomEvent).detail;
+            setErr(maskRef.unmaskedValue ? $t("person.incompleteDate") : null);
+        }
+        function onComplete(e: Event) {
+            const maskRef = (e as CustomEvent).detail;
+            setErr(null);
+            setDate(parseMaskedDateStr(maskRef.value));
+            validateLifetimeRange();
+        }
+        el.addEventListener("accept", onAccept);
+        el.addEventListener("complete", onComplete);
+        return () => {
+            el.removeEventListener("accept", onAccept);
+            el.removeEventListener("complete", onComplete);
+        };
     }
 
-    function completeBirthDate({ detail: maskRef }) {
-        birthDateErrString = null;
-        birthDate = parseMaskedDateStr(maskRef.value);
-        validateLifetimeRange();
-    }
+    $effect(() => {
+        if (!birthInputEl) return;
+        return attachMaskedDateListeners(
+            birthInputEl,
+            (err) => (birthDateErrString = err),
+            (d) => (birthDate = d),
+        );
+    });
 
-    function acceptDeathDate({ detail: maskRef }) {
-        if (!maskRef.unmaskedValue) deathDateErrString = null;
-        else deathDateErrString = $t("person.incompleteDate");
-    }
-
-    function completeDeathDate({ detail: maskRef }) {
-        deathDateErrString = null;
-        deathDate = parseMaskedDateStr(maskRef.value);
-        validateLifetimeRange();
-    }
+    $effect(() => {
+        if (!deathInputEl) return;
+        return attachMaskedDateListeners(
+            deathInputEl,
+            (err) => (deathDateErrString = err),
+            (d) => (deathDate = d),
+        );
+    });
 
     function validateLifetimeRange() {
         if (!birthDate || !deathDate) return;
@@ -164,11 +187,10 @@
                     <div class="mt-3 mb-2">{$t("person.lifeYears")}</div>
                     <div class="col-md-6 mb-2">
                         <input
+                            bind:this={birthInputEl}
                             id="birthDateInput"
                             value={dateToMaskedDateStr(birthDate)}
                             use:imask={dateMaskingOpts}
-                            on:accept={acceptBirthDate}
-                            on:complete={completeBirthDate}
                             class="form-control birthdate-input {birthDateErrString ? 'is-invalid' : ''}"
                             readonly={readOnly}
                             placeholder={$t("person.datePlaceholder")}
@@ -177,11 +199,10 @@
                     </div>
                     <div class="col-md-6 mb-2">
                         <input
+                            bind:this={deathInputEl}
                             id="deathDateInput"
                             value={dateToMaskedDateStr(deathDate)}
                             use:imask={dateMaskingOpts}
-                            on:accept={acceptDeathDate}
-                            on:complete={completeDeathDate}
                             class="form-control deathdate-input {deathDateErrString ? 'is-invalid' : ''}"
                             readonly={readOnly}
                             placeholder={$t("person.datePlaceholder")}
@@ -203,14 +224,14 @@
             </div>
             <div class="modal-footer">
                 {#if !readOnly}
-                    <button type="button" class="btn btn-danger me-auto" on:click={() => personRemoved()}>{$t("common.delete")}</button>
+                    <button type="button" class="btn btn-danger me-auto" onclick={personRemoved}>{$t("common.delete")}</button>
                 {/if}
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
                 <button
                     type="button"
                     class="btn btn-primary"
                     disabled={birthDateErrString != null || deathDateErrString != null}
-                    on:click={() => personUpdated()}>{$t("common.save")}</button
+                    onclick={personUpdated}>{$t("common.save")}</button
                 >
             </div>
         </div>

--- a/frontend/src/components/rename_stemma_modal/RenameStemmaModal.svelte
+++ b/frontend/src/components/rename_stemma_modal/RenameStemmaModal.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-    import { createEventDispatcher } from "svelte";
     import { onMount } from "svelte";
     import * as bootstrap from "bootstrap";
     import { t } from "../../i18n";
 
-    const dispatch = createEventDispatcher();
+    type Props = {
+        onstemmaRenamed?: (payload: { stemmaId: string; name: string }) => void;
+    };
 
-    let modalEl;
-    let input;
-    let renamedStemmaId;
+    let { onstemmaRenamed }: Props = $props();
+
+    let modalEl = $state<HTMLElement>(null);
+    let input = $state<HTMLInputElement>(null);
+    let renamedStemmaId = $state<string>(null);
 
     onMount(() => {
         modalEl.addEventListener("shown.bs.modal", () => input.focus());
@@ -16,9 +19,9 @@
 
     function handleRenameClick() {
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
-        let name = input.value;
+        const name = input.value;
         input.value = "";
-        dispatch("stemmaRenamed", { stemmaId: renamedStemmaId, name: name });
+        onstemmaRenamed?.({ stemmaId: renamedStemmaId, name });
     }
 
     export function promptStemmaRename(stemmaId: string, currentName: string) {
@@ -50,7 +53,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
-                <button type="button" class="btn btn-primary" on:click={handleRenameClick}>{$t("stemma.rename")}</button>
+                <button type="button" class="btn btn-primary" onclick={handleRenameClick}>{$t("stemma.rename")}</button>
             </div>
         </div>
     </div>

--- a/frontend/src/components/settings_modal/SettingsModal.svelte
+++ b/frontend/src/components/settings_modal/SettingsModal.svelte
@@ -1,20 +1,23 @@
 <script lang="ts">
     import * as bootstrap from "bootstrap";
-    import { createEventDispatcher } from "svelte";
     import type { Settings } from "../../model";
     import { DEFAULT_SETTINGS, ViewMode } from "../../model";
     import { t } from "../../i18n";
 
-    let modalEl;
-    let _settings: Settings = DEFAULT_SETTINGS;
+    type Props = {
+        onsettingsChanged?: (settings: Settings) => void;
+    };
 
-    const dispatch = createEventDispatcher();
+    let { onsettingsChanged }: Props = $props();
+
+    let modalEl = $state<HTMLElement>(null);
+    let _settings = $state<Settings>(DEFAULT_SETTINGS);
 
     function saveSettings() {
         const showAllInput = document.getElementById("showAll") as HTMLInputElement | null;
         const viewAll = showAllInput?.checked ?? false;
 
-        dispatch("settingsChanged", {
+        onsettingsChanged?.({
             viewMode: viewAll ? ViewMode.ALL : ViewMode.EDITABLE_ONLY,
         });
 
@@ -45,7 +48,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{$t("common.cancel")}</button>
-                <button type="button" class="btn btn-primary" on:click={saveSettings}>{$t("common.save")}</button>
+                <button type="button" class="btn btn-primary" onclick={saveSettings}>{$t("common.save")}</button>
             </div>
         </div>
     </div>

--- a/frontend/src/components/stats_card/StatsCard.svelte
+++ b/frontend/src/components/stats_card/StatsCard.svelte
@@ -4,10 +4,14 @@
     import { HiglightLineages } from "../../highlight";
     import { t } from "../../i18n";
 
-    export let stemma: Stemma;
-    export let stemmaIndex: StemmaIndex;
-    export let highlight: HiglightLineages;
-    export let highlightVersion: number;
+    type Props = {
+        stemma: Stemma;
+        stemmaIndex: StemmaIndex;
+        highlight: HiglightLineages;
+        highlightVersion: number;
+    };
+
+    let { stemma, stemmaIndex, highlight, highlightVersion }: Props = $props();
 
     type Stats = {
         active: boolean;
@@ -47,12 +51,13 @@
         };
     }
 
-    $: stats =
+    const stats = $derived(
         stemma && stemmaIndex && highlight && highlightVersion >= 0
             ? highlight.isActive()
                 ? highlightedStats()
                 : totalStats()
-            : null;
+            : null
+    );
 </script>
 
 {#if stats}

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -6,6 +6,6 @@ module.exports = {
         style: less(),
     }),
     compilerOptions: {
-        runes: false,
+        runes: true,
     },
 };


### PR DESCRIPTION
## Summary
- Rewrites all 20 `frontend/src/**/*.svelte` components off legacy mode into Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`, `$bindable`, callback props, `onevent` attributes).
- Flips `svelte.config.js` and `rollup.config.js` to `runes: true`; the Rollup config keeps a second svelte plugin instance for `node_modules` at `runes: false` so legacy third-party packages (`svelte-loading-spinners`) still compile.
- Cleans up reactive plumbing introduced by the mechanical migration: `$effect` callback-mirrors replaced with direct calls in `PersonSelector` / `CreateSelectPerson`; `selectedItem` mirrors converted from `$effect` to `$derived`; duplicate `@imask/svelte` listener wiring in `PersonDetailsModal` extracted into one helper; non-reactive fields in `FullStemma` and `VisualPersonDescription` reverted from `$state` to plain `let`.
- Updates `CLAUDE.md` and `.claude/skills/frontend-style/SKILL.md` to document runes-only guidance.

## Test plan
- [x] `npm run check` (svelte-check): 0 errors, 0 warnings
- [x] `npm test` (Jest): 65/65 passed
- [x] `npm run build` (Rollup): clean
- [x] `npm test` (e2e Playwright): 3/3 passed (`arrows`, `dropdown_align`, `smoke`)
- [ ] Manual sanity-check in the dev server before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)