### PR TITLE
Add SVG export of current chart view

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -82,6 +82,12 @@
         return err.message;
     }
 
+    function exportFilename(): string {
+        const current = ownedStemmas?.find((s) => s.id === currentStemmaId);
+        const base = (current?.name ?? $t("nav.exportDefaultName")).trim().replace(/[\\/:*?"<>|]+/g, "_");
+        return `${base || "stemma"}.svg`;
+    }
+
     function handleSignIn(user: User) {
         saveCredential(user.id_token);
 
@@ -158,6 +164,7 @@
         oninvite={() => inviteModal.showInvintation()}
         onabout={() => aboutModal.show()}
         onsettings={() => settingsModal.show()}
+        onexport={() => stemmaChart.exportSvg(exportFilename())}
         onzoomToPerson={(id) => stemmaChart.zoomToNode(id)}
     />
 

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -21,6 +21,7 @@
     import { computeInitialLayout } from "../initialLayout";
     import { NodeLayoutCache } from "../nodeLayoutCache";
     import { PinnedPeopleStorage } from "../pinnedPeopleStorage";
+    import { exportChartSvg } from "../svgExport";
 
     type Props = {
         stemma: Stemma;
@@ -139,6 +140,12 @@
     const zoomHandler = d3.zoom().on("zoom", (e) => {
         svg.select("g.main").attr("transform", e.transform);
     });
+
+    export function exportSvg(filename: string) {
+        if (!svg) return;
+        const node = svg.node() as SVGSVGElement | null;
+        if (node) exportChartSvg(node, filename);
+    }
 
     export function zoomToNode(id: string) {
         const scaleZoom = 2;

--- a/frontend/src/components/Navbar.svelte
+++ b/frontend/src/components/Navbar.svelte
@@ -18,6 +18,7 @@
         oninvite?: () => void;
         onabout?: () => void;
         onsettings?: () => void;
+        onexport?: () => void;
         onzoomToPerson?: (id: string) => void;
     };
 
@@ -35,6 +36,7 @@
         oninvite,
         onabout,
         onsettings,
+        onexport,
         onzoomToPerson,
     }: Props = $props();
 
@@ -142,6 +144,11 @@
                     <li class="nav-item">
                         <a class="nav-link {disabled ? 'd-none' : ''}" href="/" onclick={(e) => { e.preventDefault(); onsettings?.(); }}
                             ><i class="bi bi-gear-fill"></i> {$t('nav.settings')}</a
+                        >
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {disabled ? 'd-none' : ''}" href="/" onclick={(e) => { e.preventDefault(); onexport?.(); }}
+                            ><i class="bi bi-download"></i> {$t('nav.export')}</a
                         >
                     </li>
                 </ul>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -41,6 +41,8 @@ export const en: Record<string, string> = {
     'nav.settings': 'Settings',
     'nav.about': 'About',
     'nav.language': 'Language',
+    'nav.export': 'Export SVG',
+    'nav.exportDefaultName': 'stemma',
 
     // Common buttons
     'common.cancel': 'Cancel',
@@ -179,6 +181,8 @@ export const ru: Record<string, string> = {
     'nav.settings': 'Настройки',
     'nav.about': 'О проекте',
     'nav.language': 'Язык',
+    'nav.export': 'Скачать SVG',
+    'nav.exportDefaultName': 'родословная',
 
     // Common buttons
     'common.cancel': 'Отмена',

--- a/frontend/src/svgExport.test.ts
+++ b/frontend/src/svgExport.test.ts
@@ -1,0 +1,64 @@
+import { buildExportableSvg } from "./svgExport";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function makeChartSvg(): SVGSVGElement {
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.setAttribute("id", "chart");
+    svg.setAttribute("class", "w-100 p-3 fullHeight");
+
+    const main = document.createElementNS(SVG_NS, "g");
+    main.setAttribute("class", "main");
+    main.setAttribute("transform", "translate(120, 50) scale(1.5)");
+
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("fill", "#326f93");
+    main.appendChild(circle);
+
+    svg.appendChild(main);
+    return svg;
+}
+
+describe("buildExportableSvg", () => {
+    test("strips host classes and live transform", () => {
+        const svg = makeChartSvg();
+        const out = buildExportableSvg(svg, { x: 0, y: 0, width: 100, height: 80 });
+
+        expect(out).not.toContain('class="w-100 p-3 fullHeight"');
+        expect(out).not.toContain("translate(120, 50)");
+    });
+
+    test("adds svg namespace and viewBox derived from bbox + padding", () => {
+        const svg = makeChartSvg();
+        const out = buildExportableSvg(svg, { x: 10, y: 20, width: 100, height: 80 }, 20);
+
+        expect(out).toContain(`xmlns="${SVG_NS}"`);
+        expect(out).toContain(`viewBox="-10 0 140 120"`);
+        expect(out).toContain(`width="140"`);
+        expect(out).toContain(`height="120"`);
+    });
+
+    test("inlines export font + text fill", () => {
+        const svg = makeChartSvg();
+        const out = buildExportableSvg(svg, { x: 0, y: 0, width: 10, height: 10 });
+
+        expect(out).toMatch(/font-family="[^"]+"/);
+        expect(out).toContain('fill="#212529"');
+    });
+
+    test("preserves rendered child styling", () => {
+        const svg = makeChartSvg();
+        const out = buildExportableSvg(svg, { x: 0, y: 0, width: 10, height: 10 });
+
+        expect(out).toContain('fill="#326f93"');
+    });
+
+    test("does not mutate source svg", () => {
+        const svg = makeChartSvg();
+        const originalTransform = svg.querySelector("g.main")?.getAttribute("transform");
+        buildExportableSvg(svg, { x: 0, y: 0, width: 10, height: 10 });
+
+        expect(svg.querySelector("g.main")?.getAttribute("transform")).toBe(originalTransform);
+        expect(svg.getAttribute("class")).toBe("w-100 p-3 fullHeight");
+    });
+});

--- a/frontend/src/svgExport.ts
+++ b/frontend/src/svgExport.ts
@@ -1,0 +1,51 @@
+const SVG_NS = "http://www.w3.org/2000/svg";
+const XLINK_NS = "http://www.w3.org/1999/xlink";
+const EXPORT_FONT_FAMILY = "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif";
+const EXPORT_TEXT_FILL = "#212529";
+
+export type BBox = { x: number; y: number; width: number; height: number };
+
+export function buildExportableSvg(source: SVGSVGElement, bbox: BBox, padding = 20): string {
+    const clone = source.cloneNode(true) as SVGSVGElement;
+
+    clone.removeAttribute("class");
+    clone.removeAttribute("style");
+
+    const main = clone.querySelector("g.main");
+    if (main) main.removeAttribute("transform");
+
+    const width = Math.max(1, Math.ceil(bbox.width + padding * 2));
+    const height = Math.max(1, Math.ceil(bbox.height + padding * 2));
+    const minX = Math.floor(bbox.x - padding);
+    const minY = Math.floor(bbox.y - padding);
+
+    clone.setAttribute("xmlns", SVG_NS);
+    clone.setAttribute("xmlns:xlink", XLINK_NS);
+    clone.setAttribute("viewBox", `${minX} ${minY} ${width} ${height}`);
+    clone.setAttribute("width", String(width));
+    clone.setAttribute("height", String(height));
+    clone.setAttribute("font-family", EXPORT_FONT_FAMILY);
+    clone.setAttribute("fill", EXPORT_TEXT_FILL);
+
+    return new XMLSerializer().serializeToString(clone);
+}
+
+export function downloadSvg(content: string, filename: string): void {
+    const blob = new Blob([content], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+export function exportChartSvg(source: SVGSVGElement, filename: string): void {
+    const main = source.querySelector("g.main") as SVGGraphicsElement | null;
+    const bbox: BBox = main && typeof main.getBBox === "function"
+        ? main.getBBox()
+        : { x: 0, y: 0, width: source.clientWidth || 800, height: source.clientHeight || 600 };
+    downloadSvg(buildExportableSvg(source, bbox), filename);
+}


### PR DESCRIPTION
## Summary
- New \`Export SVG\` button in the navbar that downloads the current chart as an `.svg` file.
- Exported file preserves the current highlight (lineage shading, arrow markers, font) by serializing the live SVG DOM rather than re-rendering.
- Viewport-independent: the live pan/zoom transform on `g.main` is stripped on the clone and replaced with a `viewBox` derived from `getBBox()` + padding, so the export always contains the full chart regardless of how the user has panned/zoomed.

## Implementation
- `frontend/src/svgExport.ts` — pure `buildExportableSvg(source, bbox, padding)` (clones, normalizes namespaces, inlines export font and text fill, sets viewBox), `downloadSvg(content, filename)` (Blob + anchor click), `exportChartSvg(svg, filename)` composer.
- `FullStemma.svelte` exposes `exportSvg(filename)`.
- `Navbar.svelte` gets an `onexport` callback prop and a `bi-download` nav button.
- `App.svelte` wires the callback and computes the filename from the current stemma name (sanitized for filesystem-illegal chars), falling back to a localized default.
- `i18n.ts` adds `nav.export` / `nav.exportDefaultName` for `en` and `ru`.

## Test plan
- [x] `npm test` — 70/70 pass (5 new tests in `svgExport.test.ts` cover namespace, viewBox math, font/fill inlining, child-style preservation, no-mutate guarantee).
- [x] `npm run check` — 0 errors / 0 warnings.
- [ ] Manual: dev server, hover a person to set a highlight, click Export SVG, verify the downloaded file opens with the correct viewport, shaded vs. highlighted styling, and arrow markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)