### PR TITLE
Fuzzy Russian/Latin person search + unknown person placeholder

### DIFF
--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -23,6 +23,8 @@
     import { NodeLayoutCache } from "../nodeLayoutCache";
     import { PinnedPeopleStorage } from "../pinnedPeopleStorage";
     import { exportChartSvg } from "../svgExport";
+    import { personDisplayName } from "../personDisplayName";
+    import { t } from "../i18n";
 
     type Props = {
         stemma: Stemma;
@@ -84,7 +86,8 @@
                 families = stemma.families.filter((f) => !f.readOnly);
             }
 
-            const [nodes, relations] = makeNodesAndRelations(people, families);
+            const displayPeople = people.map((p) => ({ ...p, name: personDisplayName(p.name, $t) }));
+            const [nodes, relations] = makeNodesAndRelations(displayPeople, families);
             const initialPositions = computeInitialLayout(stemmaIndex, people, families, window.innerWidth, window.innerHeight);
             reconfigureGraph(nodes, relations, initialPositions);
         }

--- a/frontend/src/components/family_modal/CreateSelectPerson.svelte
+++ b/frontend/src/components/family_modal/CreateSelectPerson.svelte
@@ -6,6 +6,7 @@
     import PersonSelector from "../misc/PersonSelector.svelte";
     import { t } from "../../i18n";
     import { filterEditablePeople } from "../../personSelectionRules";
