### PR TITLE
Defer photo upload/removal until person Save

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -199,9 +199,7 @@
     <PersonSelectionModal
         bind:this={personSelectionModal}
         onpersonRemoved={(id) => controller.removePerson(id)}
-        onpersonUpdated={(p) => controller.updatePerson(p.id, p.description, p.pin)}
-        onphotoUploaded={(p) => controller.uploadPersonPhoto(p.id, p.file)}
-        onphotoRemoved={(id) => controller.removePersonPhoto(id)}
+        onpersonUpdated={(p) => controller.savePerson(p.id, p.description, p.pin, p.photoUpload, p.photoRemove)}
     />
 
     <InviteModal bind:this={inviteModal} {stemma} {stemmaIndex} oninvite={(p) => controller.createInvitationToken(p.personId, p.email)} />

--- a/frontend/src/appController.test.ts
+++ b/frontend/src/appController.test.ts
@@ -1,9 +1,15 @@
 import { get } from "svelte/store";
 import { AppController } from "./appController";
-import type { Stemma } from "./model";
+import type { CreateNewPerson, Stemma } from "./model";
+import { StemmaIndex } from "./stemmaIndex";
+import { PinnedPeopleStorage } from "./pinnedPeopleStorage";
 
 function drainPromises() {
     return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function drainAll() {
+    for (let i = 0; i < 6; i++) await drainPromises();
 }
 
 describe("AppController", () => {
@@ -135,5 +141,195 @@ describe("AppController", () => {
         expect(get(controller.currentStemmaId)).toBe("b");
         expect(get(controller.stemma)).toEqual(stemmaB);
         expect(localStorage.getItem("stemma_last_stemma_id")).toBe("b");
+    });
+
+    describe("savePerson", () => {
+        const stemmaId = "s1";
+        const personId = "p1";
+        const baseStemma: Stemma = {
+            type: "Stemma",
+            people: [
+                {
+                    type: "PersonDescription",
+                    id: personId,
+                    name: "Bob",
+                    birthDate: null,
+                    deathDate: null,
+                    bio: "",
+                    readOnly: false,
+                } as any,
+            ],
+            families: [],
+        };
+        const updatedStemma: Stemma = {
+            ...baseStemma,
+            people: [{ ...baseStemma.people[0], name: "Bobby" } as any],
+        };
+        const sameDescr: CreateNewPerson = {
+            type: "CreateNewPerson",
+            name: "Bob",
+            birthDate: null,
+            deathDate: null,
+            bio: "",
+        } as any;
+        const changedDescr: CreateNewPerson = {
+            ...sameDescr,
+            name: "Bobby",
+        };
+
+        function makeController(model: any) {
+            const c = new AppController("http://example", () => model as any);
+            (c as any).model = model;
+            c.currentStemmaId.set(stemmaId);
+            c.stemmaIndex.set(new StemmaIndex(baseStemma));
+            c.pinnedStorage.set(new PinnedPeopleStorage(stemmaId));
+            return c;
+        }
+
+        test("no-op when nothing changed", async () => {
+            const model = {
+                requestPhotoUploadUrl: jest.fn(),
+                uploadPhotoToPresignedUrl: jest.fn(),
+                setPersonPhoto: jest.fn(),
+                updatePerson: jest.fn(),
+            };
+            const c = makeController(model);
+            c.savePerson(personId, sameDescr, false, null, false);
+            await drainAll();
+            expect(model.requestPhotoUploadUrl).not.toHaveBeenCalled();
+            expect(model.setPersonPhoto).not.toHaveBeenCalled();
+            expect(model.updatePerson).not.toHaveBeenCalled();
+        });
+
+        test("only fields changed: just updatePerson", async () => {
+            const model = {
+                requestPhotoUploadUrl: jest.fn(),
+                uploadPhotoToPresignedUrl: jest.fn(),
+                setPersonPhoto: jest.fn(),
+                updatePerson: jest.fn().mockResolvedValue(updatedStemma),
+            };
+            const c = makeController(model);
+            c.savePerson(personId, changedDescr, false, null, false);
+            await drainAll();
+            expect(model.updatePerson).toHaveBeenCalledTimes(1);
+            expect(model.setPersonPhoto).not.toHaveBeenCalled();
+            expect(model.requestPhotoUploadUrl).not.toHaveBeenCalled();
+        });
+
+        test("only photo upload (no field change): upload chain, no updatePerson", async () => {
+            const model = {
+                requestPhotoUploadUrl: jest.fn().mockResolvedValue({ uploadUrl: "u", photoKey: "k" }),
+                uploadPhotoToPresignedUrl: jest.fn().mockResolvedValue(undefined),
+                setPersonPhoto: jest.fn().mockResolvedValue(baseStemma),
+                updatePerson: jest.fn(),
+            };
+            const c = makeController(model);
+            const blob = new Blob([new Uint8Array([1])], { type: "image/jpeg" });
+            c.savePerson(personId, sameDescr, false, blob, false);
+            await drainAll();
+            expect(model.requestPhotoUploadUrl).toHaveBeenCalledWith(stemmaId, personId, "image/jpeg");
+            expect(model.uploadPhotoToPresignedUrl).toHaveBeenCalledWith("u", blob);
+            expect(model.setPersonPhoto).toHaveBeenCalledWith(stemmaId, personId, "k", expect.anything());
+            expect(model.updatePerson).not.toHaveBeenCalled();
+        });
+
+        test("photo upload + fields: upload finishes before updatePerson", async () => {
+            const order: string[] = [];
+            const model = {
+                requestPhotoUploadUrl: jest.fn().mockImplementation(async () => {
+                    order.push("requestPhotoUploadUrl");
+                    return { uploadUrl: "u", photoKey: "k" };
+                }),
+                uploadPhotoToPresignedUrl: jest.fn().mockImplementation(async () => {
+                    order.push("uploadPhotoToPresignedUrl");
+                }),
+                setPersonPhoto: jest.fn().mockImplementation(async () => {
+                    order.push("setPersonPhoto");
+                    return baseStemma;
+                }),
+                updatePerson: jest.fn().mockImplementation(async () => {
+                    order.push("updatePerson");
+                    return updatedStemma;
+                }),
+            };
+            const c = makeController(model);
+            const blob = new Blob([new Uint8Array([1])], { type: "image/jpeg" });
+            c.savePerson(personId, changedDescr, false, blob, false);
+            await drainAll();
+            expect(order).toEqual([
+                "requestPhotoUploadUrl",
+                "uploadPhotoToPresignedUrl",
+                "setPersonPhoto",
+                "updatePerson",
+            ]);
+        });
+
+        test("photo remove + fields: setPersonPhoto(null) before updatePerson", async () => {
+            const order: string[] = [];
+            const model = {
+                requestPhotoUploadUrl: jest.fn(),
+                uploadPhotoToPresignedUrl: jest.fn(),
+                setPersonPhoto: jest.fn().mockImplementation(async (_sid: string, _pid: string, key: string | null) => {
+                    order.push(`setPersonPhoto:${key}`);
+                    return baseStemma;
+                }),
+                updatePerson: jest.fn().mockImplementation(async () => {
+                    order.push("updatePerson");
+                    return updatedStemma;
+                }),
+            };
+            const c = makeController(model);
+            c.savePerson(personId, changedDescr, false, null, true);
+            await drainAll();
+            expect(model.requestPhotoUploadUrl).not.toHaveBeenCalled();
+            expect(order).toEqual(["setPersonPhoto:null", "updatePerson"]);
+        });
+
+        test("only photo remove: setPersonPhoto(null), no updatePerson", async () => {
+            const model = {
+                requestPhotoUploadUrl: jest.fn(),
+                uploadPhotoToPresignedUrl: jest.fn(),
+                setPersonPhoto: jest.fn().mockResolvedValue(baseStemma),
+                updatePerson: jest.fn(),
+            };
+            const c = makeController(model);
+            c.savePerson(personId, sameDescr, false, null, true);
+            await drainAll();
+            expect(model.setPersonPhoto).toHaveBeenCalledWith(stemmaId, personId, null, expect.anything());
+            expect(model.updatePerson).not.toHaveBeenCalled();
+        });
+
+        test("photoUpload wins over photoRemove when both flags are set", async () => {
+            const model = {
+                requestPhotoUploadUrl: jest.fn().mockResolvedValue({ uploadUrl: "u", photoKey: "k" }),
+                uploadPhotoToPresignedUrl: jest.fn().mockResolvedValue(undefined),
+                setPersonPhoto: jest.fn().mockResolvedValue(baseStemma),
+                updatePerson: jest.fn(),
+            };
+            const c = makeController(model);
+            const blob = new Blob([new Uint8Array([1])], { type: "image/jpeg" });
+            c.savePerson(personId, sameDescr, false, blob, true);
+            await drainAll();
+            expect(model.setPersonPhoto).toHaveBeenCalledWith(stemmaId, personId, "k", expect.anything());
+            expect(model.setPersonPhoto).not.toHaveBeenCalledWith(stemmaId, personId, null, expect.anything());
+        });
+
+        test("updatePerson is skipped when photo step fails", async () => {
+            const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+            const model = {
+                requestPhotoUploadUrl: jest.fn().mockResolvedValue({ uploadUrl: "u", photoKey: "k" }),
+                uploadPhotoToPresignedUrl: jest.fn().mockRejectedValue(new Error("boom")),
+                setPersonPhoto: jest.fn(),
+                updatePerson: jest.fn(),
+            };
+            const c = makeController(model);
+            const blob = new Blob([new Uint8Array([1])], { type: "image/jpeg" });
+            c.savePerson(personId, changedDescr, false, blob, false);
+            await drainAll();
+            expect(model.setPersonPhoto).not.toHaveBeenCalled();
+            expect(model.updatePerson).not.toHaveBeenCalled();
+            expect(get(c.err)).toBeInstanceOf(Error);
+            errSpy.mockRestore();
+        });
     });
 });

--- a/frontend/src/appController.ts
+++ b/frontend/src/appController.ts
@@ -192,48 +192,58 @@ export class AppController {
         this.manipulateStemma((model, stemmaId) => model.removeFamily(stemmaId, familyId))
     }
 
-    updatePerson(personId: string, descr: CreateNewPerson, pin: boolean) {
-        let si = get(this.stemmaIndex)
+    savePerson(personId: string, descr: CreateNewPerson, pin: boolean, photoUpload: Blob | null, photoRemove: boolean) {
+        const stemmaId = get(this.currentStemmaId)
+        const si = get(this.stemmaIndex)
         this.refreshVisual(si, personId, pin);
 
-        let originalPerson = si.person(personId);
-        if (
-            originalPerson.birthDate != descr.birthDate ||
-            originalPerson.deathDate != descr.deathDate ||
-            originalPerson.name != descr.name ||
-            originalPerson.bio != descr.bio
-        ) {
-            this.manipulateStemma((model, stemmaId) => model.updatePerson(stemmaId, personId, descr, si))
-        }
-    }
+        const original = si.person(personId);
+        const fieldsChanged =
+            original.birthDate != descr.birthDate ||
+            original.deathDate != descr.deathDate ||
+            original.name != descr.name ||
+            original.bio != descr.bio;
 
-    removePerson(personId: string) {
-        this.manipulateStemma((model, stemmaId) => model.removePerson(stemmaId, personId, get(this.stemmaIndex)))
-    }
+        if (!photoUpload && !photoRemove && !fieldsChanged) return;
 
-    uploadPersonPhoto(personId: string, file: Blob) {
-        let stemmaId = get(this.currentStemmaId)
         this.isWorking.set(true)
         this.err.set(null)
-        this.model
-            .requestPhotoUploadUrl(stemmaId, personId, file.type)
-            .then((urlInfo) =>
-                this.model.uploadPhotoToPresignedUrl(urlInfo.uploadUrl, file).then(() => urlInfo.photoKey),
-            )
-            .then((photoKey) => this.model.setPersonPhoto(stemmaId, personId, photoKey, get(this.stemmaIndex)))
-            .then((result) => {
-                this.refreshIndexes(result, stemmaId)
-                this.stemma.set(result)
+
+        const photoStep: Promise<void> = photoUpload
+            ? this.model
+                  .requestPhotoUploadUrl(stemmaId, personId, photoUpload.type)
+                  .then((urlInfo) =>
+                      this.model.uploadPhotoToPresignedUrl(urlInfo.uploadUrl, photoUpload).then(() => urlInfo.photoKey),
+                  )
+                  .then((photoKey) => this.model.setPersonPhoto(stemmaId, personId, photoKey, get(this.stemmaIndex)))
+                  .then((result) => {
+                      this.refreshIndexes(result, stemmaId)
+                      this.stemma.set(result)
+                  })
+            : photoRemove
+              ? this.model.setPersonPhoto(stemmaId, personId, null, get(this.stemmaIndex)).then((result) => {
+                    this.refreshIndexes(result, stemmaId)
+                    this.stemma.set(result)
+                })
+              : Promise.resolve()
+
+        photoStep
+            .then(() => {
+                if (!fieldsChanged) return
+                return this.model.updatePerson(stemmaId, personId, descr, get(this.stemmaIndex)).then((result) => {
+                    this.refreshIndexes(result, stemmaId)
+                    this.stemma.set(result)
+                })
             })
             .catch((err) => {
                 this.err.set(err)
-                console.error('Err when uploading person photo: ', err.stack)
+                console.error('Err when saving person: ', err.stack)
             })
             .finally(() => this.isWorking.set(false))
     }
 
-    removePersonPhoto(personId: string) {
-        this.manipulateStemma((model, stemmaId) => model.setPersonPhoto(stemmaId, personId, null, get(this.stemmaIndex)))
+    removePerson(personId: string) {
+        this.manipulateStemma((model, stemmaId) => model.removePerson(stemmaId, personId, get(this.stemmaIndex)))
     }
 
     createInvitationToken(personId: string, email: string) {

--- a/frontend/src/components/person_details_modal/PersonDetailsModal.svelte
+++ b/frontend/src/components/person_details_modal/PersonDetailsModal.svelte
@@ -6,16 +6,13 @@
         id: string;
         pin: boolean;
         description: CreateNewPerson;
+        photoUpload: Blob | null;
+        photoRemove: boolean;
     };
 
     export type ShowPerson = {
         pin: boolean;
         description: PersonDescription;
-    };
-
-    export type UploadPersonPhoto = {
-        id: string;
-        file: Blob;
     };
 
     const CROP_OUTPUT_SIZE = 512;
@@ -52,11 +49,9 @@
     type Props = {
         onpersonUpdated?: (payload: UpdatePerson) => void;
         onpersonRemoved?: (id: string) => void;
-        onphotoUploaded?: (payload: UploadPersonPhoto) => void;
-        onphotoRemoved?: (id: string) => void;
     };
 
-    let { onpersonUpdated, onpersonRemoved, onphotoUploaded, onphotoRemoved }: Props = $props();
+    let { onpersonUpdated, onpersonRemoved }: Props = $props();
 
     let modalEl = $state<HTMLElement>(null);
     let birthInputEl = $state<HTMLInputElement>(null);
@@ -72,6 +67,10 @@
     let readOnly = $state<boolean>(false);
     let photoUrl = $state<string | null>(null);
     let photoErrString = $state<string | null>(null);
+    let originalPhotoUrl: string | null = null;
+    let pendingPhotoBlob = $state<Blob | null>(null);
+    let pendingPhotoPreviewUrl = $state<string | null>(null);
+    let pendingPhotoRemove = $state<boolean>(false);
 
     let cropImageEl = $state<HTMLImageElement>(null);
     let cropContainerEl = $state<HTMLElement>(null);
@@ -100,6 +99,8 @@
                 bio,
             },
             pin: pinned,
+            photoUpload: pendingPhotoBlob,
+            photoRemove: pendingPhotoRemove,
         });
 
         bootstrap.Modal.getOrCreateInstance(modalEl).hide();
@@ -133,15 +134,24 @@
         bio = p.description.bio;
         pinned = p.pin;
         readOnly = p.description.readOnly;
-        photoUrl = p.description.photoUrl ?? null;
+        originalPhotoUrl = p.description.photoUrl ?? null;
+        photoUrl = originalPhotoUrl;
         photoErrString = null;
         if (photoFileInputEl) photoFileInputEl.value = "";
         resetCropState();
+        resetPendingPhoto();
 
         birthDateErrString = null;
         deathDateErrString = null;
 
         bootstrap.Modal.getOrCreateInstance(modalEl).show();
+    }
+
+    function resetPendingPhoto() {
+        if (pendingPhotoPreviewUrl) URL.revokeObjectURL(pendingPhotoPreviewUrl);
+        pendingPhotoPreviewUrl = null;
+        pendingPhotoBlob = null;
+        pendingPhotoRemove = false;
     }
 
     function resetCropState() {
@@ -275,9 +285,12 @@
                     photoErrString = $t("person.photoUploadFailed");
                     return;
                 }
-                onphotoUploaded?.({ id, file: blob });
+                if (pendingPhotoPreviewUrl) URL.revokeObjectURL(pendingPhotoPreviewUrl);
+                pendingPhotoBlob = blob;
+                pendingPhotoPreviewUrl = URL.createObjectURL(blob);
+                pendingPhotoRemove = false;
+                photoUrl = pendingPhotoPreviewUrl;
                 resetCropState();
-                bootstrap.Modal.getOrCreateInstance(modalEl).hide();
             },
             CROP_OUTPUT_MIME,
             CROP_OUTPUT_QUALITY,
