### PR TITLE
Run e2e Playwright tests in parallel (closes #161)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   expect: {
     timeout: 20_000
   },
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  workers: process.env.CI ? 4 : undefined,
   reporter: "list",
   use: {
     baseURL: "http://127.0.0.1:4173",

--- a/e2e/tests/_fixtures.ts
+++ b/e2e/tests/_fixtures.ts
@@ -1,0 +1,18 @@
+import { test as base, type Page } from "@playwright/test";
+
+// Each test runs against its own bypass-auth user so the shared DynamoDB table
+// can host parallel workers without cross-test data collisions. The frontend
+// reads window.__STEMMA_E2E_USER__ when E2E_AUTO_LOGIN=1 (see App.svelte /
+// V2App.svelte) and sends it as the bearer token; the backend's
+// AllowAnyTokenVerifier treats anything containing '@' as the email itself.
+export const test = base.extend<{ page: Page }>({
+  page: async ({ page }, use, testInfo) => {
+    const token = `e2e-${testInfo.testId}@stemma.local`;
+    await page.addInitScript((t) => {
+      (window as unknown as { __STEMMA_E2E_USER__: string }).__STEMMA_E2E_USER__ = t;
+    }, token);
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/tests/arrows.spec.ts
+++ b/e2e/tests/arrows.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./_fixtures";
 import { waitForFirstLoginSeeded } from "./_seeded";
 
 test("relationship arrows are rendered on a populated stemma", async ({ page }) => {

--- a/e2e/tests/dropdown_align.spec.ts
+++ b/e2e/tests/dropdown_align.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./_fixtures";
 import { SEEDED_STEMMA_COUNT, waitForFirstLoginSeeded } from "./_seeded";
 
 const NAMES = ["A", "A very long stemma name that should ellipsize quite far", "Middle"];

--- a/e2e/tests/person_modal_screenshot.spec.ts
+++ b/e2e/tests/person_modal_screenshot.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./_fixtures";
 
 const SAMPLE_PHOTO = "tests/fixtures/sample_photo.jpg";
 

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./_fixtures";
 
 test("loads app with e2e auth bypass", async ({ page }) => {
   await page.goto("/");

--- a/e2e/tests/v2_bootstrap.spec.ts
+++ b/e2e/tests/v2_bootstrap.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./_fixtures";
 
 test("v2 ghost flow: orphan person → person ghost → stub family → family ghost → backend create", async ({ page }) => {
   await page.goto("/v2");

--- a/e2e/tests/v2_modal_backdrop_dismiss.spec.ts
+++ b/e2e/tests/v2_modal_backdrop_dismiss.spec.ts
@@ -1,7 +1,5 @@
-import { test, expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
-
-test.describe.configure({ mode: "serial" });
+import { test, expect } from "./_fixtures";
 
 const DESKTOP = { width: 1280, height: 800 };
 

--- a/e2e/tests/v2_modals_mobile_screenshots.spec.ts
+++ b/e2e/tests/v2_modals_mobile_screenshots.spec.ts
@@ -1,6 +1,4 @@
-import { test, expect } from "@playwright/test";
-
-test.describe.configure({ mode: "serial" });
+import { test, expect } from "./_fixtures";
 
 const MOBILE = { width: 390, height: 844 };
 

--- a/e2e/tests/v2_modals_screenshots.spec.ts
+++ b/e2e/tests/v2_modals_screenshots.spec.ts
@@ -1,6 +1,4 @@
-import { test, expect } from "@playwright/test";
-
-test.describe.configure({ mode: "serial" });
+import { test, expect } from "./_fixtures";
 
 const DESKTOP = { width: 1280, height: 800 };
 

--- a/e2e/tests/v2_screenshots.spec.ts
+++ b/e2e/tests/v2_screenshots.spec.ts
@@ -1,6 +1,4 @@
-import { test, expect } from "@playwright/test";
-
-test.describe.configure({ mode: "serial" });
+import { test, expect } from "./_fixtures";
 
 const DESKTOP = { width: 1280, height: 800 };
 const MOBILE = { width: 390, height: 844 };

--- a/e2e/tests/v2_search.spec.ts
+++ b/e2e/tests/v2_search.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./_fixtures";
 
 test("v2 search: find person, focus tree, handle no-match", async ({ page }) => {
   await page.goto("/v2");

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -162,7 +162,8 @@
     onMount(() => {
         if (e2eAutoLoginEnabled) {
             e2eMode = true;
-            handleSignIn({ id_token: "e2e-user@stemma.local" } as User);
+            const override = (window as unknown as { __STEMMA_E2E_USER__?: string }).__STEMMA_E2E_USER__;
+            handleSignIn({ id_token: override || "e2e-user@stemma.local" } as User);
             return;
         }
 

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -547,7 +547,8 @@
     onMount(() => {
         if (e2eAutoLoginEnabled) {
             e2eMode = true;
-            handleSignIn({ id_token: "e2e-user@stemma.local" } as User);
+            const override = (window as unknown as { __STEMMA_E2E_USER__?: string }).__STEMMA_E2E_USER__;
+            handleSignIn({ id_token: override || "e2e-user@stemma.local" } as User);
         } else {
             initializeGoogleAuth(google_client_id).catch((err) => console.error("Google Identity init failed", err));
 


### PR DESCRIPTION
## Summary
- Per-test bypass-auth user isolation via Playwright fixture (`e2e/tests/_fixtures.ts`): `addInitScript` sets `window.__STEMMA_E2E_USER__` to `e2e-{testId}@stemma.local`; frontend `App.svelte` / `V2App.svelte` read it as the auto-login token. Backend `AllowAnyTokenVerifier` treats `@`-containing tokens as the email, so each test ends up in its own DynamoDB user namespace.
- `playwright.config.ts`: `fullyParallel: true`, `workers: process.env.CI ? 4 : undefined`.
- Removed redundant `test.describe.configure({ mode: "serial" })` from four spec files where the only reason for serial was the shared-user collision now solved by the fixture.

## Result
- 3 consecutive local CI-mode runs: 1.0m / 57.5s / 1.0m (was ~4m serial). All 21 tests pass.

## Test plan
- [ ] CI green on this branch
- [ ] CI duration drops under 2 min for e2e job

🤖 Generated with [Claude Code](https://claude.com/claude-code)