### PR TITLE
Defer bundle.js so mount waits for #app

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,7 +16,7 @@
 
 	<script>window.__gsiReady = new Promise(function (r) { window.__gsiResolve = r; });</script>
 	<script async src="https://accounts.google.com/gsi/client" onload="window.__gsiResolve()"></script>
-	<script async src='build/bundle.js'></script>
+	<script defer src='build/bundle.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- `bundle.js` is loaded with `async` from `<head>`. Since #90 hashed bundles are served `max-age=31536000, immutable`, so on reload the bundle executes from cache before `<div id="app">` is parsed.
- `main.ts` then throws `App mount target "#app" was not found` and the page stays blank.
- Switching to `defer` keeps the parallel download but postpones execution until the DOM is parsed, fixing the race.

## Test plan
- [ ] Deploy and reload the app several times in a clean profile — page renders, no console error.
- [ ] First (cold) visit still works.
- [ ] Network tab still shows `bundle.js` downloading in parallel with the GSI script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)