### PR TITLE
Keep v2 simulation running during person/family mutations

### DIFF
--- a/frontend/src/appController.test.ts
+++ b/frontend/src/appController.test.ts
@@ -143,6 +143,99 @@ describe("AppController", () => {
         expect(localStorage.getItem("stemma_last_stemma_id")).toBe("b");
     });
 
+    test("selectStemma toggles isWorking when switching to a different stemma", async () => {
+        let resolveFetch: (s: Stemma) => void;
+        const model = {
+            getStemma: jest.fn().mockReturnValue(new Promise<Stemma>((r) => { resolveFetch = r; })),
+        };
+        const controller = new AppController("http://example", () => model as any);
+        (controller as any).model = model;
+        controller.currentStemmaId.set("a");
+
+        controller.selectStemma("b");
+        expect(get(controller.isWorking)).toBe(true);
+
+        resolveFetch!(stemmaB);
+        await drainPromises();
+        expect(get(controller.isWorking)).toBe(false);
+    });
+
+    test("selectStemma does not toggle isWorking when re-fetching the same stemma", async () => {
+        let resolveFetch: (s: Stemma) => void;
+        const model = {
+            getStemma: jest.fn().mockReturnValue(new Promise<Stemma>((r) => { resolveFetch = r; })),
+        };
+        const controller = new AppController("http://example", () => model as any);
+        (controller as any).model = model;
+        controller.currentStemmaId.set("b");
+
+        controller.selectStemma("b");
+        expect(get(controller.isWorking)).toBe(false);
+
+        resolveFetch!(stemmaB);
+        await drainPromises();
+        expect(get(controller.isWorking)).toBe(false);
+        expect(get(controller.stemma)).toEqual(stemmaB);
+    });
+
+    describe("silent mutations", () => {
+        const stemmaId = "s1";
+        const baseStemma: Stemma = { type: "Stemma", people: [], families: [] };
+
+        function makeController(model: any) {
+            const c = new AppController("http://example", () => model as any);
+            (c as any).model = model;
+            c.currentStemmaId.set(stemmaId);
+            c.stemmaIndex.set(new StemmaIndex(baseStemma));
+            return c;
+        }
+
+        test("createOrphanPerson with silent leaves isWorking false and returns a promise", async () => {
+            let resolveMut: (s: Stemma) => void;
+            const model = {
+                createOrphanPerson: jest.fn().mockReturnValue(new Promise<Stemma>((r) => { resolveMut = r; })),
+            };
+            const c = makeController(model);
+
+            const p = c.createOrphanPerson({ type: "CreateNewPerson", name: "x" }, { silent: true });
+            expect(get(c.isWorking)).toBe(false);
+
+            resolveMut!(stemmaB);
+            await p;
+            expect(get(c.isWorking)).toBe(false);
+            expect(get(c.stemma)).toEqual(stemmaB);
+        });
+
+        test("createOrphanPerson without silent toggles isWorking", async () => {
+            let resolveMut: (s: Stemma) => void;
+            const model = {
+                createOrphanPerson: jest.fn().mockReturnValue(new Promise<Stemma>((r) => { resolveMut = r; })),
+            };
+            const c = makeController(model);
+
+            const p = c.createOrphanPerson({ type: "CreateNewPerson", name: "x" });
+            expect(get(c.isWorking)).toBe(true);
+
+            resolveMut!(stemmaB);
+            await p;
+            expect(get(c.isWorking)).toBe(false);
+        });
+
+        test("silent mutation rejection propagates to caller", async () => {
+            const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+            const boom = new Error("boom");
+            const model = {
+                removePerson: jest.fn().mockRejectedValue(boom),
+            };
+            const c = makeController(model);
+
+            await expect(c.removePerson("p1", { silent: true })).rejects.toBe(boom);
+            expect(get(c.err)).toBe(boom);
+            expect(get(c.isWorking)).toBe(false);
+            errSpy.mockRestore();
+        });
+    });
+
     describe("savePerson", () => {
         const stemmaId = "s1";
         const personId = "p1";

--- a/frontend/src/appController.ts
+++ b/frontend/src/appController.ts
@@ -7,6 +7,8 @@ import { writable, get } from 'svelte/store';
 import { SettingsStorage } from './settingsStroage';
 import { selectStemmaId } from './appControllerSelection';
 
+export type MutationOptions = { silent?: boolean }
+
 export class AppController {
     private static readonly LAST_STEMMA_KEY = "stemma_last_stemma_id";
     private modelFactory: (endpoint: string, tokenProvider: TokenProvider) => Model;
@@ -91,7 +93,8 @@ export class AppController {
     }
 
     selectStemma(stemmaId: string) {
-        this.isWorking.set(true)
+        const sameStemma = get(this.currentStemmaId) === stemmaId
+        if (!sameStemma) this.isWorking.set(true)
         this.err.set(null)
 
         this.setCurrentStemmaId(stemmaId)
@@ -105,7 +108,7 @@ export class AppController {
                 this.err.set(err)
                 console.error('Err when fetching stemma data: ', err.stack);
             })
-            .finally(() => this.isWorking.set(false))
+            .finally(() => { if (!sameStemma) this.isWorking.set(false) })
     }
 
     removeStemma(stemmaId: string) {
@@ -180,20 +183,20 @@ export class AppController {
             .finally(() => this.isWorking.set(false))
     }
 
-    createOrphanPerson(descr: CreateNewPerson) {
-        this.manipulateStemma((model, stemmaId) => model.createOrphanPerson(stemmaId, descr))
+    createOrphanPerson(descr: CreateNewPerson, options?: MutationOptions) {
+        return this.manipulateStemma((model, stemmaId) => model.createOrphanPerson(stemmaId, descr), options)
     }
 
-    createFamily(parents: PersonDefinition[], children: PersonDefinition[]) {
-        this.manipulateStemma((model, stemmaId) => model.createFamily(stemmaId, parents, children, get(this.stemmaIndex)))
+    createFamily(parents: PersonDefinition[], children: PersonDefinition[], options?: MutationOptions) {
+        return this.manipulateStemma((model, stemmaId) => model.createFamily(stemmaId, parents, children, get(this.stemmaIndex)), options)
     }
 
-    updateFamily(familyId: string, parents: PersonDefinition[], children: PersonDefinition[]) {
-        this.manipulateStemma((model, stemmaId) => model.updateFamily(stemmaId, familyId, parents, children, get(this.stemmaIndex)))
+    updateFamily(familyId: string, parents: PersonDefinition[], children: PersonDefinition[], options?: MutationOptions) {
+        return this.manipulateStemma((model, stemmaId) => model.updateFamily(stemmaId, familyId, parents, children, get(this.stemmaIndex)), options)
     }
 
-    removeFamily(familyId: string) {
-        this.manipulateStemma((model, stemmaId) => model.removeFamily(stemmaId, familyId))
+    removeFamily(familyId: string, options?: MutationOptions) {
+        return this.manipulateStemma((model, stemmaId) => model.removeFamily(stemmaId, familyId), options)
     }
 
     savePerson(personId: string, descr: CreateNewPerson, pin: boolean, photoUpload: Blob | null, photoRemove: boolean) {
@@ -246,8 +249,8 @@ export class AppController {
             .finally(() => this.isWorking.set(false))
     }
 
-    removePerson(personId: string) {
-        this.manipulateStemma((model, stemmaId) => model.removePerson(stemmaId, personId, get(this.stemmaIndex)))
+    removePerson(personId: string, options?: MutationOptions) {
+        return this.manipulateStemma((model, stemmaId) => model.removePerson(stemmaId, personId, get(this.stemmaIndex)), options)
     }
 
     createInvitationToken(personId: string, email: string) {
@@ -257,13 +260,17 @@ export class AppController {
             .then(tkn => this.invitationToken.set(tkn))
     }
 
-    private manipulateStemma(action: (m: Model, currentStemmaId: string) => Promise<Stemma>) {
+    private manipulateStemma(
+        action: (m: Model, currentStemmaId: string) => Promise<Stemma>,
+        options?: MutationOptions,
+    ): Promise<void> {
         let currentStemmaId = get(this.currentStemmaId)
+        const silent = options?.silent ?? false
 
-        this.isWorking.set(true)
+        if (!silent) this.isWorking.set(true)
         this.err.set(null)
 
-        action(this.model, currentStemmaId)
+        return action(this.model, currentStemmaId)
             .then((result) => {
                 this.refreshIndexes(result, currentStemmaId)
                 this.stemma.set(result)
@@ -271,8 +278,9 @@ export class AppController {
             .catch(err => {
                 this.err.set(err)
                 console.error('Err when manipulating stemma data: ', err.stack);
+                throw err
             })
-            .finally(() => this.isWorking.set(false))
+            .finally(() => { if (!silent) this.isWorking.set(false) })
     }
 
 

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -59,6 +59,8 @@
 
     let editMode = $state(false);
     let stubFamilies = $state<Map<string, StubEntry>>(new Map());
+    let pendingRemovedPersonIds = $state<Set<string>>(new Set());
+    let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
 
     let ownedStemmas = $state<StemmaDescription[]>([]);
     let currentStemmaId = $state<string | null>(null);
@@ -85,11 +87,18 @@
 
     const controller = new AppController(untrack(() => stemma_backend_url));
 
+    let lastStemmaIdSeen: string | null = null;
     const subscriptions = [
         controller.currentStemmaId.subscribe((s) => (currentStemmaId = s)),
         controller.stemma.subscribe((s) => {
+            const switchedStemma = currentStemmaId !== lastStemmaIdSeen;
+            lastStemmaIdSeen = currentStemmaId;
             stemma = s;
-            stubFamilies = new Map();
+            if (s === null || switchedStemma) {
+                stubFamilies = new Map();
+                pendingRemovedPersonIds = new Set();
+                pendingRemovedFamilyIds = new Set();
+            }
         }),
         controller.ownedStemmas.subscribe((os) => (ownedStemmas = os)),
         controller.stemmaIndex.subscribe((si) => (stemmaIndex = si)),
@@ -126,13 +135,28 @@
     });
 
     $effect(() => {
-        if (!stemmaChart || !stubFamilies) return;
-        stubFamilies.forEach((_entry, tempId) => {
-            const familyEl = document.getElementById(normalizeId("family", tempId));
-            const circle = familyEl?.querySelector("circle");
-            if (circle) circle.classList.add("stub-family");
-        });
+        if (!stemmaChart) return;
+        void stubFamilies;
+        void pendingRemovedPersonIds;
+        void pendingRemovedFamilyIds;
+        tick().then(() => applyPendingClasses());
     });
+
+    function applyPendingClasses() {
+        const svgEl = document.getElementById("chart");
+        if (!svgEl) return;
+        svgEl.querySelectorAll("circle.v2-pending-remove, circle.stub-family").forEach((el) => {
+            el.classList.remove("v2-pending-remove", "stub-family");
+        });
+        const markCircle = (nodeId: string, cls: string) => {
+            const el = document.getElementById(nodeId);
+            const circle = el?.querySelector("circle");
+            if (circle) circle.classList.add(cls);
+        };
+        stubFamilies.forEach((_entry, tempId) => markCircle(normalizeId("family", tempId), "stub-family"));
+        pendingRemovedPersonIds.forEach((id) => markCircle(normalizeId("person", id), "v2-pending-remove"));
+        pendingRemovedFamilyIds.forEach((id) => markCircle(normalizeId("family", id), "v2-pending-remove"));
+    }
 
     type GhostSpec = {
         x: number;
@@ -277,6 +301,7 @@
     }
 
     function handlePersonSelected(person: PersonDescription) {
+        if (pendingRemovedPersonIds.has(person.id)) return;
         personEditModal?.showPersonDetails({
             description: person,
             pin: pinnedPeople?.isPinned(person.id) ?? false,
@@ -286,6 +311,7 @@
     function handleFamilySelected(family: FamilyDescription) {
         const tempId = family.id;
         if (stubFamilies.has(tempId)) return;
+        if (pendingRemovedFamilyIds.has(tempId)) return;
         selectedFamilyEl = document.getElementById(normalizeId("family", tempId));
         selectedFamilyId = tempId;
         familySheetOpen = true;
@@ -320,11 +346,12 @@
     function handleCreateFamilyFromStub(payload: FamilyFromStubPayload) {
         const anchor: PersonArg = { type: "ExistingPerson", id: payload.anchorPersonId };
         const { parents, children } = STUB_FAMILY_LAYOUT[`${payload.anchorRole}-${payload.action}`](anchor, payloadOther(payload));
-        controller.createFamily(parents, children);
 
         const next = new Map(stubFamilies);
         next.delete(payload.stubId);
         stubFamilies = next;
+
+        controller.createFamily(parents, children, { silent: true }).catch(() => {});
     }
 
     function appendToFamily(familyId: string, action: GhostFamilyAction, person: PersonArg) {
@@ -333,7 +360,39 @@
         const asArgs = (ids: string[]): PersonArg[] => ids.map((id) => ({ type: "ExistingPerson", id }));
         const parents = action === "addParent" ? [...asArgs(family.parents), person] : asArgs(family.parents);
         const children = action === "addChild" ? [...asArgs(family.children), person] : asArgs(family.children);
-        controller.updateFamily(familyId, parents, children);
+        controller.updateFamily(familyId, parents, children, { silent: true }).catch(() => {});
+    }
+
+    function runCreateOrphanPerson(name: string) {
+        controller.createOrphanPerson({ type: "CreateNewPerson", name }, { silent: true }).catch(() => {});
+    }
+
+    function clearPendingRemovedPerson(id: string) {
+        if (!pendingRemovedPersonIds.has(id)) return;
+        const next = new Set(pendingRemovedPersonIds);
+        next.delete(id);
+        pendingRemovedPersonIds = next;
+    }
+
+    function clearPendingRemovedFamily(id: string) {
+        if (!pendingRemovedFamilyIds.has(id)) return;
+        const next = new Set(pendingRemovedFamilyIds);
+        next.delete(id);
+        pendingRemovedFamilyIds = next;
+    }
+
+    function runRemovePerson(personId: string) {
+        pendingRemovedPersonIds = new Set([...pendingRemovedPersonIds, personId]);
+        controller
+            .removePerson(personId, { silent: true })
+            .finally(() => clearPendingRemovedPerson(personId));
+    }
+
+    function runRemoveFamily(familyId: string) {
+        pendingRemovedFamilyIds = new Set([...pendingRemovedFamilyIds, familyId]);
+        controller
+            .removeFamily(familyId, { silent: true })
+            .finally(() => clearPendingRemovedFamily(familyId));
     }
 
     let currentToken = $state<string | null>(null);
@@ -438,7 +497,7 @@
             testid: "v2-name-modal",
             inputTestid: "v2-name-input",
             confirmTestid: "v2-name-confirm",
-            onaccept: (name) => controller.createOrphanPerson({ type: "CreateNewPerson", name }),
+            onaccept: (name) => runCreateOrphanPerson(name),
         });
     }
 
@@ -459,7 +518,7 @@
             confirmLabel: $t("common.delete"),
             danger: true,
             testid: "v2-remove-family-modal",
-            onaccept: () => controller.removeFamily(familyId),
+            onaccept: () => runRemoveFamily(familyId),
         });
     }
 
@@ -471,7 +530,7 @@
             danger: true,
             testid: "v2-remove-person-modal",
             onaccept: () => {
-                controller.removePerson(payload.id);
+                runRemovePerson(payload.id);
                 personEditModal?.dismiss();
             },
         });
@@ -808,6 +867,18 @@
     :global(.stub-family) {
         stroke-dasharray: 6 3;
         stroke: #6c757d;
+    }
+
+    :global(.v2-pending-remove) {
+        stroke-dasharray: 4 4;
+        stroke: #dc3545;
+        opacity: 0.45;
+        animation: v2-pending-pulse 1.2s ease-in-out infinite;
+    }
+
+    @keyframes v2-pending-pulse {
+        0%, 100% { stroke-opacity: 1; }
+        50% { stroke-opacity: 0.35; }
     }
 
     :global(.v2-ghost-mount) {

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -367,32 +367,29 @@
         controller.createOrphanPerson({ type: "CreateNewPerson", name }, { silent: true }).catch(() => {});
     }
 
-    function clearPendingRemovedPerson(id: string) {
-        if (!pendingRemovedPersonIds.has(id)) return;
-        const next = new Set(pendingRemovedPersonIds);
-        next.delete(id);
-        pendingRemovedPersonIds = next;
+    function setWith<T>(s: Set<T>, v: T): Set<T> {
+        return s.has(v) ? s : new Set([...s, v]);
     }
 
-    function clearPendingRemovedFamily(id: string) {
-        if (!pendingRemovedFamilyIds.has(id)) return;
-        const next = new Set(pendingRemovedFamilyIds);
-        next.delete(id);
-        pendingRemovedFamilyIds = next;
+    function setWithout<T>(s: Set<T>, v: T): Set<T> {
+        if (!s.has(v)) return s;
+        const next = new Set(s);
+        next.delete(v);
+        return next;
     }
 
     function runRemovePerson(personId: string) {
-        pendingRemovedPersonIds = new Set([...pendingRemovedPersonIds, personId]);
+        pendingRemovedPersonIds = setWith(pendingRemovedPersonIds, personId);
         controller
             .removePerson(personId, { silent: true })
-            .finally(() => clearPendingRemovedPerson(personId));
+            .finally(() => { pendingRemovedPersonIds = setWithout(pendingRemovedPersonIds, personId); });
     }
 
     function runRemoveFamily(familyId: string) {
-        pendingRemovedFamilyIds = new Set([...pendingRemovedFamilyIds, familyId]);
+        pendingRemovedFamilyIds = setWith(pendingRemovedFamilyIds, familyId);
         controller
             .removeFamily(familyId, { silent: true })
-            .finally(() => clearPendingRemovedFamily(familyId));
+            .finally(() => { pendingRemovedFamilyIds = setWithout(pendingRemovedFamilyIds, familyId); });
     }
 
     let currentToken = $state<string | null>(null);


### PR DESCRIPTION
## Summary
- Edit-mode mutations in v2 (`createOrphanPerson`, `createFamily`, `updateFamily`, `removeFamily`, `removePerson`) now run silently — no global overlay, canvas stays mounted, D3 force simulation keeps ticking.
- `selectStemma` skips the overlay when the requested id matches the currently loaded one; the existing `mergeData` D3 join already preserves positions via session/layout cache.
- Pending removals show a dashed red pulse on the affected node/family until the backend confirms; success or failure both clear the marker via `.finally`.

Closes #144

## Test plan
- [x] `npm test` (frontend jest, 140 tests)
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm test` (e2e Playwright, 21 tests) — run before final simplify; behavior of the simplify-only commit is mechanically identical
- [ ] Manual: v2 edit mode → add person, add family, remove person, remove family. Confirm no global spinner, simulation keeps running, removed nodes pulse red until backend confirms.
- [ ] Manual: switch stemma to a different id → overlay shown. Re-select same stemma → no overlay, graph merges in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)