### PR TITLE
Force regional S3 host on presigned upload URLs

### DIFF
--- a/backend_py/src/stemma/apps/bootstrap.py
+++ b/backend_py/src/stemma/apps/bootstrap.py
@@ -56,7 +56,7 @@ def photo_store_from_env():
 def _s3_signature_config():
     from botocore.config import Config
 
-    return Config(signature_version="s3v4")
+    return Config(signature_version="s3v4", s3={"addressing_style": "virtual"})
 
 
 def _ensure_table(resource, table_name: str) -> None:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -229,7 +229,7 @@
         <div>
             <div class="alert alert-danger alert-dismissible fade mt-2 mx-2 show">
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label={$t("common.close")}></button>
-                <div><strong>{$t('app.oops')} </strong>{errorMessage(error)}</div>
+                <div><strong>{$t('app.oops')}</strong> {errorMessage(error)}</div>
             </div>
         </div>
     {/if}


### PR DESCRIPTION
## Summary
- Presigned PUT URLs were signed against the legacy global `<bucket>.s3.amazonaws.com` host. For an eu-central-1 bucket, S3 answers with a 301 redirect to the regional host without CORS headers, so the browser preflight blocked the upload even though the bucket's own CORS rules are correct. Pinning the S3 addressing style to `virtual` makes boto3 emit the regional virtual-hosted host (`<bucket>.s3.eu-central-1.amazonaws.com`) directly.
- Minor: move the trailing space outside the `<strong>` tag in the inline error banner so the rendered message reads "Oops! Failed to fetch" instead of "Oops!Failed to fetch" (Svelte was stripping whitespace immediately inside the closing tag).

## Test plan
- [x] `uv run pytest` (70/70 pass)
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `npm run check` (svelte-check)
- [ ] After deploy: open a person, upload a photo from the production frontend, verify the PUT succeeds (no CORS error) and the photo renders back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)