### PR TITLE
Backend: LinkPersonsRequest for drag-connect linking (#149)

### DIFF
--- a/backend/src/stemma/apis/request_handler.py
+++ b/backend/src/stemma/apis/request_handler.py
@@ -12,6 +12,7 @@ from stemma.domain.requests import (
     DeletePersonRequest,
     DeleteStemmaRequest,
     GetStemmaRequest,
+    LinkPersonsRequest,
     ListDescribeStemmasRequest,
     RenameStemmaRequest,
     Request,
@@ -76,6 +77,8 @@ class RequestHandler:
                 return self._update_person(user, request)
             case CreateOrphanPersonRequest():
                 return self._create_orphan_person(user, request)
+            case LinkPersonsRequest():
+                return self._link_persons(user, request)
             case CloneStemmaRequest():
                 return self._clone_stemma(user, request)
             case RenameStemmaRequest():
@@ -143,6 +146,15 @@ class RequestHandler:
     def _create_orphan_person(self, user: User, request: CreateOrphanPersonRequest) -> Stemma:
         return self._storage.create_orphan_person(
             user.user_id, request.stemma_id, request.person_descr
+        )
+
+    def _link_persons(self, user: User, request: LinkPersonsRequest) -> Stemma:
+        return self._storage.link_persons(
+            user.user_id,
+            request.stemma_id,
+            request.from_person_id,
+            request.to_person_id,
+            request.role,
         )
 
     def _create_invitation_token(

--- a/backend/src/stemma/domain/errors.py
+++ b/backend/src/stemma/domain/errors.py
@@ -91,6 +91,24 @@ class UnsupportedPhotoType(StemmaError):
     type: Literal["UnsupportedPhotoType"] = "UnsupportedPhotoType"
 
 
+@dataclass(config=DOMAIN_CONFIG)
+class AmbiguousLinkTarget(StemmaError):
+    person_id: str
+    type: Literal["AmbiguousLinkTarget"] = "AmbiguousLinkTarget"
+
+
+@dataclass(config=DOMAIN_CONFIG)
+class SpouseLinkAlreadyExists(StemmaError):
+    family_id: str
+    type: Literal["SpouseLinkAlreadyExists"] = "SpouseLinkAlreadyExists"
+
+
+@dataclass(config=DOMAIN_CONFIG)
+class TooManyParents(StemmaError):
+    family_id: str
+    type: Literal["TooManyParents"] = "TooManyParents"
+
+
 StemmaErrorUnion = Annotated[
     UnknownError
     | RequestDeserializationProblem
@@ -105,6 +123,9 @@ StemmaErrorUnion = Annotated[
     | InvalidInviteToken
     | ForeignInviteToken
     | StemmaHasCycles
-    | UnsupportedPhotoType,
+    | UnsupportedPhotoType
+    | AmbiguousLinkTarget
+    | SpouseLinkAlreadyExists
+    | TooManyParents,
     Discriminator("type"),
 ]

--- a/backend/src/stemma/domain/requests.py
+++ b/backend/src/stemma/domain/requests.py
@@ -130,6 +130,18 @@ class CreateOrphanPersonRequest:
     type: Literal["CreateOrphanPersonRequest"] = "CreateOrphanPersonRequest"
 
 
+LinkRole = Literal["spouse", "parent", "child"]
+
+
+@dataclass(frozen=True, config=DOMAIN_CONFIG)
+class LinkPersonsRequest:
+    stemma_id: str
+    from_person_id: str
+    to_person_id: str
+    role: LinkRole
+    type: Literal["LinkPersonsRequest"] = "LinkPersonsRequest"
+
+
 @dataclass(frozen=True, config=DOMAIN_CONFIG)
 class RequestPhotoUploadUrlRequest:
     stemma_id: str
@@ -161,6 +173,7 @@ Request = Annotated[
     | DeletePersonRequest
     | UpdatePersonRequest
     | CreateOrphanPersonRequest
+    | LinkPersonsRequest
     | RequestPhotoUploadUrlRequest
     | SetPersonPhotoRequest,
     Discriminator("type"),

--- a/backend/src/stemma/storage/storage_service.py
+++ b/backend/src/stemma/storage/storage_service.py
@@ -11,14 +11,23 @@ from stemma.domain.errors import (
     AccessToFamilyDenied,
     AccessToPersonDenied,
     AccessToStemmaDenied,
+    AmbiguousLinkTarget,
     ChildAlreadyBelongsToFamily,
     DuplicatedIds,
     IncompleteFamily,
     IsNotTheOnlyStemmaOwner,
     NoSuchPersonId,
+    SpouseLinkAlreadyExists,
     StemmaHasCycles,
+    TooManyParents,
 )
-from stemma.domain.requests import CreateFamily, CreateNewPerson, ExistingPerson, PersonDefinition
+from stemma.domain.requests import (
+    CreateFamily,
+    CreateNewPerson,
+    ExistingPerson,
+    LinkRole,
+    PersonDefinition,
+)
 from stemma.domain.responses import FamilyDescription, PersonDescription, Stemma, StemmaDescription
 from stemma.domain.user import User
 from stemma.seed.kings_of_europe import SeedStemma
@@ -275,6 +284,32 @@ class StorageService:
         snapshot = self._load_snapshot(stemma_id)
         self._require_family_access(snapshot, user_id, family_id)
         self._delete_family(stemma_id, family_id, snapshot.family_owners)
+
+    def link_persons(
+        self, user_id: str, stemma_id: str, from_person_id: str, to_person_id: str, role: LinkRole
+    ) -> Stemma:
+        snapshot = self._load_snapshot(stemma_id)
+        self._require_stemma_access(snapshot, user_id)
+        for pid in (from_person_id, to_person_id):
+            if pid not in snapshot.people:
+                raise NoSuchPersonId(id=pid)
+            if (pid, user_id) not in snapshot.person_owners:
+                raise AccessToPersonDenied(person_id=pid)
+
+        if role == "spouse":
+            target_family_id, family = _plan_spouse_link(from_person_id, to_person_id, snapshot)
+        elif role == "child":
+            target_family_id, family = _plan_child_link(from_person_id, to_person_id, snapshot)
+        else:
+            target_family_id, family = _plan_parent_link(from_person_id, to_person_id, snapshot)
+
+        if target_family_id is not None:
+            self._require_family_access(snapshot, user_id, target_family_id)
+
+        stemma, _ = self._apply_family_change(
+            snapshot, user_id, target_family_id=target_family_id, family=family
+        )
+        return stemma
 
     # ---------- people ----------
 
@@ -697,6 +732,72 @@ def _find_family_with_existing_parents(
         if set(fam.parents) == target:
             return fam.id
     return None
+
+
+def _plan_spouse_link(
+    from_pid: str, to_pid: str, snapshot: _StemmaSnapshot
+) -> tuple[str | None, CreateFamily]:
+    for fam in snapshot.families.values():
+        if set(fam.parents) == {from_pid, to_pid}:
+            raise SpouseLinkAlreadyExists(family_id=fam.id)
+    family = CreateFamily(
+        parent1=ExistingPerson(id=from_pid),
+        parent2=ExistingPerson(id=to_pid),
+        children=[],
+    )
+    return None, family
+
+
+def _plan_child_link(
+    from_pid: str, to_pid: str, snapshot: _StemmaSnapshot
+) -> tuple[str | None, CreateFamily]:
+    family_ids = [f.id for f in snapshot.families.values() if from_pid in f.parents]
+    if len(family_ids) > 1:
+        raise AmbiguousLinkTarget(person_id=from_pid)
+    if not family_ids:
+        family = CreateFamily(
+            parent1=ExistingPerson(id=from_pid),
+            parent2=None,
+            children=[ExistingPerson(id=to_pid)],
+        )
+        return None, family
+    existing = snapshot.families[family_ids[0]]
+    parents_def: list[PersonDefinition] = [ExistingPerson(id=p) for p in existing.parents]
+    children_def: list[PersonDefinition] = [ExistingPerson(id=c) for c in existing.children]
+    children_def.append(ExistingPerson(id=to_pid))
+    family = CreateFamily(
+        parent1=parents_def[0] if parents_def else None,
+        parent2=parents_def[1] if len(parents_def) > 1 else None,
+        children=children_def,
+    )
+    return existing.id, family
+
+
+def _plan_parent_link(
+    from_pid: str, to_pid: str, snapshot: _StemmaSnapshot
+) -> tuple[str | None, CreateFamily]:
+    family_ids = [f.id for f in snapshot.families.values() if from_pid in f.children]
+    if len(family_ids) > 1:
+        raise AmbiguousLinkTarget(person_id=from_pid)
+    if not family_ids:
+        family = CreateFamily(
+            parent1=ExistingPerson(id=to_pid),
+            parent2=None,
+            children=[ExistingPerson(id=from_pid)],
+        )
+        return None, family
+    existing = snapshot.families[family_ids[0]]
+    if len(existing.parents) >= 2:
+        raise TooManyParents(family_id=existing.id)
+    parents_def: list[PersonDefinition] = [ExistingPerson(id=p) for p in existing.parents]
+    parents_def.append(ExistingPerson(id=to_pid))
+    children_def: list[PersonDefinition] = [ExistingPerson(id=c) for c in existing.children]
+    family = CreateFamily(
+        parent1=parents_def[0],
+        parent2=parents_def[1] if len(parents_def) > 1 else None,
+        children=children_def,
+    )
+    return existing.id, family
 
 
 def _make_person_row(pid: str, definition: CreateNewPerson) -> _PersonRow:

--- a/backend/tests/test_codec.py
+++ b/backend/tests/test_codec.py
@@ -7,6 +7,7 @@ from stemma.domain.requests import (
     CreateNewPerson,
     CreateOrphanPersonRequest,
     ExistingPerson,
+    LinkPersonsRequest,
     RequestPhotoUploadUrlRequest,
     SetPersonPhotoRequest,
     UpdatePersonRequest,
@@ -116,6 +117,22 @@ def test_encode_error_with_fields() -> None:
 def test_encode_error_without_fields() -> None:
     assert encode_error(IncompleteFamily()) == {"type": "IncompleteFamily"}
     assert encode_error(InvalidInviteToken()) == {"type": "InvalidInviteToken"}
+
+
+def test_decode_link_persons_request() -> None:
+    payload = {
+        "type": "LinkPersonsRequest",
+        "stemmaId": "s1",
+        "fromPersonId": "p1",
+        "toPersonId": "p2",
+        "role": "spouse",
+    }
+    request = decode_request(payload)
+    assert isinstance(request, LinkPersonsRequest)
+    assert request.stemma_id == "s1"
+    assert request.from_person_id == "p1"
+    assert request.to_person_id == "p2"
+    assert request.role == "spouse"
 
 
 def test_decode_request_photo_upload_url_request() -> None:

--- a/backend/tests/test_link_persons.py
+++ b/backend/tests/test_link_persons.py
@@ -1,0 +1,157 @@
+import pytest
+
+from stemma.domain.errors import (
+    AccessToPersonDenied,
+    AmbiguousLinkTarget,
+    NoSuchPersonId,
+    SpouseLinkAlreadyExists,
+    StemmaHasCycles,
+    TooManyParents,
+)
+from stemma.storage.storage_service import StorageService
+
+from tests.factories import (
+    create_james,
+    create_jane,
+    create_jill,
+    create_john,
+    create_july,
+    create_josh,
+    existing,
+    family,
+    render_families,
+)
+
+
+def _orphan_ids(storage: StorageService, user_id: str, sid: str, *definitions) -> list[str]:
+    ids: list[str] = []
+    for definition in definitions:
+        before = {p.id for p in storage.stemma(user_id, sid).people}
+        stemma = storage.create_orphan_person(user_id, sid, definition)
+        new_ids = [p.id for p in stemma.people if p.id not in before]
+        assert len(new_ids) == 1
+        ids.append(new_ids[0])
+    return ids
+
+
+def test_link_spouse_creates_new_family(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    [jane_id, john_id] = _orphan_ids(storage, user.user_id, sid, create_jane, create_john)
+
+    storage.link_persons(user.user_id, sid, jane_id, john_id, "spouse")
+
+    stemma = storage.stemma(user.user_id, sid)
+    assert render_families(stemma) == ["(Jane, John) parentsOf ()"]
+
+
+def test_link_spouse_rejects_existing_pair(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    _, fam = storage.create_family(user.user_id, sid, family(create_jane, create_john)(create_jill))
+    jane_id, john_id = fam.parents
+    with pytest.raises(SpouseLinkAlreadyExists) as exc:
+        storage.link_persons(user.user_id, sid, jane_id, john_id, "spouse")
+    assert exc.value.family_id == fam.id
+
+
+def test_link_child_to_couple_appends_to_existing_family(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    _, fam = storage.create_family(user.user_id, sid, family(create_jane, create_john)(create_jill))
+    jane_id = fam.parents[0]
+    [josh_id] = _orphan_ids(storage, user.user_id, sid, create_josh)
+
+    storage.link_persons(user.user_id, sid, jane_id, josh_id, "child")
+
+    stemma = storage.stemma(user.user_id, sid)
+    assert render_families(stemma) == ["(Jane, John) parentsOf (Jill, Josh)"]
+
+
+def test_link_child_creates_new_family_for_orphan_parent(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    [jane_id, jill_id] = _orphan_ids(storage, user.user_id, sid, create_jane, create_jill)
+
+    storage.link_persons(user.user_id, sid, jane_id, jill_id, "child")
+
+    stemma = storage.stemma(user.user_id, sid)
+    assert render_families(stemma) == ["(Jane) parentsOf (Jill)"]
+
+
+def test_link_child_ambiguous_when_parent_in_multiple_families(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    _, f1 = storage.create_family(user.user_id, sid, family(create_jane, create_john)(create_jill))
+    jane_id = f1.parents[0]
+    storage.create_family(user.user_id, sid, family(existing(jane_id), create_james)(create_july))
+    [josh_id] = _orphan_ids(storage, user.user_id, sid, create_josh)
+
+    with pytest.raises(AmbiguousLinkTarget) as exc:
+        storage.link_persons(user.user_id, sid, jane_id, josh_id, "child")
+    assert exc.value.person_id == jane_id
+
+
+def test_link_parent_to_orphan_child_creates_new_family(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    [jill_id, jane_id] = _orphan_ids(storage, user.user_id, sid, create_jill, create_jane)
+
+    storage.link_persons(user.user_id, sid, jill_id, jane_id, "parent")
+
+    stemma = storage.stemma(user.user_id, sid)
+    assert render_families(stemma) == ["(Jane) parentsOf (Jill)"]
+
+
+def test_link_parent_adds_second_parent_to_single_parent_family(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    _, fam = storage.create_family(user.user_id, sid, family(create_jane)(create_jill))
+    jill_id = fam.children[0]
+    [john_id] = _orphan_ids(storage, user.user_id, sid, create_john)
+
+    storage.link_persons(user.user_id, sid, jill_id, john_id, "parent")
+
+    stemma = storage.stemma(user.user_id, sid)
+    assert render_families(stemma) == ["(Jane, John) parentsOf (Jill)"]
+
+
+def test_link_parent_rejects_when_family_already_has_two_parents(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    _, fam = storage.create_family(user.user_id, sid, family(create_jane, create_john)(create_jill))
+    jill_id = fam.children[0]
+    [james_id] = _orphan_ids(storage, user.user_id, sid, create_james)
+
+    with pytest.raises(TooManyParents) as exc:
+        storage.link_persons(user.user_id, sid, jill_id, james_id, "parent")
+    assert exc.value.family_id == fam.id
+
+
+def test_link_persons_rejects_cycle(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    _, f1 = storage.create_family(user.user_id, sid, family(create_jane)(create_jill))
+    jane_id = f1.parents[0]
+    jill_id = f1.children[0]
+
+    with pytest.raises(StemmaHasCycles):
+        storage.link_persons(user.user_id, sid, jane_id, jill_id, "parent")
+
+
+def test_link_persons_requires_known_person(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user@test.com")
+    sid = storage.create_stemma(user.user_id, "s")
+    [jane_id] = _orphan_ids(storage, user.user_id, sid, create_jane)
+    with pytest.raises(NoSuchPersonId):
+        storage.link_persons(user.user_id, sid, jane_id, "missing-id", "spouse")
+
+
+def test_link_persons_requires_person_ownership(storage: StorageService) -> None:
+    owner = storage.get_or_create_user("owner@test.com")
+    stranger = storage.get_or_create_user("stranger@test.com")
+    sid = storage.create_stemma(owner.user_id, "s")
+    [jane_id, john_id] = _orphan_ids(storage, owner.user_id, sid, create_jane, create_john)
+    storage.chown(stranger.user_id, sid, jane_id)
+    with pytest.raises(AccessToPersonDenied):
+        storage.link_persons(stranger.user_id, sid, jane_id, john_id, "spouse")


### PR DESCRIPTION
## Summary
- Adds \`LinkPersonsRequest { stemmaId, fromPersonId, toPersonId, role }\` with \`spouse | parent | child\` roles. Backend builds the family node implicitly.
- Reuses the existing \`_apply_family_change\` plumbing (cycle detection, child-conflict checks, ownership grants).
- New errors: \`AmbiguousLinkTarget\`, \`SpouseLinkAlreadyExists\`, \`TooManyParents\`.

## Semantics
- \`spouse\`: new family with both as parents; rejects if the pair already shares a family.
- \`child\` (from = parent, to = child): if \`from\` is a parent in exactly 1 family → append \`to\` as child; if 0 → new family; if >1 → \`AmbiguousLinkTarget\`.
- \`parent\` (from = child, to = parent): if \`from\` is a child in exactly 1 family → add \`to\` as second parent (rejects \`TooManyParents\` if full); if 0 → new family.

## Scope
Backend slice of #149. Frontend bulk-add tray, drag-connect UI, ghost-flow trim, and removal of \`stubFamilies\` / \`augmentedStemma\` will follow in a separate PR.

## Test plan
- [x] \`uv run pytest\` (86 passed, incl. 11 new \`test_link_persons\`)
- [x] \`uv run ruff check\`
- [x] \`uv run pyright\`
- [ ] Manual smoke after frontend wiring lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)