### PR TITLE
Resolve overlapping graph labels via d3fc-label-layout

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@imask/svelte": "^6.6.3",
+        "d3fc-label-layout": "^5.1.0",
         "fuzzysort": "^3.1.0",
         "jwt-decode": "^4.0.0",
         "lodash.clone": "^4.5.0",
@@ -3640,6 +3641,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -3960,6 +3967,153 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3fc-data-join": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3fc-data-join/-/d3fc-data-join-2.0.0.tgz",
+      "integrity": "sha512-iUWQSn6Qa708fs9wqeqbZIhpffDSIFXDjAACd31zlrzk2eoWnMvkhcB8SIYowhwYhwvcV9ugAhdOifwSRAfcXw==",
+      "deprecated": "This package is deprecated, please use @d3fc/d3fc-data-join instead.",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "^1.0.0",
+        "d3-transition": "^1.0.0"
+      }
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-ease": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+      "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-data-join/node_modules/d3-transition": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
+      "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "1"
+      }
+    },
+    "node_modules/d3fc-label-layout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/d3fc-label-layout/-/d3fc-label-layout-5.1.0.tgz",
+      "integrity": "sha512-A5lGjawFWxq8+HPjlxHp3vSzsUz2WHaCbz0eDMArGloAAeVpBevMaNAXtyEvEYo88IJWNX4SnAW6JzhzHs5edA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^1.0.0",
+        "d3-scale": "^1.0.6",
+        "d3-selection": "^1.0.0",
+        "d3fc-data-join": "^2.0.0",
+        "d3fc-rebind": "^4.0.0"
+      }
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-scale": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3fc-label-layout/node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/d3fc-rebind": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/d3fc-rebind/-/d3fc-rebind-4.1.1.tgz",
+      "integrity": "sha512-o6zVxefVvY3jTKfCjsisjhPa9Te9d/D0la3F1rhQfUFE2IIdsgjkYBVAarTHc+O7KTIkzt0pI8lw3wbCsrel2w==",
+      "deprecated": "This package is deprecated, please use @d3fc/d3fc-rebind instead.",
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -10247,6 +10401,11 @@
         "d3-path": "1 - 3"
       }
     },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
     "d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -10473,6 +10632,137 @@
         "d3-selection": "2 - 3",
         "d3-transition": "2 - 3"
       }
+    },
+    "d3fc-data-join": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3fc-data-join/-/d3fc-data-join-2.0.0.tgz",
+      "integrity": "sha512-iUWQSn6Qa708fs9wqeqbZIhpffDSIFXDjAACd31zlrzk2eoWnMvkhcB8SIYowhwYhwvcV9ugAhdOifwSRAfcXw==",
+      "requires": {
+        "d3-selection": "^1.0.0",
+        "d3-transition": "^1.0.0"
+      },
+      "dependencies": {
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-dispatch": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+          "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+        },
+        "d3-ease": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+          "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-selection": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+          "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
+        },
+        "d3-timer": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+          "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
+        },
+        "d3-transition": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
+          "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
+          "requires": {
+            "d3-color": "1",
+            "d3-dispatch": "1",
+            "d3-ease": "1",
+            "d3-interpolate": "1",
+            "d3-selection": "^1.1.0",
+            "d3-timer": "1"
+          }
+        }
+      }
+    },
+    "d3fc-label-layout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/d3fc-label-layout/-/d3fc-label-layout-5.1.0.tgz",
+      "integrity": "sha512-A5lGjawFWxq8+HPjlxHp3vSzsUz2WHaCbz0eDMArGloAAeVpBevMaNAXtyEvEYo88IJWNX4SnAW6JzhzHs5edA==",
+      "requires": {
+        "d3-array": "^1.0.0",
+        "d3-scale": "^1.0.6",
+        "d3-selection": "^1.0.0",
+        "d3fc-data-join": "^2.0.0",
+        "d3fc-rebind": "^4.0.0"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+          "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "d3-color": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        },
+        "d3-interpolate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+          "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+          "requires": {
+            "d3-color": "1"
+          }
+        },
+        "d3-scale": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+          "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+          "requires": {
+            "d3-array": "^1.2.0",
+            "d3-collection": "1",
+            "d3-color": "1",
+            "d3-format": "1",
+            "d3-interpolate": "1",
+            "d3-time": "1",
+            "d3-time-format": "2"
+          }
+        },
+        "d3-selection": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+          "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
+        },
+        "d3-time": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+          "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+        },
+        "d3-time-format": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+          "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+          "requires": {
+            "d3-time": "1"
+          }
+        }
+      }
+    },
+    "d3fc-rebind": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/d3fc-rebind/-/d3fc-rebind-4.1.1.tgz",
+      "integrity": "sha512-o6zVxefVvY3jTKfCjsisjhPa9Te9d/D0la3F1rhQfUFE2IIdsgjkYBVAarTHc+O7KTIkzt0pI8lw3wbCsrel2w=="
     },
     "data-urls": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@imask/svelte": "^6.6.3",
+    "d3fc-label-layout": "^5.1.0",
     "fuzzysort": "^3.1.0",
     "jwt-decode": "^4.0.0",
     "lodash.clone": "^4.5.0",

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -6,6 +6,7 @@
     import { onMount } from "svelte";
     import { HiglightLineages } from "../highlight";
     import {
+        applyLabelLayout,
         configureSimulation,
         resetSessionPositions,
         setActiveLayoutCache,
@@ -218,6 +219,7 @@
             });
 
         renderChart(svg, highlight, stemmaIndex, markers);
