### PR TITLE
Pan-mode toggle for v2 edit mode

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -259,6 +259,8 @@ export const en: Record<string, string> = {
     'v2.placeholderName': '?',
     'v2.createChildTitle': 'Create child',
     'v2.createChildLabel': 'Name',
+    'v2.panModeOn': 'Pan canvas',
+    'v2.panModeOff': 'Exit pan mode',
 };
 
 export const ru: Record<string, string> = {
@@ -488,6 +490,8 @@ export const ru: Record<string, string> = {
     'v2.placeholderName': '?',
     'v2.createChildTitle': 'Создать потомка',
     'v2.createChildLabel': 'Имя',
+    'v2.panModeOn': 'Перемещать холст',
+    'v2.panModeOff': 'Выйти из режима перемещения',
 };
 
 const dictionaries: Record<Locale, Record<string, string>> = { en, ru };

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -62,6 +62,9 @@
     type PendingFamily = { tempId: string; parents: string[]; children: string[] };
 
     let editMode = $state(false);
+    let panMode = $state(false);
+    let spacePan = $state(false);
+    const panActive = $derived(editMode && (panMode || spacePan));
     let pendingRemovedPersonIds = $state<Set<string>>(new Set());
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let pendingAdds = $state<PendingAdd[]>([]);
@@ -454,6 +457,7 @@
 
         const onMouseDown = (e: MouseEvent) => {
             if (e.button !== 0) return;
+            if (panActive) return;
             const targetG = (e.target as Element | null)?.closest?.("g[id^='person_'], g[id^='family_']") as SVGGElement | null;
             let source: SourceRef;
             let center: { x: number; y: number };
@@ -642,6 +646,56 @@
             window.removeEventListener("mouseup", onMouseUp);
             window.removeEventListener("keydown", onKeyDown);
             cleanup();
+        };
+    });
+
+    $effect(() => {
+        if (!editMode) {
+            panMode = false;
+            spacePan = false;
+        }
+    });
+
+    $effect(() => {
+        if (!editMode) return;
+        const isTypingTarget = (t: EventTarget | null): boolean => {
+            if (!(t instanceof HTMLElement)) return false;
+            const tag = t.tagName;
+            return tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable;
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.code !== "Space" || e.repeat) return;
+            if (isTypingTarget(e.target)) return;
+            spacePan = true;
+            e.preventDefault();
+        };
+        const onKeyUp = (e: KeyboardEvent) => {
+            if (e.code !== "Space") return;
+            spacePan = false;
+        };
+        window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("keyup", onKeyUp);
+        return () => {
+            window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("keyup", onKeyUp);
+            spacePan = false;
+        };
+    });
+
+    $effect(() => {
+        if (!panActive) {
+            document.body.classList.remove("v2-pan-armed", "v2-pan-dragging");
+            return;
+        }
+        document.body.classList.add("v2-pan-armed");
+        const onDown = () => document.body.classList.add("v2-pan-dragging");
+        const onUp = () => document.body.classList.remove("v2-pan-dragging");
+        window.addEventListener("mousedown", onDown);
+        window.addEventListener("mouseup", onUp);
+        return () => {
+            window.removeEventListener("mousedown", onDown);
+            window.removeEventListener("mouseup", onUp);
+            document.body.classList.remove("v2-pan-armed", "v2-pan-dragging");
         };
     });
 
@@ -950,8 +1004,10 @@
             <div class="v2-bottom-right">
                 <V2Fab
                     {editMode}
+                    {panMode}
                     disabled={isWorking}
                     oneditToggle={() => { editMode = !editMode; }}
+                    onpanToggle={() => { panMode = !panMode; }}
                     onaddPerson={openAddPerson}
                 />
             </div>
@@ -1255,6 +1311,16 @@
     :global(body.v2-linking),
     :global(body.v2-linking *) {
         cursor: crosshair !important;
+    }
+
+    :global(body.v2-pan-armed),
+    :global(body.v2-pan-armed *) {
+        cursor: grab !important;
+    }
+
+    :global(body.v2-pan-dragging),
+    :global(body.v2-pan-dragging *) {
+        cursor: grabbing !important;
     }
 
     .v2-drag-tip {

--- a/frontend/src/v2/components/V2Fab.svelte
+++ b/frontend/src/v2/components/V2Fab.svelte
@@ -3,16 +3,30 @@
 
     type Props = {
         editMode: boolean;
+        panMode: boolean;
         disabled: boolean;
         oneditToggle?: () => void;
+        onpanToggle?: () => void;
         onaddPerson?: () => void;
     };
 
-    let { editMode, disabled, oneditToggle, onaddPerson }: Props = $props();
+    let { editMode, panMode, disabled, oneditToggle, onpanToggle, onaddPerson }: Props = $props();
 </script>
 
 <div class="v2-fab-cluster">
     {#if editMode}
+        <button
+            type="button"
+            class="fab fab-secondary"
+            class:active={panMode}
+            aria-label={panMode ? $t("v2.panModeOff") : $t("v2.panModeOn")}
+            aria-pressed={panMode}
+            disabled={disabled}
+            onclick={() => onpanToggle?.()}
+            data-testid="v2-pan-fab"
+        >
+            <i class="bi bi-arrows-move"></i>
+        </button>
         <button
             type="button"
             class="fab fab-secondary"
@@ -97,6 +111,16 @@
 
     .fab-secondary:not(:disabled):hover {
         box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+    }
+
+    .fab-secondary.active {
+        background: #495057;
+        color: #fff;
+        box-shadow: 0 4px 12px rgba(73, 80, 87, 0.4);
+    }
+
+    .fab-secondary.active:not(:disabled):hover {
+        box-shadow: 0 6px 18px rgba(73, 80, 87, 0.5);
     }
 
     @media (max-width: 767.98px) {


### PR DESCRIPTION
Closes #157.

## Summary
- Adds a pan-mode FAB above the edit toggle (visible only in edit mode). Toggling it swaps the canvas drag behavior from link-gesture to d3-zoom pan.
- Holding **Space** while in edit mode temporarily enables pan-mode (Figma-style); releasing restores link mode. Typing in inputs is ignored.
- Link-gesture mousedown early-returns when pan-mode is active, letting d3-zoom (already attached to `#chart` via `svg.call(zoomHandler)` in `FullStemma`) handle the drag.
- Cursor: `grab` while pan-armed, `grabbing` while mouse is down.
- Pan-mode auto-resets when leaving edit mode.
- i18n: `v2.panModeOn` / `v2.panModeOff` in both en and ru.

## Test plan
- [ ] In v2 edit mode, toggle pan-mode → canvas drag pans the graph; node mousedown no longer starts a link gesture.
- [ ] Toggle pan-mode off → link gesture works again.
- [ ] Hold Space in edit mode → cursor flips to grab and pan works; release Space → link mode resumes.
- [ ] Space-hold while focused in a text input (e.g. prompt modal) inserts a space and does not trigger pan.
- [ ] Leaving edit mode resets pan-mode toggle.
- [ ] Touch pan still works on mobile in edit mode when pan-mode is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)