### PR TITLE
Fix CloudFront alias drift: set cloudFrontAlias=stemma.link

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -8,6 +8,6 @@ s3_prefix = "stemma-app"
 region = "eu-central-1"
 confirm_changeset = false
 capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
-parameter_overrides = "AppName=\"stemma-app\" Stage=\"dev_local\""
+parameter_overrides = "AppName=\"stemma-app\" Stage=\"dev_local\" cloudFrontAlias=\"stemma.link\""
 image_repositories = []
 disable_rollback = false


### PR DESCRIPTION
## Summary
- Deployed `stemma-app` SAM stack has `cloudFrontAlias=web.stemma.link` (an old parameter override) while Route53 apex `stemma.link` aliases to the CloudFront distribution and the ACM cert covers `stemma.link` + `*.stemma.link`.
- Result: visiting `https://stemma.link/` returned `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` because CloudFront rejected the SNI for `stemma.link` (alias was `web.stemma.link`).
- CloudFront aliases were patched out-of-band to include `stemma.link` (live fix). This PR aligns `samconfig.toml` so the next master deploy reapplies the same parameter and the orphan `web.stemma.link` alias can be dropped cleanly.

## Test plan
- [ ] Merge → CD runs `sam deploy --no-confirm-changeset` with new override.
- [ ] After deploy, verify `aws cloudfront get-distribution --id EK907L1QOXWMF` shows `Aliases = [stemma.link]` only.
- [ ] Verify `curl -I https://stemma.link/` returns 200 (already true post-manual fix).
- [ ] Verify Route53 still has `stemma.link.` A-alias → CloudFront (SAM `assetsDnsRecord` resource manages this; expected in-sync after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)