### PR TITLE
Stop deleting shared photo objects from S3

### DIFF
--- a/backend_py/src/stemma/apis/request_handler.py
+++ b/backend_py/src/stemma/apis/request_handler.py
@@ -116,8 +116,7 @@ class RequestHandler:
         return TokenAccepted(stemmas=owned, last_stemma=last_stemma)
 
     def _delete_stemma(self, user: User, request: DeleteStemmaRequest) -> OwnedStemmas:
-        photo_keys = self._storage.remove_stemma(user.user_id, request.stemma_id)
-        self._delete_photos(photo_keys)
+        self._storage.remove_stemma(user.user_id, request.stemma_id)
         owned = self._storage.list_owned_stemmas(user.user_id)
         return OwnedStemmas(stemmas=owned, first_stemma=None)
 
@@ -129,10 +128,7 @@ class RequestHandler:
         return self._storage.stemma(user.user_id, request.stemma_id)
 
     def _delete_person(self, user: User, request: DeletePersonRequest) -> Stemma:
-        photo_keys = self._storage.remove_person(
-            user.user_id, request.stemma_id, request.person_id
-        )
-        self._delete_photos(photo_keys)
+        self._storage.remove_person(user.user_id, request.stemma_id, request.person_id)
         return self._storage.stemma(user.user_id, request.stemma_id)
 
     def _update_person(self, user: User, request: UpdatePersonRequest) -> Stemma:
@@ -188,17 +184,10 @@ class RequestHandler:
         )
 
     def _set_person_photo(self, user: User, request: SetPersonPhotoRequest) -> Stemma:
-        previous = self._storage.set_person_photo(
+        self._storage.set_person_photo(
             user.user_id, request.stemma_id, request.person_id, request.photo_key
         )
-        if previous is not None and previous != request.photo_key:
-            self._delete_photos([previous])
         return self._storage.stemma(user.user_id, request.stemma_id)
-
-    def _delete_photos(self, keys: list[str]) -> None:
-        if not keys or self._photo_store is None:
-            return
-        self._photo_store.delete(keys)
 
 
 def _order_with_default_first(

--- a/backend_py/tests/test_person_photo.py
+++ b/backend_py/tests/test_person_photo.py
@@ -144,7 +144,7 @@ def test_handler_request_photo_upload_url_returns_signed_url(
     assert response.upload_url.startswith("https://")
 
 
-def test_handler_set_person_photo_replaces_previous_and_deletes_from_s3(
+def test_handler_set_person_photo_leaves_previous_object_in_s3(
     storage: StorageService, users: UserService, photo_store: S3PhotoService, s3_client
 ) -> None:
     _, sid, pid = _seed_person(storage)
@@ -161,11 +161,11 @@ def test_handler_set_person_photo_replaces_previous_and_deletes_from_s3(
         user, SetPersonPhotoRequest(stemma_id=sid, person_id=pid, photo_key=new_key)
     )
     assert isinstance(response, Stemma)
-    assert not _object_exists(s3_client, old_key)
+    assert _object_exists(s3_client, old_key)
     assert _object_exists(s3_client, new_key)
 
 
-def test_handler_delete_person_cascades_photo_delete(
+def test_handler_delete_person_leaves_photo_in_s3(
     storage: StorageService, users: UserService, photo_store: S3PhotoService, s3_client
 ) -> None:
     _, sid, pid = _seed_person(storage)
@@ -176,10 +176,10 @@ def test_handler_delete_person_cascades_photo_delete(
     storage.set_person_photo(user.user_id, sid, pid, key)
 
     handler.handle(user, DeletePersonRequest(stemma_id=sid, person_id=pid))
-    assert not _object_exists(s3_client, key)
+    assert _object_exists(s3_client, key)
 
 
-def test_handler_delete_stemma_cascades_photo_delete(
+def test_handler_delete_stemma_leaves_photo_in_s3(
     storage: StorageService, users: UserService, photo_store: S3PhotoService, s3_client
 ) -> None:
     _, sid, pid = _seed_person(storage)
@@ -190,7 +190,32 @@ def test_handler_delete_stemma_cascades_photo_delete(
     storage.set_person_photo(user.user_id, sid, pid, key)
 
     handler.handle(user, DeleteStemmaRequest(stemma_id=sid))
-    assert not _object_exists(s3_client, key)
+    assert _object_exists(s3_client, key)
+
+
+def test_handler_clone_stemma_shares_photo_keys_and_survives_replace(
+    storage: StorageService, users: UserService, photo_store: S3PhotoService, s3_client
+) -> None:
+    _, sid, pid = _seed_person(storage)
+    handler = RequestHandler(storage, users, photo_store=photo_store)
+    user = storage.get_or_create_user("user@test.com")
+    original_key = photo_key(sid, pid)
+    _put_object(s3_client, original_key)
+    storage.set_person_photo(user.user_id, sid, pid, original_key)
+
+    cloned = storage.clone_stemma(user.user_id, sid, "clone")
+    cloned_person = next(p for p in cloned.people if p.photo_url is not None)
+    assert cloned_person.photo_url is not None
+    assert original_key in cloned_person.photo_url
+
+    replacement_key = "replacement_key"
+    _put_object(s3_client, replacement_key)
+    handler.handle(
+        user,
+        SetPersonPhotoRequest(stemma_id=sid, person_id=pid, photo_key=replacement_key),
+    )
+    assert _object_exists(s3_client, original_key)
+    assert _object_exists(s3_client, replacement_key)
 
 
 def test_set_person_photo_missing_person_raises(storage: StorageService) -> None:


### PR DESCRIPTION
## Summary
- Cloning a stemma copies person rows verbatim, so cloned persons point at the original's S3 key. The previous handler logic deleted the S3 object whenever the DB pointer changed (replace photo, remove photo, remove person, remove stemma), which broke the photo for the original or the clone depending on who acted first.
- The handler now leaves the S3 object alone in all of those paths and only clears the DB pointer. Any remaining references continue to load the photo.
- Trade-off: orphan S3 objects can accumulate when *no* reference is left. This is acceptable at current scale; cleanup can be done out of band (diff referenced `photo_key`s in DynamoDB against the bucket listing).

## Test plan
- [x] `uv run pytest tests/test_person_photo.py` — 16/16 (existing cascade tests inverted, new clone-share test added)
- [x] `uv run pytest` — 71/71
- [x] `uv run ruff check`, `uv run pyright`
- [ ] Manual smoke after deploy: clone a stemma with a photo, replace photo on the original, confirm the clone still shows the original photo

🤖 Generated with [Claude Code](https://claude.com/claude-code)