### PR TITLE
Keep users signed in via silent Google credential refresh

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -24,7 +24,9 @@
     import StatsCard from "./components/stats_card/StatsCard.svelte";
     import { SettingsStorage } from "./settingsStroage";
     import { LocalizedError, t } from "./i18n";
-    import { loadCredential, saveCredential } from "./credentialStorage";
+    import { clearCredential, loadCredential, msUntilRefresh, saveCredential } from "./credentialStorage";
+    import type { TokenProvider } from "./model";
+    import { initializeGoogleAuth, refreshCredential } from "./googleAuth";
     import { onMount, untrack } from "svelte";
 
     type Props = {
@@ -88,8 +90,58 @@
         return `${base || "stemma"}.svg`;
     }
 
+    let currentToken = $state<string>(null);
+    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+    let inflightRefresh: Promise<string> | null = null;
+    let e2eMode = false;
+
+    function scheduleRefresh(expiresAt: number) {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        if (e2eMode) return;
+        refreshTimer = setTimeout(() => {
+            void runRefresh();
+        }, msUntilRefresh(expiresAt));
+    }
+
+    function adoptToken(token: string) {
+        const saved = saveCredential(token);
+        currentToken = token;
+        if (saved) scheduleRefresh(saved.expiresAt);
+    }
+
+    function endSession() {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        refreshTimer = null;
+        clearCredential();
+        currentToken = null;
+        signedIn = false;
+    }
+
+    function runRefresh(): Promise<string> {
+        if (e2eMode) return Promise.resolve(currentToken);
+        if (inflightRefresh) return inflightRefresh;
+        inflightRefresh = refreshCredential()
+            .then((token) => {
+                adoptToken(token);
+                return token;
+            })
+            .catch((err) => {
+                endSession();
+                throw err;
+            })
+            .finally(() => {
+                inflightRefresh = null;
+            });
+        return inflightRefresh;
+    }
+
+    const tokenProvider: TokenProvider = {
+        getToken: () => currentToken,
+        refresh: () => runRefresh(),
+    };
+
     function handleSignIn(user: User) {
-        saveCredential(user.id_token);
+        adoptToken(user.id_token);
 
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has("inviteToken")) {
@@ -97,9 +149,9 @@
             urlParams.delete("inviteToken");
             window.history.pushState({}, document.title, window.location.pathname);
 
-            controller.authenticateAndBearToken(user, token);
+            controller.authenticateAndBearToken(tokenProvider, token);
         } else {
-            controller.authenticateAndListStemmas(user);
+            controller.authenticateAndListStemmas(tokenProvider);
         }
 
         signedIn = true;
