### PR TITLE
Warm Lambda during sign-in via public /warmup route

### DIFF
--- a/backend_py/src/stemma/apps/lambda_main.py
+++ b/backend_py/src/stemma/apps/lambda_main.py
@@ -52,6 +52,8 @@ def _build() -> tuple[RequestHandler, UserService]:
 
 def lambda_handler(event: dict, context: object) -> str:
     handler, users = _build()
+    if event.get("rawPath", "").endswith("/warmup"):
+        return json.dumps({"ok": True})
     email = event["requestContext"]["authorizer"]["jwt"]["claims"]["email"]
     body = event.get("body") or ""
     if event.get("isBase64Encoded"):

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -170,6 +170,8 @@
 
         if (initialCached) {
             handleSignIn({ id_token: initialCached.token });
+        } else {
+            fetch(`${stemma_backend_url}/warmup`).catch(() => {});
         }
     });
 </script>

--- a/template.yaml
+++ b/template.yaml
@@ -169,6 +169,10 @@ Resources:
         AllowMethods:
           - '*'
         MaxAge: 600
+      RouteSettings:
+        "GET /warmup":
+          ThrottlingBurstLimit: 5
+          ThrottlingRateLimit: 1
       Domain:
         DomainName: !Sub "${apiAlias}"
         CertificateArn: !Sub "${certificateArnEurope}"
@@ -244,6 +248,14 @@ Resources:
             ApiId: !Ref MyApi
             Path: /stemma
             Method: post
+        WarmupEvent:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref MyApi
+            Path: /warmup
+            Method: get
+            Auth:
+              Authorizer: NONE
       Policies:
         - S3FullAccessPolicy:
             BucketName: stemma-app-backend-assets


### PR DESCRIPTION
## Summary
- Adds an unauthenticated `GET /warmup` route on the HTTP API. Lambda runs `_build()` and returns `{"ok": true}`.
- Frontend fires the warmup fetch from `App.svelte` `onMount` only when no cached credential exists, so cold start overlaps with the Google sign-in gesture.
- API Gateway route-level throttle (1 req/s, burst 5) caps blast radius from drive-by traffic; Lambda is not invoked past the burst.

## Test plan
- [ ] `uv run pytest` passes (verified locally: 71 passed)
- [ ] `npm run check` passes (verified locally: 0 errors)
- [ ] After deploy: `curl https://api.stemma.link/warmup` returns 200 `{"ok": true}` without auth
- [ ] After deploy: `curl -X POST https://api.stemma.link/stemma` still returns 401 (auth still enforced on `/stemma`)
- [ ] After deploy: fresh-incognito visit shows shorter time-to-first-stemma vs. master
- [ ] After deploy: cached-credential reload skips warmup fetch (devtools network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)