### PR TITLE
Decide signedIn synchronously from cached credential

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -47,7 +47,9 @@
     let aboutModal = $state<ReturnType<typeof AboutModal>>(null);
     let settingsModal = $state<ReturnType<typeof SettingsModal>>(null);
 
-    let signedIn = $state(false);
+    const e2eAutoLoginEnabled = typeof E2E_AUTO_LOGIN !== "undefined" && E2E_AUTO_LOGIN === "1";
+    const initialCached = e2eAutoLoginEnabled ? null : loadCredential();
+    let signedIn = $state(e2eAutoLoginEnabled || initialCached !== null);
 
     let ownedStemmas = $state<StemmaDescription[]>(null);
     let currentStemmaId = $state<string>(null);
@@ -158,7 +160,6 @@
     }
 
     onMount(() => {
-        const e2eAutoLoginEnabled = typeof E2E_AUTO_LOGIN !== "undefined" && E2E_AUTO_LOGIN === "1";
         if (e2eAutoLoginEnabled) {
             e2eMode = true;
             handleSignIn({ id_token: "e2e-user@stemma.local" } as User);
@@ -167,9 +168,8 @@
 
         initializeGoogleAuth(google_client_id).catch((err) => console.error("Google Identity init failed", err));
 
-        const cached = loadCredential();
-        if (cached) {
-            handleSignIn({ id_token: cached.token });
+        if (initialCached) {
+            handleSignIn({ id_token: initialCached.token });
         }
     });
 </script>

--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -28,7 +28,7 @@ type CredentialListener = (token: string) => void;
 
 const REFRESH_TIMEOUT_MS = 8_000;
 
-let initialized = false;
+let initPromise: Promise<void> | null = null;
 const listeners = new Set<CredentialListener>();
 
 function gsi(): Gsi | null {
@@ -44,17 +44,18 @@ async function awaitGsi(): Promise<Gsi> {
     return g;
 }
 
-export async function initializeGoogleAuth(clientId: string): Promise<void> {
-    if (initialized) return;
-    const g = await awaitGsi();
-    g.accounts.id.initialize({
-        client_id: clientId,
-        callback: (resp) => {
-            for (const l of Array.from(listeners)) l(resp.credential);
-        },
-        auto_select: true,
+export function initializeGoogleAuth(clientId: string): Promise<void> {
+    if (initPromise) return initPromise;
+    initPromise = awaitGsi().then((g) => {
+        g.accounts.id.initialize({
+            client_id: clientId,
+            callback: (resp) => {
+                for (const l of Array.from(listeners)) l(resp.credential);
+            },
+            auto_select: true,
+        });
     });
-    initialized = true;
+    return initPromise;
 }
 
 export function onCredential(listener: CredentialListener): () => void {
@@ -71,10 +72,11 @@ export async function promptInitialSignIn(fallbackTarget: HTMLElement | null): P
     });
 }
 
-export function refreshCredential(): Promise<string> {
-    if (!initialized) return Promise.reject(new Error("Google Identity Services not initialized"));
+export async function refreshCredential(): Promise<string> {
+    if (!initPromise) throw new Error("Google Identity Services not initialized");
+    await initPromise;
     const g = gsi();
-    if (!g) return Promise.reject(new Error("Google Identity Services not loaded"));
+    if (!g) throw new Error("Google Identity Services not loaded");
 
     return new Promise<string>((resolve, reject) => {
         let settled = false;


### PR DESCRIPTION
## Summary
- Followup to #114. Svelte mounts children before parents, so on reload with a valid cached token the `Authenticate` child briefly mounted, fired Google One Tap, then was unmounted once the parent's `onMount` flipped `signedIn=true` — the result was the stemma chart visible with a Google One Tap dialog on top of it.
- Move the cache check to top-level script in `App.svelte` so `signedIn` is true before the first render when a valid token is cached. Authenticate never mounts on a cache hit, no spurious One Tap.
- Make `googleAuth` init reentrant via an internal promise and have `refreshCredential` await it, so a near-expiry cached token cannot race the refresh timer against initialization.

## Test plan
- [x] `npm test` (75 tests).
- [x] `npm run check` (clean).
- [ ] Manual: reload with a valid cached token, verify no Google One Tap prompt and the chart loads directly.
- [ ] Manual: reload with a cached token within 5 minutes of expiry, verify silent refresh succeeds without a sign-in screen flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)