+    import { isUnknownPerson, personDisplayName } from "../../personDisplayName";
 
     type Props = {
         stemmaIndex: StemmaIndex;
@@ -18,11 +19,12 @@
     let namesakes = $state<(CreateNewPerson | PersonDescription)[]>([]);
     let selectedPerson = $state<CreateNewPerson | PersonDescription>(null);
     let filterText = $state("");
+    let unknown = $state(false);
 
     type SelectItem = { label: string; value: string; isCreator?: boolean };
 
     const peopleNames = $derived(
-        stemma ? [...new Set(filterEditablePeople(stemma.people).map((p) => p.name))] : []
+        stemma ? [...new Set(filterEditablePeople(stemma.people).map((p) => p.name).filter((n) => !isUnknownPerson(n)))] : []
     );
 
     const peopleItems = $derived.by(() => {
@@ -38,7 +40,7 @@
     });
 
     const selectedItem = $derived<SelectItem | null>(
-        selectedPerson ? { label: selectedPerson.name, value: selectedPerson.name } : null
+        selectedPerson ? { label: personDisplayName(selectedPerson.name, $t), value: selectedPerson.name } : null
     );
 
     function personSelected(p: CreateNewPerson | PersonDescription) {
@@ -54,6 +56,19 @@
         namesakes = [];
         selectedPerson = null;
         filterText = "";
+        unknown = false;
+    }
+
+    function toggleUnknown() {
+        if (unknown) {
+            const unknownPerson: CreateNewPerson = { type: "CreateNewPerson", name: "" };
+            namesakes = [unknownPerson];
+            personSelected(unknownPerson);
+        } else {
+            namesakes = [];
+            selectedPerson = null;
+            onselected?.(null);
+        }
     }
 
     function handleSelect(e: any) {
@@ -77,11 +92,22 @@
                 on:clear={() => reset()}
                 hideEmptyState={true}
                 value={selectedItem}
+                disabled={unknown}
             >
                 <svelte:fragment slot="clear-icon">
                     <ClearIcon />
                 </svelte:fragment>
             </Select>
+            <div class="form-check form-switch mt-2">
+                <input
+                    class="form-check-input"
+                    type="checkbox"
+                    id="createPersonUnknownSwitch"
+                    bind:checked={unknown}
+                    onchange={toggleUnknown}
+                />
+                <label class="form-check-label" for="createPersonUnknownSwitch">{$t("person.unknownToggle")}</label>
+            </div>
         </div>
         <div class="flex-grow-1 mt-2 mb-2" style="min-height:400px">
             <PersonSelector people={namesakes} {stemmaIndex} onselect={personSelected} />

--- a/frontend/src/components/family_modal/FamilyGeneration.svelte
+++ b/frontend/src/components/family_modal/FamilyGeneration.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type { CreateNewPerson, PersonDescription } from "../../model";
     import { t } from "../../i18n";
+    import { personDisplayName } from "../../personDisplayName";
 
     type Props = {
         selectedPeople?: (PersonDescription | CreateNewPerson)[];
@@ -22,7 +23,7 @@
             {#each selectedPeople as p, i}
                 <tr>
                     <th class="align-middle" scope="row">{i + 1}</th>
-                    <td class="align-middle">{p.name}</td>
+                    <td class="align-middle">{personDisplayName(p.name, $t)}</td>
                     <td class="align-middle">
                         {#if !readOnly}
                             <div class="float-end">

--- a/frontend/src/components/invite_modal/InviteModal.svelte
+++ b/frontend/src/components/invite_modal/InviteModal.svelte
@@ -13,6 +13,7 @@
     import { StemmaIndex } from "../../stemmaIndex";
     import PersonSelector from "../misc/PersonSelector.svelte";
     import { t } from "../../i18n";
+    import { isUnknownPerson, personDisplayName } from "../../personDisplayName";
 
     type Props = {
         stemmaIndex: StemmaIndex;
@@ -31,7 +32,7 @@
     let inviteLink = $state("");
 
     const peopleNames = $derived(
-        stemma ? [...new Set(stemma.people.map((p) => p.name))] : []
+        stemma ? [...new Set(stemma.people.map((p) => p.name).filter((n) => !isUnknownPerson(n)))] : []
     );
 
     const peopleItems = $derived<SelectItem[]>(
@@ -39,7 +40,7 @@
     );
 
     const selectedItem = $derived<SelectItem | null>(
-        selectedPerson ? { label: selectedPerson.name, value: selectedPerson.name } : null
+        selectedPerson ? { label: personDisplayName(selectedPerson.name, $t), value: selectedPerson.name } : null
     );
 
     function nameChanged(newName: string) {

--- a/frontend/src/components/misc/VisualPersonDescription.svelte
+++ b/frontend/src/components/misc/VisualPersonDescription.svelte
@@ -4,6 +4,8 @@
     import { onMount } from "svelte";
     import { configureSimulation, initChart, makeDrag, makeNodesAndRelations, mergeData, renderChart } from "../../graphTools";
     import { HighlightAll } from "../../highlight";
+    import { personDisplayName } from "../../personDisplayName";
+    import { t } from "../../i18n";
 
     type Props = {
         chartId: string;
@@ -37,7 +39,8 @@
                 families = [];
             }
 
-            [nodes, relations] = makeNodesAndRelations(relativies, families);
+            const displayRelativies = relativies.map((p) => ({ ...p, name: personDisplayName(p.name, $t) }));
+            [nodes, relations] = makeNodesAndRelations(displayRelativies, families);
         }
     });
 

--- a/frontend/src/components/person_details_modal/PersonDetailsModal.svelte
+++ b/frontend/src/components/person_details_modal/PersonDetailsModal.svelte
@@ -46,6 +46,7 @@
     import * as bootstrap from "bootstrap";
     import { t } from "../../i18n";
     import { renderBioMarkdown } from "../../bioMarkdown";
+    import { isUnknownPerson } from "../../personDisplayName";
 
     type Props = {
         onpersonUpdated?: (payload: UpdatePerson) => void;
@@ -60,6 +61,7 @@
     let photoFileInputEl = $state<HTMLInputElement>(null);
 
     let pinned = $state<boolean>(false);
+    let unknown = $state<boolean>(false);
     let name = $state<string>("");
     let birthDate = $state<Date>(null);
     let deathDate = $state<Date>(null);
@@ -97,7 +99,7 @@
             id,
             description: {
                 type: "CreateNewPerson",
-                name,
+                name: unknown ? "" : name,
                 birthDate: dateToIsoLocalTime(birthDate),
                 deathDate: dateToIsoLocalTime(deathDate),
                 bio,
@@ -131,6 +133,7 @@
     export function showPersonDetails(p: ShowPerson) {
         id = p.description.id;
         name = p.description.name;
+        unknown = isUnknownPerson(p.description.name);
         birthDate = p.description.birthDate ? new Date(p.description.birthDate) : null;
         deathDate = p.description.deathDate ? new Date(p.description.deathDate) : null;
         if (birthInputEl) birthInputEl.value = dateToMaskedDateStr(birthDate) ?? "";
@@ -489,7 +492,19 @@
                     <div class="col-md-8">
                         <div class="mb-3">
                             <label for="personNameInput" class="form-label">{$t("person.name")}</label>
-                            <input class="form-control" id="personNameInput" aria-describedby="personNameHelp" bind:value={name} readonly={readOnly} />
+                            <input class="form-control" id="personNameInput" aria-describedby="personNameHelp" bind:value={name} readonly={readOnly} disabled={unknown} />
+                            {#if !readOnly}
+                                <div class="form-check form-switch mt-2">
+                                    <input
+                                        class="form-check-input"
+                                        type="checkbox"
+                                        id="personUnknownSwitch"
+                                        bind:checked={unknown}
+                                        onchange={() => { if (unknown) name = ""; }}
+                                    />
+                                    <label class="form-check-label" for="personUnknownSwitch">{$t("person.unknownToggle")}</label>
+                                </div>
+                            {/if}
                         </div>
                         <div class="form-label">{$t("person.lifeYears")}</div>
                         <div class="row g-2">

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -133,6 +133,8 @@ export const en: Record<string, string> = {
     'person.photoUploadFailed': 'Photo upload failed. Try again',
     'person.photoAdjustTitle': 'Adjust photo',
     'person.photoAdjustHint': 'Drag to position, use the slider to zoom',
+    'person.unknown': 'Unknown',
+    'person.unknownToggle': 'Unknown person',
 
     // Settings modal
     'settings.title': 'Display settings',
@@ -287,6 +289,8 @@ export const ru: Record<string, string> = {
     'person.photoUploadFailed': 'Не удалось загрузить фото. Попробуйте еще раз',
     'person.photoAdjustTitle': 'Подгонка фото',
     'person.photoAdjustHint': 'Двигайте мышью, масштабируйте ползунком',
+    'person.unknown': 'Неизвестно',
+    'person.unknownToggle': 'Неизвестный',
 
     // Settings modal
     'settings.title': 'Настройки отображения',

--- a/frontend/src/personDisplayName.ts
+++ b/frontend/src/personDisplayName.ts
@@ -1,0 +1,10 @@
+import type { TranslationFn } from "./i18n";
+
+export function isUnknownPerson(name: string | null | undefined): boolean {
+    return !name || name.trim() === "";
+}
+
+export function personDisplayName(name: string | null | undefined, t: TranslationFn): string {
+    if (!name || name.trim() === "") return t("person.unknown");
+    return name;
+}

--- a/frontend/src/personSearch.ts
+++ b/frontend/src/personSearch.ts
@@ -1,6 +1,7 @@
 import Fuse, { type FuseResult, type IFuseOptions } from "fuse.js";
 import type { PersonDescription } from "./model";
 import { hasCyrillic, toLatinVariants } from "./transliteration";
+import { isUnknownPerson } from "./personDisplayName";
 
 const MIN_QUERY_LENGTH = 2;
 const DEFAULT_LIMIT = 8;
@@ -48,7 +49,8 @@ export function searchPeople(
     limit: number = DEFAULT_LIMIT,
 ): PersonSearchResult[] {
     if (query.length < MIN_QUERY_LENGTH) return [];
-    const fuse = new Fuse(people as PersonDescription[], FUSE_OPTIONS);
+    const searchable = people.filter((p) => !isUnknownPerson(p.name));
+    const fuse = new Fuse(searchable as PersonDescription[], FUSE_OPTIONS);
     const scored = new Map<string, FuseResult<PersonDescription>>();
     for (const variant of searchVariants(query)) {
         for (const result of fuse.search(variant, { limit })) {


### PR DESCRIPTION
## Summary
- Tolerate ё/й typos and Russian patronymic variants in quick search; match across Cyrillic ↔ Latin transliteration variants.
- Add an "Unknown person" toggle (in the family-member selector and person-details modal) for people whose name is unknown; stored with an empty name, rendered as the localized "Неизвестно" / "Unknown" everywhere, excluded from search and autocomplete.

## Test plan
- [x] `npm test` (frontend) — 127/127 pass
- [x] `npm run check` (frontend) — 0 errors, 0 warnings
- [x] `uv run pytest` (backend) — 71/71 pass
- [ ] Manually verify: create a family with an unknown child, check it renders as "Неизвестно" in the tree and is skipped by quick search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)