@@ -286,8 +299,17 @@
 
     function removePhoto() {
         photoErrString = null;
-        onphotoRemoved?.(id);
-        bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+        if (pendingPhotoBlob) {
+            if (pendingPhotoPreviewUrl) URL.revokeObjectURL(pendingPhotoPreviewUrl);
+            pendingPhotoPreviewUrl = null;
+            pendingPhotoBlob = null;
+            photoUrl = originalPhotoUrl;
+            return;
+        }
+        if (originalPhotoUrl) {
+            pendingPhotoRemove = true;
+            photoUrl = null;
+        }
     }
 
     function parseMaskedDateStr(str: string) {


### PR DESCRIPTION
## Summary
- Cropping or removing the photo no longer triggers an immediate upload/clear-then-close. The cropper Save and the photo Remove button only stage the change locally; the form Save commits both the photo I/O and the field update in one go, so the user no longer has to reopen the same person twice.
- New `AppController.savePerson` sequences photo upload (or removal) before `updatePerson`, eliminating the race where two concurrent stemma writes overwrote each other.
- The modal's two photo callbacks were collapsed into `photoUpload` / `photoRemove` fields on the existing `UpdatePerson` payload.

## Test plan
- [x] `npm run check` (svelte-check) clean
- [x] `npm test` (jest) — 83/83 pass; 8 new tests cover all savePerson branches (no-op, fields-only, photo-only, photo+fields ordering, photo-remove+fields, photo-remove-only, upload-wins-over-remove, error short-circuit)
- [x] `npx playwright test person_modal_screenshot.spec.ts` still green
- [ ] Manual smoke: upload + crop + edit name in one open → one Save → both land

🤖 Generated with [Claude Code](https://claude.com/claude-code)