### PR TITLE
Add AWS Backup plan with daily DynamoDB snapshots

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -235,6 +235,45 @@ Resources:
             ProjectionType: ALL
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
+  BackupVault:
+    Type: AWS::Backup::BackupVault
+    Properties:
+      BackupVaultName: !Sub "stemma-${AWS::StackName}-vault"
+  BackupRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: backup.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup
+        - arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores
+  BackupPlan:
+    Type: AWS::Backup::BackupPlan
+    Properties:
+      BackupPlan:
+        BackupPlanName: !Sub "stemma-${AWS::StackName}-plan"
+        BackupPlanRule:
+          - RuleName: DailyBackup
+            TargetBackupVault: !Ref BackupVault
+            ScheduleExpression: "cron(0 3 ? * * *)"
+            StartWindowMinutes: 60
+            CompletionWindowMinutes: 180
+            Lifecycle:
+              DeleteAfterDays: 35
+  BackupSelection:
+    Type: AWS::Backup::BackupSelection
+    Properties:
+      BackupPlanId: !Ref BackupPlan
+      BackupSelection:
+        SelectionName: StemmaTableSelection
+        IamRoleArn: !GetAtt BackupRole.Arn
+        Resources:
+          - !GetAtt StemmaTable.Arn
   StemmaFunction:
     Type: AWS::Serverless::Function
     Metadata:


### PR DESCRIPTION
## Summary
- Adds an `AWS::Backup::BackupVault`, IAM role, plan, and selection targeting `StemmaTable`.
- Daily snapshot at 03:00 UTC, 35-day retention.
- Complements existing PITR by providing independent restorable backups that survive table deletion and the PITR window.

Closes #123.

## Test plan
- [ ] `sam build` succeeds.
- [ ] `sam deploy` provisions vault, role, plan, and selection without drift.
- [ ] Manual `AWS Backup` console check: first on-demand run from the plan completes for `StemmaTable`.
- [ ] Verify a recovery point appears in the vault after the first scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)