@@ -108,9 +160,12 @@
     onMount(() => {
         const e2eAutoLoginEnabled = typeof E2E_AUTO_LOGIN !== "undefined" && E2E_AUTO_LOGIN === "1";
         if (e2eAutoLoginEnabled) {
+            e2eMode = true;
             handleSignIn({ id_token: "e2e-user@stemma.local" } as User);
             return;
         }
+
+        initializeGoogleAuth(google_client_id).catch((err) => console.error("Google Identity init failed", err));
 
         const cached = loadCredential();
         if (cached) {

--- a/frontend/src/appController.test.ts
+++ b/frontend/src/appController.test.ts
@@ -33,7 +33,7 @@ describe("AppController", () => {
         localStorage.setItem("stemma_last_stemma_id", "b");
 
         const controller = new AppController("http://example", () => model as any);
-        controller.authenticateAndListStemmas({ id_token: "token" });
+        controller.authenticateAndListStemmas({ getToken: () => "token", refresh: () => Promise.resolve("token") });
         await drainPromises();
 
         expect(model.getStemma).toHaveBeenCalledWith("b");
@@ -52,7 +52,7 @@ describe("AppController", () => {
         };
 
         const controller = new AppController("http://example", () => model as any);
-        controller.authenticateAndListStemmas({ id_token: "token" });
+        controller.authenticateAndListStemmas({ getToken: () => "token", refresh: () => Promise.resolve("token") });
         await drainPromises();
 
         expect(model.getStemma).not.toHaveBeenCalled();
@@ -72,7 +72,7 @@ describe("AppController", () => {
         };
 
         const controller = new AppController("http://example", () => model as any);
-        controller.authenticateAndListStemmas({ id_token: "token" });
+        controller.authenticateAndListStemmas({ getToken: () => "token", refresh: () => Promise.resolve("token") });
         await drainPromises();
 
         expect(model.getStemma).toHaveBeenCalledWith("b");
@@ -94,7 +94,7 @@ describe("AppController", () => {
         localStorage.setItem("stemma_last_stemma_id", "a");
 
         const controller = new AppController("http://example", () => model as any);
-        controller.authenticateAndListStemmas({ id_token: "token" });
+        controller.authenticateAndListStemmas({ getToken: () => "token", refresh: () => Promise.resolve("token") });
         await drainPromises();
 
         expect(model.getStemma).not.toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe("AppController", () => {
         };
 
         const controller = new AppController("http://example", () => model as any);
-        controller.authenticateAndListStemmas({ id_token: "token" });
+        controller.authenticateAndListStemmas({ getToken: () => "token", refresh: () => Promise.resolve("token") });
         await drainPromises();
 
         expect(model.getStemma).not.toHaveBeenCalled();

--- a/frontend/src/appController.ts
+++ b/frontend/src/appController.ts
@@ -1,6 +1,6 @@
 import { HiglightLineages } from './highlight';
 import { Model } from './model';
-import type { CreateNewPerson, PersonDefinition, Stemma, StemmaDescription, User } from './model';
+import type { CreateNewPerson, PersonDefinition, Stemma, StemmaDescription, TokenProvider } from './model';
 import { PinnedPeopleStorage } from './pinnedPeopleStorage';
 import { StemmaIndex } from './stemmaIndex';
 import { writable, get } from 'svelte/store';
@@ -9,7 +9,7 @@ import { selectStemmaId } from './appControllerSelection';
 
 export class AppController {
     private static readonly LAST_STEMMA_KEY = "stemma_last_stemma_id";
-    private modelFactory: (endpoint: string, user: User) => Model;
+    private modelFactory: (endpoint: string, tokenProvider: TokenProvider) => Model;
     stemma = writable<Stemma>(null)
     stemmaIndex = writable<StemmaIndex>(null)
     pinnedStorage = writable<PinnedPeopleStorage>(null)
@@ -24,16 +24,16 @@ export class AppController {
     private model: Model
     private stemmaBackendUrl: string
 
-    constructor(stemmaBackendUrl: string, modelFactory?: (endpoint: string, user: User) => Model) {
+    constructor(stemmaBackendUrl: string, modelFactory?: (endpoint: string, tokenProvider: TokenProvider) => Model) {
         this.stemmaBackendUrl = stemmaBackendUrl;
-        this.modelFactory = modelFactory ?? ((endpoint, user) => new Model(endpoint, user));
+        this.modelFactory = modelFactory ?? ((endpoint, tokenProvider) => new Model(endpoint, tokenProvider));
     }
 
-    authenticateAndListStemmas(user: User) {
+    authenticateAndListStemmas(tokenProvider: TokenProvider) {
         this.isWorking.set(true)
         this.err.set(null)
 
-        this.model = this.modelFactory(this.stemmaBackendUrl, user)
+        this.model = this.modelFactory(this.stemmaBackendUrl, tokenProvider)
         this.model
             .listDescribeStemmas()
             .then((result) => {
@@ -65,11 +65,11 @@ export class AppController {
             .finally(() => this.isWorking.set(false))
     }
 
-    authenticateAndBearToken(user: User, token: string) {
+    authenticateAndBearToken(tokenProvider: TokenProvider, token: string) {
         this.isWorking.set(true)
         this.err.set(null)
 
-        this.model = this.modelFactory(this.stemmaBackendUrl, user)
+        this.model = this.modelFactory(this.stemmaBackendUrl, tokenProvider)
         this.model
             .bearInvitationToken(token)
             .then((result) => {

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { jwtDecode } from "jwt-decode";
     import { onMount } from "svelte";
+    import { initializeGoogleAuth, onCredential, promptInitialSignIn } from "../googleAuth";
 
     type Props = {
         google_client_id: string;
@@ -9,47 +10,21 @@
 
     let { google_client_id, onsignIn }: Props = $props();
 
-    let gsiLoaded = $state(false);
-    let mounted = $state(false);
-
-    onMount(() => {
-        mounted = true;
-        const ready = (window as any).__gsiReady;
-        if (ready && typeof ready.then === "function") {
-            ready.then(() => {
-                gsiLoaded = true;
-            });
-        } else if ((window as any).google && (window as any).google.accounts) {
-            gsiLoaded = true;
-        }
-    });
-
-    function handleCredentialResponse(response: any) {
-        const decoded = jwtDecode<{ given_name: string; picture: string }>(response.credential);
-
+    function handleCredential(credential: string) {
+        const decoded = jwtDecode<{ given_name: string; picture: string }>(credential);
         onsignIn?.({
             name: decoded.given_name,
             image_url: decoded.picture,
-            id_token: response.credential,
+            id_token: credential,
         });
     }
 
-    $effect(() => {
-        if (gsiLoaded && mounted) {
-            (window as any).google.accounts.id.initialize({
-                client_id: google_client_id,
-                callback: handleCredentialResponse,
-                auto_select: true,
-            });
-            (window as any).google.accounts.id.prompt((notification: any) => {
-                if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
-                    (window as any).google.accounts.id.renderButton(
-                        document.getElementById("signin"),
-                        { theme: "outline", size: "large" }
-                    );
-                }
-            });
-        }
+    onMount(() => {
+        const unsubscribe = onCredential(handleCredential);
+        initializeGoogleAuth(google_client_id)
+            .then(() => promptInitialSignIn(document.getElementById("signin")))
+            .catch((err) => console.error("Google Identity init failed", err));
+        return unsubscribe;
     });
 </script>
 

--- a/frontend/src/credentialStorage.test.ts
+++ b/frontend/src/credentialStorage.test.ts
@@ -1,4 +1,4 @@
-import { clearCredential, loadCredential, saveCredential } from "./credentialStorage";
+import { clearCredential, loadCredential, msUntilRefresh, saveCredential } from "./credentialStorage";
 
 function makeToken(expSeconds: number): string {
     const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
@@ -70,5 +70,17 @@ describe("credentialStorage", () => {
         clearCredential();
 
         expect(localStorage.getItem("stemma_credential")).toBeNull();
+    });
+
+    test("msUntilRefresh returns lead time before expiry", () => {
+        const now = 1_000_000;
+        const expiresAt = now + 60 * 60_000;
+        expect(msUntilRefresh(expiresAt, now)).toBe(55 * 60_000);
+    });
+
+    test("msUntilRefresh clamps to zero when expiry is near", () => {
+        const now = 1_000_000;
+        const expiresAt = now + 30_000;
+        expect(msUntilRefresh(expiresAt, now)).toBe(0);
     });
 });

--- a/frontend/src/credentialStorage.ts
+++ b/frontend/src/credentialStorage.ts
@@ -2,11 +2,16 @@ import { jwtDecode } from "jwt-decode";
 
 const STORAGE_KEY = "stemma_credential";
 const EXPIRY_BUFFER_MS = 60_000;
+const REFRESH_LEAD_MS = 5 * 60_000;
 
 export type StoredCredential = {
     token: string;
     expiresAt: number;
 };
+
+export function msUntilRefresh(expiresAt: number, now: number = Date.now(), leadMs: number = REFRESH_LEAD_MS): number {
+    return Math.max(0, expiresAt - leadMs - now);
+}
 
 function decodeExpiry(token: string): number | null {
     const decoded = jwtDecode<{ exp?: number }>(token);

--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -1,0 +1,107 @@
+type GsiNotification = {
+    isNotDisplayed: () => boolean;
+    isSkippedMoment: () => boolean;
+    isDismissedMoment?: () => boolean;
+    getNotDisplayedReason?: () => string;
+    getSkippedReason?: () => string;
+    getDismissedReason?: () => string;
+};
+
+type GsiCredentialResponse = { credential: string };
+
+type Gsi = {
+    accounts: {
+        id: {
+            initialize: (opts: {
+                client_id: string;
+                callback: (resp: GsiCredentialResponse) => void;
+                auto_select?: boolean;
+            }) => void;
+            prompt: (handler?: (n: GsiNotification) => void) => void;
+            renderButton: (parent: HTMLElement, opts: Record<string, unknown>) => void;
+            disableAutoSelect: () => void;
+        };
+    };
+};
+
+type CredentialListener = (token: string) => void;
+
+const REFRESH_TIMEOUT_MS = 8_000;
+
+let initialized = false;
+const listeners = new Set<CredentialListener>();
+
+function gsi(): Gsi | null {
+    const w = window as unknown as { google?: Gsi };
+    return w.google ?? null;
+}
+
+async function awaitGsi(): Promise<Gsi> {
+    const ready = (window as unknown as { __gsiReady?: Promise<void> }).__gsiReady;
+    if (ready && typeof ready.then === "function") await ready;
+    const g = gsi();
+    if (!g) throw new Error("Google Identity Services not loaded");
+    return g;
+}
+
+export async function initializeGoogleAuth(clientId: string): Promise<void> {
+    if (initialized) return;
+    const g = await awaitGsi();
+    g.accounts.id.initialize({
+        client_id: clientId,
+        callback: (resp) => {
+            for (const l of Array.from(listeners)) l(resp.credential);
+        },
+        auto_select: true,
+    });
+    initialized = true;
+}
+
+export function onCredential(listener: CredentialListener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+export async function promptInitialSignIn(fallbackTarget: HTMLElement | null): Promise<void> {
+    const g = await awaitGsi();
+    g.accounts.id.prompt((notification) => {
+        if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+            if (fallbackTarget) g.accounts.id.renderButton(fallbackTarget, { theme: "outline", size: "large" });
+        }
+    });
+}
+
+export function refreshCredential(): Promise<string> {
+    if (!initialized) return Promise.reject(new Error("Google Identity Services not initialized"));
+    const g = gsi();
+    if (!g) return Promise.reject(new Error("Google Identity Services not loaded"));
+
+    return new Promise<string>((resolve, reject) => {
+        let settled = false;
+        const finish = (ok: boolean, value: string | Error) => {
+            if (settled) return;
+            settled = true;
+            unsubscribe();
+            clearTimeout(timer);
+            if (ok) resolve(value as string);
+            else reject(value as Error);
+        };
+        const unsubscribe = onCredential((token) => finish(true, token));
+        const timer = setTimeout(() => finish(false, new Error("Silent refresh timed out")), REFRESH_TIMEOUT_MS);
+
+        try {
+            g.accounts.id.prompt((notification) => {
+                if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                    finish(false, new Error("Silent refresh blocked by GIS"));
+                }
+            });
+        } catch (err) {
+            finish(false, err instanceof Error ? err : new Error(String(err)));
+        }
+    });
+}
+
+export function disableAutoSelect(): void {
+    const g = gsi();
+    if (g) g.accounts.id.disableAutoSelect();
+}

--- a/frontend/src/model.test.ts
+++ b/frontend/src/model.test.ts
@@ -1,0 +1,73 @@
+import { Model } from "./model";
+
+function fakeResponse(status: number, body: unknown = {}) {
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        json: async () => body,
+    } as unknown as Response;
+}
+
+describe("Model", () => {
+    const okStemma = { type: "Stemma", people: [], families: [] };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("retries once after 401 using a freshly refreshed token", async () => {
+        let calls = 0;
+        const refresh = jest.fn().mockResolvedValue("new-token");
+        const fetchMock = jest.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+            calls += 1;
+            const auth = (init.headers as Record<string, string>)["Authorization"];
+            if (calls === 1) {
+                expect(auth).toBe("Bearer old-token");
+                return fakeResponse(401);
+            }
+            expect(auth).toBe("Bearer new-token");
+            return fakeResponse(200, okStemma);
+        });
+        (globalThis as any).fetch = fetchMock;
+
+        const model = new Model("http://example", {
+            getToken: () => "old-token",
+            refresh,
+        });
+
+        const result = await model.getStemma("s");
+        expect(result).toEqual(okStemma);
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("throws sessionExpired when refresh fails", async () => {
+        const refresh = jest.fn().mockRejectedValue(new Error("nope"));
+        const fetchMock = jest.fn().mockResolvedValue(fakeResponse(401));
+        (globalThis as any).fetch = fetchMock;
+
+        const model = new Model("http://example", {
+            getToken: () => "old-token",
+            refresh,
+        });
+
+        await expect(model.getStemma("s")).rejects.toMatchObject({ key: "error.sessionExpired" });
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("throws sessionExpired when refreshed token still gets 401", async () => {
+        const refresh = jest.fn().mockResolvedValue("new-token");
+        const fetchMock = jest.fn().mockResolvedValue(fakeResponse(401));
+        (globalThis as any).fetch = fetchMock;
+
+        const model = new Model("http://example", {
+            getToken: () => "old-token",
+            refresh,
+        });
+
+        await expect(model.getStemma("s")).rejects.toMatchObject({ key: "error.sessionExpired" });
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/frontend/src/model.ts
+++ b/frontend/src/model.ts
@@ -106,16 +106,24 @@ export type StemmaResponse =
 
 //aux
 export type User = { id_token: string }
+export type TokenProvider = {
+    getToken: () => string;
+    refresh: () => Promise<string>;
+}
 
 export class Model {
     endpoint: string;
-    commonHeader;
+    private tokenProvider: TokenProvider;
 
-    constructor(endpoint: string, user: User) {
+    constructor(endpoint: string, tokenProvider: TokenProvider) {
         this.endpoint = endpoint
-        this.commonHeader = {
+        this.tokenProvider = tokenProvider
+    }
+
+    private headers(token: string) {
+        return {
             'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-            'Authorization': `Bearer ${user.id_token}`
+            'Authorization': `Bearer ${token}`,
         }
     }
 
@@ -200,15 +208,28 @@ export class Model {
     }
 
     private async send<R extends StemmaResponse>(request: Request, stemmaIndex: StemmaIndex | null): Promise<R> {
-        const response = await fetch(`${this.endpoint}/stemma`, {
+        const body = JSON.stringify(request)
+        let response = await fetch(`${this.endpoint}/stemma`, {
             method: 'POST',
-            headers: this.commonHeader,
-            body: JSON.stringify(request),
+            headers: this.headers(this.tokenProvider.getToken()),
+            body,
         })
-        if (response.status === 401) throw new LocalizedError("error.sessionExpired")
+        if (response.status === 401) {
+            try {
+                const refreshed = await this.tokenProvider.refresh()
+                response = await fetch(`${this.endpoint}/stemma`, {
+                    method: 'POST',
+                    headers: this.headers(refreshed),
+                    body,
+                })
+            } catch {
+                throw new LocalizedError("error.sessionExpired")
+            }
+            if (response.status === 401) throw new LocalizedError("error.sessionExpired")
+        }
         if (!response.ok) throw new LocalizedError("error.unexpectedResponse")
-        const body = (await response.json()) as StemmaResponse
-        return mapStemmaError(body, (id) => this.describePerson(id, stemmaIndex)) as R
+        const payload = (await response.json()) as StemmaResponse
+        return mapStemmaError(payload, (id) => this.describePerson(id, stemmaIndex)) as R
     }
 
     private describePerson(id: string, stemmaIndex?: StemmaIndex) {


### PR DESCRIPTION
## Summary
- Schedules a GIS `prompt()` ~5 min before the cached Google ID token expires so active users no longer get bounced hourly (closes #113).
- Routes API requests through a `TokenProvider`; on a 401 the request retries once with a freshly refreshed token, and a failed refresh clears the session and returns the user to the sign-in screen.
- Extracts GIS init/prompt into a shared `googleAuth.ts` module so the initial sign-in and the silent refresh share a single credential channel.
- E2E auto-login keeps working — `e2eMode` skips both GIS init and the refresh scheduler.

## Test plan
- [x] `npm test` (16 suites, 75 tests — adds 401-retry / refresh-failure cases for `Model` and lead-time cases for `credentialStorage.msUntilRefresh`).
- [x] `npm run check` (svelte-check clean).
- [ ] Manual: log in, leave a tab idle past the token expiry, confirm no Google sign-in screen reappears and the next request succeeds.
- [ ] Manual: revoke Google access mid-session, confirm the next refresh fails and the app falls back to the sign-in screen without a mid-action error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)