### PR TITLE
Tolerate ё/й and patronymic typos in person search

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@imask/svelte": "^6.6.3",
         "d3fc-label-layout": "^5.1.0",
         "dompurify": "^3.4.7",
-        "fuzzysort": "^3.1.0",
+        "fuse.js": "^7.4.1",
         "jwt-decode": "^4.0.0",
         "lodash.clone": "^4.5.0",
         "lodash.isequal": "^4.5.0",
@@ -4591,11 +4591,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fuzzysort": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
-      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
-      "license": "MIT"
+    "node_modules/fuse.js": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.1.tgz",
+      "integrity": "sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -11108,10 +11115,10 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
-    "fuzzysort": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
-      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="
+    "fuse.js": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.1.tgz",
+      "integrity": "sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "@imask/svelte": "^6.6.3",
     "d3fc-label-layout": "^5.1.0",
     "dompurify": "^3.4.7",
-    "fuzzysort": "^3.1.0",
+    "fuse.js": "^7.4.1",
     "jwt-decode": "^4.0.0",
     "lodash.clone": "^4.5.0",
     "lodash.isequal": "^4.5.0",

--- a/frontend/src/components/misc/SearchAutocomplete.svelte
+++ b/frontend/src/components/misc/SearchAutocomplete.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-    import fuzzysort from "fuzzysort";
     import type { PersonDescription } from "../../model";
     import { t } from "../../i18n";
