### PR TITLE
Rename AWS SSO profile to stemma in docs

### DIFF
--- a/.claude/skills/stemma-migration/SKILL.md
+++ b/.claude/skills/stemma-migration/SKILL.md
@@ -23,30 +23,30 @@ new `Request` dataclass + handler branch instead — do not migrate around the A
 
 ## AWS access
 
-Production uses AWS Identity Center (SSO). One-time setup:
+Production uses AWS Identity Center (SSO). Profile name is `stemma`. One-time setup:
 
 ```sh
 aws configure sso
 # Prompts (values come from your Identity Center portal / admin):
-#   SSO session name        — any label, e.g. "stemma"
+#   SSO session name        — "stemma"
 #   SSO start URL           — your organisation's Identity Center start URL
 #   SSO region              — region where the SSO directory lives (often us-east-1)
 #   Account + role          — pick from the list shown
 #   CLI default Region      — eu-central-1 for this project
-#   Profile name            — auto-suggested, accept or customize
+#   Profile name            — "stemma"
 ```
 
 Refresh the SSO session whenever it expires (~8 h):
 
 ```sh
-aws sso login --profile <profile>
-AWS_PROFILE=<profile> aws sts get-caller-identity   # sanity check before any write
+aws sso login --profile stemma
+AWS_PROFILE=stemma aws sts get-caller-identity   # sanity check before any write
 ```
 
 Discover the DynamoDB table name (CloudFormation generates it; never hardcode):
 
 ```sh
-AWS_PROFILE=<profile> aws dynamodb list-tables --region eu-central-1
+AWS_PROFILE=stemma aws dynamodb list-tables --region eu-central-1
 # look for stemma-app-StemmaTable-XXXXX
 ```
 
@@ -97,7 +97,7 @@ hex chars). Dates are ISO strings (`YYYY-MM-DD`).
 Run pattern (no project venv needed — scripts only depend on `boto3`):
 
 ```sh
-AWS_PROFILE=<profile> uvx --with boto3 python \
+AWS_PROFILE=stemma uvx --with boto3 python \
   .claude/skills/stemma-migration/scripts/<script>.py \
   --table stemma-app-StemmaTable-XXXXX --region eu-central-1 --dry-run
 ```
@@ -105,7 +105,7 @@ AWS_PROFILE=<profile> uvx --with boto3 python \
 Or, if you're already in `backend_py/` with `uv sync` done:
 
 ```sh
-AWS_PROFILE=<profile> uv run python \
+AWS_PROFILE=stemma uv run python \
   ../.claude/skills/stemma-migration/scripts/<script>.py …
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,16 @@ Optional / context-dependent:
 
 One-off corrections to the production DynamoDB table go through the `stemma-migration` skill (see `.claude/skills/stemma-migration/`).
 
+### AWS access (production)
+
+Production access uses AWS Identity Center (SSO). The local profile is named `stemma`:
+
+```sh
+aws sso login --profile stemma
+AWS_PROFILE=stemma aws sts get-caller-identity   # sanity check
+AWS_PROFILE=stemma sam deploy                    # local SAM deploys (CI uses access keys, not profile)
+```
+
 Lambda-only (set in `template.yaml` Globals or by `bootstrap`):
 - `STEMMA_INVITE_SECRET_NAME` — Secrets Manager ID fetched at cold start; its JSON contents populate `INVITE_SECRET` via `os.environ.setdefault`.
 

--- a/data/genealogy/kings-of-europe/README.md
+++ b/data/genealogy/kings-of-europe/README.md
@@ -29,7 +29,7 @@ Lambda artifact. The markdown analyses below stay here for reference.
 Need SSO access to the prod table. The dump scripts live in `.claude/skills/stemma-migration/scripts/`:
 
 ```sh
-AWS_PROFILE=<profile> uvx --with boto3 python \
+AWS_PROFILE=stemma uvx --with boto3 python \
   .claude/skills/stemma-migration/scripts/dump_stemma.py \
   --table stemma-app-StemmaTable-17GSYHFZQU76H --region eu-central-1 \
   --stemma 1cd5147ad05b5b619cb5e0efb9ccfab8 \


### PR DESCRIPTION
## Summary
- Standardize the local AWS SSO profile name as `stemma` across CLAUDE.md, the `stemma-migration` skill, and the kings-of-europe README.
- Replace `<profile>` placeholders with the concrete name.
- Add an "AWS access (production)" subsection to CLAUDE.md noting that CI uses access keys (no profile), while local `sam deploy` should use `AWS_PROFILE=stemma`.

No code or infra changes — docs only. The actual profile rename in `~/.aws/config` is a local action and not part of this diff.

## Test plan
- [ ] `AWS_PROFILE=stemma aws sts get-caller-identity` returns the production account
- [ ] `AWS_PROFILE=stemma aws dynamodb list-tables --region eu-central-1` lists the stemma table

🤖 Generated with [Claude Code](https://claude.com/claude-code)