### PR TITLE
Add v2 person search

### DIFF
--- a/e2e/tests/v2_search.spec.ts
+++ b/e2e/tests/v2_search.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+test("v2 search: find person, focus tree, handle no-match", async ({ page }) => {
+  await page.goto("/v2");
+
+  const editFab = page.getByTestId("v2-edit-fab");
+  await expect(editFab).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+
+  // Pick a stemma with at least one person. Default landing is a populated stemma.
+  const svg = page.locator("svg#chart");
+  if (!(await svg.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    // Add one person so search is populated.
+    await editFab.click();
+    await page.getByTestId("v2-add-person-fab").click();
+    const nameInput = page.getByTestId("v2-name-input");
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill("Searchable");
+    await page.getByTestId("v2-name-confirm").click();
+    await expect(svg).toBeVisible({ timeout: 15_000 });
+    await expect(svg.locator("text").filter({ hasText: "Searchable" })).toBeVisible({ timeout: 15_000 });
+  }
+
+  const search = page.getByTestId("v2-search");
+  await expect(search).toBeVisible();
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: "test-results/v2-search-01-idle.png" });
+
+  const input = page.getByTestId("v2-search-input");
+  await expect(input).toBeVisible();
+
+  // No-results state.
+  await input.click();
+  await input.fill("zzqx-unlikely-name");
+  await expect(page.getByTestId("v2-search-no-results")).toBeVisible();
+  await page.waitForTimeout(200);
+  await page.screenshot({ path: "test-results/v2-search-02-no-results.png" });
+
+  // Real person from canvas.
+  await input.fill("");
+  const firstPersonText = await svg.locator("g[id^='person_'] text").first().textContent();
+  expect(firstPersonText).toBeTruthy();
+  const fragment = (firstPersonText ?? "").trim().slice(0, 3);
+  expect(fragment.length).toBeGreaterThanOrEqual(2);
+
+  await input.fill(fragment);
+  const dropdown = page.getByTestId("v2-search-dropdown");
+  await expect(dropdown).toBeVisible();
+  const result = page.getByTestId("v2-search-result").first();
+  await expect(result).toBeVisible();
+  await page.waitForTimeout(200);
+  await page.screenshot({ path: "test-results/v2-search-03-results.png" });
+
+  await result.click();
+
+  await expect(dropdown).not.toBeVisible();
+  await expect(input).toHaveValue("");
+  await page.waitForTimeout(900);
+  await page.screenshot({ path: "test-results/v2-search-04-after-zoom.png" });
+});

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -230,6 +230,7 @@ export const en: Record<string, string> = {
     'v2.removeFamilyMessage': 'Members stay but lose their links through this family.',
     'v2.removePersonTitle': 'Delete {name}?',
     'v2.removePersonMessage': 'Person is removed from the tree along with their family links.',
+    'v2.searchNoResults': 'No people match',
 };
 
 export const ru: Record<string, string> = {
@@ -430,6 +431,7 @@ export const ru: Record<string, string> = {
     'v2.removeFamilyMessage': 'Люди останутся, но потеряют связи через эту семью.',
     'v2.removePersonTitle': 'Удалить {name}?',
     'v2.removePersonMessage': 'Человек будет удалён из дерева вместе с его семейными связями.',
+    'v2.searchNoResults': 'Никто не найден',
 };
 
 const dictionaries: Record<Locale, Record<string, string>> = { en, ru };

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -15,6 +15,7 @@
     import V2Menu from "./components/V2Menu.svelte";
     import V2Fab from "./components/V2Fab.svelte";
     import V2EditPill from "./components/V2EditPill.svelte";
+    import V2Search from "./components/V2Search.svelte";
     import V2EmptyState from "./components/V2EmptyState.svelte";
     import V2Sheet from "./components/V2Sheet.svelte";
     import V2PersonCard from "./components/V2PersonCard.svelte";
@@ -469,11 +470,18 @@
                 />
             </div>
 
-            {#if editMode}
-                <div class="v2-top-center">
+            <div class="v2-top-center">
+                {#if stemma && stemma.people.length > 0}
+                    <V2Search
+                        people={stemma.people}
+                        disabled={isWorking}
+                        onselect={(id) => stemmaChart?.zoomToNode(id)}
+                    />
+                {/if}
+                {#if editMode}
                     <V2EditPill />
-                </div>
-            {/if}
+                {/if}
+            </div>
 
             <div class="v2-top-right">
                 <V2Menu
@@ -642,8 +650,12 @@
         top: 16px;
         left: 50%;
         transform: translateX(-50%);
-        pointer-events: none;
+        pointer-events: auto;
         z-index: 100;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
     }
 
     .v2-top-right {

--- a/frontend/src/v2/components/V2Search.svelte
+++ b/frontend/src/v2/components/V2Search.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+    import type { PersonDescription } from "../../model";
+    import { t } from "../../i18n";
+    import { highlightMatches, searchPeople } from "../../personSearch";
+
+    type Props = {
+        people: PersonDescription[];
+        disabled?: boolean;
+        onselect?: (id: string) => void;
+    };
+
+    let { people, disabled = false, onselect }: Props = $props();
+
+    let query = $state("");
+    let activeIndex = $state(-1);
+    let focused = $state(false);
+    let inputEl = $state<HTMLInputElement | null>(null);
+    let blurTimeout: ReturnType<typeof setTimeout>;
+
+    const results = $derived(searchPeople(query, people));
+    const hasQuery = $derived(query.trim().length >= 2);
+    const showDropdown = $derived(focused && hasQuery);
+    const showNoResults = $derived(showDropdown && results.length === 0);
+
+    $effect(() => {
+        results;
+        activeIndex = -1;
+    });
+
+    function lifespan(p: PersonDescription): string {
+        const parts = [p.birthDate || "?", p.deathDate].filter(Boolean);
+        return parts.length ? parts.join(" – ") : "";
+    }
+
+    function selectPerson(id: string) {
+        onselect?.(id);
+        query = "";
+        focused = false;
+        inputEl?.blur();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") {
+            query = "";
+            focused = false;
+            inputEl?.blur();
+            return;
+        }
+        if (!showDropdown || results.length === 0) return;
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            activeIndex = (activeIndex + 1) % results.length;
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            activeIndex = (activeIndex - 1 + results.length) % results.length;
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            const idx = activeIndex >= 0 ? activeIndex : 0;
+            selectPerson(results[idx].item.id);
+        }
+    }
+
+    function handleBlur() {
+        blurTimeout = setTimeout(() => {
+            focused = false;
+        }, 150);
+    }
+
+    function handleFocus() {
+        clearTimeout(blurTimeout);
+        focused = true;
+    }
+
+    function clearQuery() {
+        query = "";
+        inputEl?.focus();
+    }
+</script>
+
+<div class="v2-search" data-testid="v2-search">
+    <i class="bi bi-search search-icon" aria-hidden="true"></i>
+    <input
+        bind:this={inputEl}
+        type="search"
+        class="search-input"
+        placeholder={$t("search.placeholder")}
+        bind:value={query}
+        {disabled}
+        onkeydown={handleKeydown}
+        onblur={handleBlur}
+        onfocus={handleFocus}
+        aria-label={$t("search.placeholder")}
+        data-testid="v2-search-input"
+    />
+    {#if query.length > 0}
+        <button
+            type="button"
+            class="clear-btn"
+            onclick={clearQuery}
+            aria-label={$t("common.close")}
+            data-testid="v2-search-clear"
+        >
+            <i class="bi bi-x"></i>
+        </button>
+    {/if}
+
+    {#if showDropdown}
+        <div class="search-dropdown" data-testid="v2-search-dropdown">
+            {#if showNoResults}
+                <div class="no-results" data-testid="v2-search-no-results">
+                    {$t("v2.searchNoResults")}
+                </div>
+            {:else}
+                {#each results as result, i}
+                    <button
+                        type="button"
+                        class="search-row"
+                        class:active={i === activeIndex}
+                        onmousedown={(e) => { e.preventDefault(); selectPerson(result.item.id); }}
+                        data-testid="v2-search-result"
+                    >
+                        <span class="row-name">{@html highlightMatches(result.item.name, result.matchedIndices)}</span>
+                        {#if lifespan(result.item)}
+                            <span class="row-meta">{lifespan(result.item)}</span>
+                        {/if}
+                    </button>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .v2-search {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        padding: 6px 10px;
+        position: relative;
+        width: min(320px, calc(100vw - 200px));
+        min-width: 200px;
+    }
+
+    .search-icon {
+        color: #6c757d;
+        font-size: 0.95rem;
+        flex-shrink: 0;
+    }
+
+    .search-input {
+        flex: 1 1 auto;
+        min-width: 0;
+        border: none;
+        outline: none;
+        background: transparent;
+        font-size: 0.875rem;
+        color: #212529;
+        padding: 2px 0;
+    }
+
+    .search-input::placeholder {
+        color: #adb5bd;
+    }
+
+    .search-input::-webkit-search-cancel-button {
+        display: none;
+    }
+
+    .clear-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background: transparent;
+        border: none;
+        color: #6c757d;
+        cursor: pointer;
+        flex-shrink: 0;
+        font-size: 0.95rem;
+    }
+
+    .clear-btn:hover {
+        background: #e9ecef;
+        color: #212529;
+    }
+
+    .search-dropdown {
+        position: absolute;
+        top: calc(100% + 8px);
+        left: 0;
+        right: 0;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        max-height: 320px;
+        overflow-y: auto;
+        z-index: 1000;
+        padding: 4px 0;
+    }
+
+    .search-row {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        width: 100%;
+        padding: 8px 12px;
+        background: none;
+        border: none;
+        text-align: left;
+        font-size: 0.875rem;
+        color: #212529;
+        cursor: pointer;
+    }
+
+    .search-row:hover,
+    .search-row.active {
+        background: #f1f7ff;
+    }
+
+    .row-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .row-name :global(b) {
+        font-weight: 700;
+        color: #0d6efd;
+    }
+
+    .row-meta {
+        color: #6c757d;
+        font-size: 0.8rem;
+        flex-shrink: 0;
+    }
+
+    .no-results {
+        padding: 10px 12px;
+        color: #6c757d;
+        font-size: 0.85rem;
+        text-align: center;
+    }
+</style>

--- a/frontend/src/v2/components/V2Sheet.svelte
+++ b/frontend/src/v2/components/V2Sheet.svelte
@@ -190,6 +190,9 @@
     .popover-panel {
         position: fixed;
         width: 320px;
+        max-height: calc(100vh - 32px);
+        display: flex;
+        flex-direction: column;
         background: var(--v2-bg-surface);
         border-radius: var(--v2-radius-modal);
         box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
@@ -203,6 +206,8 @@
     }
 
     .popover-body {
+        flex: 1;
+        overflow-y: auto;
         padding: 16px 18px 8px;
     }
 


### PR DESCRIPTION
## Summary
- New `V2Search.svelte` pill at v2 top-center, reuses existing `searchPeople` (fuse.js + Cyrillic/Latin transliteration) and `highlightMatches`.
- Selecting a result focuses the canvas via `stemmaChart.zoomToNode(id)`.
- Empty/no-results states, keyboard nav (↑/↓/Enter/Escape), clear button.
- i18n: reuses `search.placeholder`; adds `v2.searchNoResults` (en + ru).

Closes #135

## Test plan
- [x] `npm run check` clean
- [x] `npm test` (frontend jest) all pass
- [x] `npm run build` ok
- [x] `e2e/tests/v2_search.spec.ts` pass — no-results state + select-then-zoom flow
- [x] `e2e/tests/v2_bootstrap.spec.ts` regression check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)