+    import { highlightMatches, searchPeople } from "../../personSearch";
 
     type Props = {
         people?: PersonDescription[];
@@ -16,9 +16,7 @@
     let showDropdown = $state(false);
     let blurTimeout: ReturnType<typeof setTimeout>;
 
-    const results = $derived(
-        query.length >= 2 ? fuzzysort.go(query, people, { key: "name", limit: 8 }) : []
-    );
+    const results = $derived(searchPeople(query, people));
 
     $effect(() => {
         showDropdown = results.length > 0 && query.length >= 2;
@@ -48,7 +46,7 @@
         } else if (e.key === "Enter") {
             e.preventDefault();
             if (activeIndex >= 0 && activeIndex < results.length) {
-                selectPerson(results[activeIndex].obj.id);
+                selectPerson(results[activeIndex].item.id);
             }
         } else if (e.key === "Escape") {
             showDropdown = false;
@@ -87,11 +85,11 @@
                     <button
                         class="dropdown-item {i === activeIndex ? 'active' : ''}"
                         type="button"
-                        onmousedown={(e) => { e.preventDefault(); selectPerson(result.obj.id); }}
+                        onmousedown={(e) => { e.preventDefault(); selectPerson(result.item.id); }}
                     >
-                        <span>{@html result.highlight('<b>', '</b>')}</span>
-                        {#if lifespan(result.obj)}
-                            <small class="text-muted ms-2">{lifespan(result.obj)}</small>
+                        <span>{@html highlightMatches(result.item.name, result.matchedIndices)}</span>
+                        {#if lifespan(result.item)}
+                            <small class="text-muted ms-2">{lifespan(result.item)}</small>
                         {/if}
                     </button>
                 </li>

--- a/frontend/src/personSearch.test.ts
+++ b/frontend/src/personSearch.test.ts
@@ -73,6 +73,42 @@ describe("searchPeople", () => {
         expect(ids).toEqual(["1"]);
     });
 
+    it("finds Иван when querying Latin Ivan", () => {
+        const ids = searchPeople("Ivan", [
+            person("1", "Иван Иванов"),
+            person("2", "Пётр Сидоров"),
+        ]).map((r) => r.item.id);
+        expect(ids).toContain("1");
+        expect(ids).not.toContain("2");
+    });
+
+    it("finds Latin Ivan when querying Иван", () => {
+        const ids = searchPeople("Иван", [
+            person("1", "Ivan Petrov"),
+            person("2", "John Smith"),
+        ]).map((r) => r.item.id);
+        expect(ids).toContain("1");
+        expect(ids).not.toContain("2");
+    });
+
+    it("matches Юрий via Latin yuriy", () => {
+        const ids = searchPeople("yuriy", [
+            person("1", "Юрий Гагарин"),
+            person("2", "Сергей Королёв"),
+        ]).map((r) => r.item.id);
+        expect(ids).toContain("1");
+        expect(ids).not.toContain("2");
+    });
+
+    it("matches Фёдор via Latin Fedor", () => {
+        const ids = searchPeople("Fedor", [
+            person("1", "Фёдор Достоевский"),
+            person("2", "Лев Толстой"),
+        ]).map((r) => r.item.id);
+        expect(ids).toContain("1");
+        expect(ids).not.toContain("2");
+    });
+
     it("respects the limit", () => {
         const people = Array.from({ length: 20 }, (_, i) =>
             person(String(i), `Иван ${i}`),

--- a/frontend/src/personSearch.test.ts
+++ b/frontend/src/personSearch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "@jest/globals";
+import type { PersonDescription } from "./model";
+import { highlightMatches, normalizeRu, searchPeople } from "./personSearch";
+
+function person(id: string, name: string): PersonDescription {
+    return { type: "PersonDescription", id, name, readOnly: false };
+}
+
+describe("normalizeRu", () => {
+    it("lowercases", () => {
+        expect(normalizeRu("Иван")).toBe("иван");
+    });
+
+    it("replaces ё with е", () => {
+        expect(normalizeRu("Фёдор")).toBe("федор");
+    });
+
+    it("replaces й with и", () => {
+        expect(normalizeRu("Андрей")).toBe("андреи");
+    });
+
+    it("preserves length", () => {
+        const input = "Фёдор Прокопьевич Алексей";
+        expect(normalizeRu(input).length).toBe(input.length);
+    });
+});
+
+describe("searchPeople", () => {
+    it("returns empty for queries shorter than 2 chars", () => {
+        expect(searchPeople("a", [person("1", "Alice")])).toEqual([]);
+    });
+
+    it("finds Фёдор when querying Федор", () => {
+        const ids = searchPeople("Федор", [
+            person("1", "Фёдор Иванов"),
+            person("2", "Иван Петров"),
+        ]).map((r) => r.item.id);
+        expect(ids).toEqual(["1"]);
+    });
+
+    it("finds Федор when querying Фёдор", () => {
+        const ids = searchPeople("Фёдор", [
+            person("1", "Федор Иванов"),
+            person("2", "Иван Петров"),
+        ]).map((r) => r.item.id);
+        expect(ids).toEqual(["1"]);
+    });
+
+    it("finds Фёдор when querying full name with case mismatch", () => {
+        const ids = searchPeople("федор", [person("1", "Фёдор Иванов")]).map(
+            (r) => r.item.id,
+        );
+        expect(ids).toEqual(["1"]);
+    });
+
+    it("tolerates patronymic variants Прокопьевич/Прокопиевич/Прокопивич", () => {
+        const people = [
+            person("1", "Иван Прокопьевич"),
+            person("2", "Иван Прокопиевич"),
+            person("3", "Иван Прокопивич"),
+            person("4", "Пётр Сидоров"),
+        ];
+        const ids = searchPeople("Прокопиевич", people).map((r) => r.item.id);
+        expect(ids).toEqual(expect.arrayContaining(["1", "2", "3"]));
+        expect(ids).not.toContain("4");
+    });
+
+    it("ignores unrelated names", () => {
+        const ids = searchPeople("Иван", [
+            person("1", "Иван Иванов"),
+            person("2", "Мария Сидорова"),
+        ]).map((r) => r.item.id);
+        expect(ids).toEqual(["1"]);
+    });
+
+    it("respects the limit", () => {
+        const people = Array.from({ length: 20 }, (_, i) =>
+            person(String(i), `Иван ${i}`),
+        );
+        expect(searchPeople("Иван", people, 3)).toHaveLength(3);
+    });
+
+    it("returns match indices into the original name", () => {
+        const [result] = searchPeople("Фёдор", [person("1", "Фёдор Иванов")]);
+        expect(result.matchedIndices.length).toBeGreaterThan(0);
+        for (const [start, end] of result.matchedIndices) {
+            expect(start).toBeGreaterThanOrEqual(0);
+            expect(end).toBeLessThan("Фёдор Иванов".length);
+        }
+    });
+});
+
+describe("highlightMatches", () => {
+    it("wraps matched ranges in <b>", () => {
+        expect(highlightMatches("Федор", [[0, 4]])).toBe("<b>Федор</b>");
+    });
+
+    it("escapes HTML in unmatched portions", () => {
+        expect(highlightMatches("<bad>", [])).toBe("&lt;bad&gt;");
+    });
+
+    it("returns escaped name when no matches", () => {
+        expect(highlightMatches("Иван", [])).toBe("Иван");
+    });
+
+    it("interleaves matched and unmatched segments", () => {
+        expect(highlightMatches("Фёдор Иванов", [[0, 4]])).toBe(
+            "<b>Фёдор</b> Иванов",
+        );
+    });
+});

--- a/frontend/src/personSearch.ts
+++ b/frontend/src/personSearch.ts
@@ -1,0 +1,67 @@
+import Fuse, { type IFuseOptions } from "fuse.js";
+import type { PersonDescription } from "./model";
+
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_LIMIT = 8;
+
+export function normalizeRu(value: string): string {
+    return value
+        .toLowerCase()
+        .replace(/ё/g, "е")
+        .replace(/й/g, "и");
+}
+
+export type PersonSearchMatch = readonly [number, number];
+
+export type PersonSearchResult = {
+    item: PersonDescription;
+    matchedIndices: ReadonlyArray<PersonSearchMatch>;
+};
+
+const FUSE_OPTIONS: IFuseOptions<PersonDescription> = {
+    keys: [{ name: "name", getFn: (person) => normalizeRu(person.name) }],
+    includeMatches: true,
+    threshold: 0.4,
+    ignoreLocation: true,
+    minMatchCharLength: MIN_QUERY_LENGTH,
+};
+
+export function searchPeople(
+    query: string,
+    people: ReadonlyArray<PersonDescription>,
+    limit: number = DEFAULT_LIMIT,
+): PersonSearchResult[] {
+    if (query.length < MIN_QUERY_LENGTH) return [];
+    const fuse = new Fuse(people as PersonDescription[], FUSE_OPTIONS);
+    return fuse.search(normalizeRu(query), { limit }).map((result) => ({
+        item: result.item,
+        matchedIndices: result.matches?.[0]?.indices ?? [],
+    }));
+}
+
+export function highlightMatches(
+    name: string,
+    indices: ReadonlyArray<PersonSearchMatch>,
+): string {
+    if (indices.length === 0) return escapeHtml(name);
+    const sorted = [...indices].sort((a, b) => a[0] - b[0]);
+    let out = "";
+    let cursor = 0;
+    for (const [start, end] of sorted) {
+        if (start < cursor) continue;
+        if (start > cursor) out += escapeHtml(name.slice(cursor, start));
+        out += "<b>" + escapeHtml(name.slice(start, end + 1)) + "</b>";
+        cursor = end + 1;
+    }
+    if (cursor < name.length) out += escapeHtml(name.slice(cursor));
+    return out;
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}

--- a/frontend/src/personSearch.ts
+++ b/frontend/src/personSearch.ts
@@ -1,14 +1,23 @@
-import Fuse, { type IFuseOptions } from "fuse.js";
+import Fuse, { type FuseResult, type IFuseOptions } from "fuse.js";
 import type { PersonDescription } from "./model";
+import { hasCyrillic, toLatinVariants } from "./transliteration";
 
 const MIN_QUERY_LENGTH = 2;
 const DEFAULT_LIMIT = 8;
+const FUSE_THRESHOLD = 0.4;
 
 export function normalizeRu(value: string): string {
     return value
         .toLowerCase()
         .replace(/ё/g, "е")
         .replace(/й/g, "и");
+}
+
+function searchVariants(value: string): string[] {
+    const variants = new Set<string>();
+    if (hasCyrillic(value)) variants.add(normalizeRu(value));
+    for (const v of toLatinVariants(value)) variants.add(v);
+    return [...variants];
 }
 
 export type PersonSearchMatch = readonly [number, number];
@@ -19,11 +28,18 @@ export type PersonSearchResult = {
 };
 
 const FUSE_OPTIONS: IFuseOptions<PersonDescription> = {
-    keys: [{ name: "name", getFn: (person) => normalizeRu(person.name) }],
-    includeMatches: true,
-    threshold: 0.4,
+    keys: [{ name: "name", getFn: (person) => searchVariants(person.name) }],
+    threshold: FUSE_THRESHOLD,
     ignoreLocation: true,
     minMatchCharLength: MIN_QUERY_LENGTH,
+    includeScore: true,
+};
+
+const HIGHLIGHT_OPTIONS: IFuseOptions<string> = {
+    includeMatches: true,
+    threshold: FUSE_THRESHOLD,
+    ignoreLocation: true,
+    minMatchCharLength: 1,
 };
 
 export function searchPeople(
@@ -33,10 +49,33 @@ export function searchPeople(
 ): PersonSearchResult[] {
     if (query.length < MIN_QUERY_LENGTH) return [];
     const fuse = new Fuse(people as PersonDescription[], FUSE_OPTIONS);
-    return fuse.search(normalizeRu(query), { limit }).map((result) => ({
-        item: result.item,
-        matchedIndices: result.matches?.[0]?.indices ?? [],
-    }));
+    const scored = new Map<string, FuseResult<PersonDescription>>();
+    for (const variant of searchVariants(query)) {
+        for (const result of fuse.search(variant, { limit })) {
+            const prior = scored.get(result.item.id);
+            if (!prior || (result.score ?? 1) < (prior.score ?? 1)) {
+                scored.set(result.item.id, result);
+            }
+        }
+    }
+    return [...scored.values()]
+        .sort((a, b) => (a.score ?? 1) - (b.score ?? 1))
+        .slice(0, limit)
+        .map((r) => ({
+            item: r.item,
+            matchedIndices: computeHighlight(r.item.name, query),
+        }));
+}
+
+function computeHighlight(
+    name: string,
+    query: string,
+): ReadonlyArray<PersonSearchMatch> {
+    if (hasCyrillic(name) !== hasCyrillic(query)) return [];
+    const normalizedName = normalizeRu(name);
+    const normalizedQuery = normalizeRu(query);
+    const fuse = new Fuse([normalizedName], HIGHLIGHT_OPTIONS);
+    return fuse.search(normalizedQuery)[0]?.matches?.[0]?.indices ?? [];
 }
 
 export function highlightMatches(

--- a/frontend/src/transliteration.test.ts
+++ b/frontend/src/transliteration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "@jest/globals";
+import { hasCyrillic, toLatinVariants } from "./transliteration";
+
+describe("hasCyrillic", () => {
+    it("detects Cyrillic letters", () => {
+        expect(hasCyrillic("Иван")).toBe(true);
+        expect(hasCyrillic("Иван Petrov")).toBe(true);
+    });
+
+    it("returns false for Latin-only strings", () => {
+        expect(hasCyrillic("Ivan Petrov")).toBe(false);
+        expect(hasCyrillic("")).toBe(false);
+    });
+});
+
+describe("toLatinVariants", () => {
+    it("collapses Иван to ivan across all schemes", () => {
+        expect(toLatinVariants("Иван")).toEqual(["ivan"]);
+    });
+
+    it("returns multiple forms for ambiguous Юрий", () => {
+        const variants = toLatinVariants("Юрий");
+        expect(variants).toEqual(expect.arrayContaining(["iurii", "yuriy"]));
+    });
+
+    it("renders ё as both e and yo", () => {
+        const variants = toLatinVariants("Фёдор");
+        expect(variants).toEqual(expect.arrayContaining(["fedor", "fyodor"]));
+    });
+
+    it("renders х as kh and h", () => {
+        const variants = toLatinVariants("Хабаров");
+        expect(variants).toEqual(expect.arrayContaining(["khabarov", "habarov"]));
+    });
+
+    it("strips ь and ъ", () => {
+        const variants = toLatinVariants("Прокопьевич");
+        for (const v of variants) expect(v).not.toContain("ь");
+    });
+
+    it("preserves spaces and Latin segments", () => {
+        const variants = toLatinVariants("Иван Петров");
+        expect(variants.every((v) => v.includes(" "))).toBe(true);
+    });
+
+    it("lowercases Latin input and returns a single variant", () => {
+        expect(toLatinVariants("Ivan")).toEqual(["ivan"]);
+    });
+
+    it("returns empty-string variant for empty input", () => {
+        expect(toLatinVariants("")).toEqual([""]);
+    });
+});

--- a/frontend/src/transliteration.ts
+++ b/frontend/src/transliteration.ts
@@ -1,0 +1,44 @@
+type Scheme = Readonly<Record<string, string>>;
+
+const GOST: Scheme = {
+    а: "a", б: "b", в: "v", г: "g", д: "d", е: "e", ё: "e", ж: "zh", з: "z",
+    и: "i", й: "i", к: "k", л: "l", м: "m", н: "n", о: "o", п: "p", р: "r",
+    с: "s", т: "t", у: "u", ф: "f", х: "kh", ц: "ts", ч: "ch", ш: "sh", щ: "shch",
+    ъ: "", ы: "y", ь: "", э: "e", ю: "iu", я: "ia",
+};
+
+const BGN_PCGN: Scheme = {
+    а: "a", б: "b", в: "v", г: "g", д: "d", е: "e", ё: "yo", ж: "zh", з: "z",
+    и: "i", й: "y", к: "k", л: "l", м: "m", н: "n", о: "o", п: "p", р: "r",
+    с: "s", т: "t", у: "u", ф: "f", х: "kh", ц: "ts", ч: "ch", ш: "sh", щ: "shch",
+    ъ: "", ы: "y", ь: "", э: "e", ю: "yu", я: "ya",
+};
+
+const NAIVE: Scheme = {
+    а: "a", б: "b", в: "v", г: "g", д: "d", е: "e", ё: "yo", ж: "zh", з: "z",
+    и: "i", й: "y", к: "k", л: "l", м: "m", н: "n", о: "o", п: "p", р: "r",
+    с: "s", т: "t", у: "u", ф: "f", х: "h", ц: "c", ч: "ch", ш: "sh", щ: "sch",
+    ъ: "", ы: "i", ь: "", э: "e", ю: "yu", я: "ya",
+};
+
+const SCHEMES: ReadonlyArray<Scheme> = [GOST, BGN_PCGN, NAIVE];
+
+const CYRILLIC_RANGE = /[Ѐ-ӿ]/;
+
+export function hasCyrillic(input: string): boolean {
+    return CYRILLIC_RANGE.test(input);
+}
+
+export function toLatinVariants(input: string): string[] {
+    const lower = input.toLowerCase();
+    if (!hasCyrillic(lower)) return [lower];
+    const variants = new Set<string>();
+    for (const scheme of SCHEMES) variants.add(applyScheme(lower, scheme));
+    return [...variants];
+}
+
+function applyScheme(value: string, scheme: Scheme): string {
+    let out = "";
+    for (const ch of value) out += ch in scheme ? scheme[ch] : ch;
+    return out;
+}


### PR DESCRIPTION
## Summary
- Replace `fuzzysort` with `fuse.js` for Levenshtein-style typo tolerance.
- Add `personSearch.ts` with `normalizeRu` (lowercase, ё→е, й→и — length-preserving) and `searchPeople` / `highlightMatches` helpers, plus 16 unit tests covering Russian-name edge cases.
- `SearchAutocomplete.svelte` now delegates to the new pure module so highlight indices map cleanly back onto the original name.

## Test plan
- [x] `npm test` (113 passed)
- [x] `npm run check` (0 errors, 0 warnings)
- [ ] Manual: open person search, type `Федор`, expect `Фёдор …` in results
- [ ] Manual: type `Прокопиевич`, expect all of `Прокопьевич / Прокопиевич / Прокопивич` to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)