+        if (fullyCached) applyLabelLayout(svg, nodes);
         makeDrag(
             svg,
             simulation,

--- a/frontend/src/graphTools.js
+++ b/frontend/src/graphTools.js
@@ -1,4 +1,5 @@
 import * as d3 from "d3";
+import { layoutGreedy, layoutRemoveOverlaps } from "d3fc-label-layout";
 import {
     personR, familyR, defaultFamilyColor, shadedNodeColor,
     relationsColor, shadedRelationColor, childRelationWidth,
@@ -67,7 +68,7 @@ export function setActiveLayoutCache(cache) {
 }
 
 export function configureSimulation(svg, nodes, relations, width, height) {
-    return d3
+    const sim = d3
         .forceSimulation(nodes)
         .force(
             "link",
@@ -80,25 +81,70 @@ export function configureSimulation(svg, nodes, relations, width, height) {
             d3.forceCollide().radius((d) => d.r * 20)
         )
         .force("repelForce", d3.forceManyBody().strength(-1500).distanceMin(85))
-        .velocityDecay(0.8)
-        .on("tick", () => {
-            svg.select("g.main")
-                .selectAll("g")
-                .attr("transform", (d) => {
-                    sessionPositions.set(d.id, [d.x, d.y])
-                    if (activeLayoutCache) activeLayoutCache.set(d.id, d.x, d.y, d.vx ?? 0, d.vy ?? 0)
-                    return "translate(" + d.x + "," + d.y + ")"
-                });
+        .velocityDecay(0.8);
 
-            svg.selectAll("line")
-                .attr("x1", (d) => d.source.x)
-                .attr("y1", (d) => d.source.y)
-                .attr("x2", (d) => d.target.x)
-                .attr("y2", (d) => d.target.y);
-        })
-        .on("end", () => {
-            if (activeLayoutCache) activeLayoutCache.save()
-        });
+    sim.on("tick", () => {
+        svg.select("g.main")
+            .selectAll("g")
+            .attr("transform", (d) => {
+                sessionPositions.set(d.id, [d.x, d.y])
+                if (activeLayoutCache) activeLayoutCache.set(d.id, d.x, d.y, d.vx ?? 0, d.vy ?? 0)
+                return "translate(" + d.x + "," + d.y + ")"
+            });
+
+        svg.selectAll("line")
+            .attr("x1", (d) => d.source.x)
+            .attr("y1", (d) => d.source.y)
+            .attr("x2", (d) => d.target.x)
+            .attr("y2", (d) => d.target.y);
+    });
+
+    sim.on("end", () => {
+        applyLabelLayout(svg, sim.nodes());
+        if (activeLayoutCache) activeLayoutCache.save();
+    });
+
+    return sim;
+}
+
+export function applyLabelLayout(svg, nodes) {
+    const persons = nodes.filter((n) => n.type === "person");
+    if (persons.length === 0) return;
+
+    const rects = persons.map((p) => {
+        const t = document.querySelector(`#${CSS.escape(p.id)} text`);
+        let w = 80, h = 20;
+        if (t) {
+            const bb = t.getBBox();
+            w = bb.width + 4;
+            h = bb.height + 4;
+        }
+        return {
+            hidden: false,
+            x: p.x - personR,
+            y: p.y + 20,
+            width: w,
+            height: h,
+            _origin: p,
+            _w: w,
+            _h: h,
+        };
+    });
+
+    const strategy = layoutRemoveOverlaps(layoutGreedy());
+    const placed = strategy(rects);
+
+    persons.forEach((p, i) => {
+        const slot = placed[i];
+        const before = rects[i];
+        const dx = slot.x - p.x;
+        const dy = slot.y - p.y;
+        const node = svg.select(`#${CSS.escape(p.id)}`);
+        node.select("text")
+            .attr("dx", dx)
+            .attr("dy", dy + before._h * 0.7)
+            .style("display", slot.hidden ? "none" : null);
+    });
 }
 
 export function updateSimulation(simulation, nodes, relations) {
@@ -205,7 +251,9 @@ export function mergeData(svg, nodes, relations, width, height, initialPositions
                     .append("g")
                     .attr("id", n => n.id);
                 people.append("circle");
-                people.append("text");
+                people.append("text")
+                    .attr("dx", -personR)
+                    .attr("dy", 40);
 
                 enter
                     .filter(n => n.type == "family")
@@ -284,7 +332,5 @@ export function renderChart(svg, highlight, stemmaIndex, markers) {
     svg.selectAll("text")
         .raise()
         .text((node) => node.name)
-        .style("font-size", labelFontSize)
-        .attr("dy", 40)
-        .attr("dx", -personR);
+        .style("font-size", labelFontSize);
 }


### PR DESCRIPTION
## Summary
- Add `d3fc-label-layout` and run a greedy + remove-overlaps pass over the rendered person-label bboxes once the force simulation stabilizes.
- Computed positions are written back as `dx`/`dy` on the existing inline `<text>` elements, so hover styling, pin overlays, and DOM structure stay untouched.
- Fully-cached renders (where the simulation never ticks) get a manual `applyLabelLayout` pass so the first paint is already de-overlapped.

## Caveats
- During an active simulation (drag, restart) labels render at their last-computed offsets — overlaps can briefly reappear and resolve when the sim hits `end`.
- The strategy only sees label-vs-label collisions, not connector lines.
- `npm audit` flags transitive deprecation warnings on `d3fc-data-join` / `d3fc-rebind`; not addressed here.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm test` — 83/83 pass
- [x] `npm run build` — bundle ok
- [ ] Visual smoke on a large family tree (browser verification not done locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)