### PR TITLE
v2 edit-mode: open PersonDetails modal before drag-creating a person

### DIFF
--- a/e2e/tests/v2_drag_ux.spec.ts
+++ b/e2e/tests/v2_drag_ux.spec.ts
@@ -246,6 +246,75 @@ test.describe("v2 drag tooltips", () => {
   });
 });
 
+test("v2 family→empty release opens person details modal and creates child", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const ts = Date.now();
+  const a = `Pat${ts}`;
+  const b = `Quinn${ts}`;
+  const child = `Rita${ts}`;
+  await addOrphan(page, a);
+  await addOrphan(page, b);
+  const pat = await nodeByText(page, a);
+  await pressAndDrag(page, pat.cx, pat.cy, pat.cx + 280, pat.cy);
+  await page.mouse.up();
+  const quinn = await nodeByText(page, b);
+  const fc = await familyCenter(page);
+  await dropPersonOnFamily(page, quinn, fc);
+  await waitForRealFamily(page);
+  const fc2 = await familyCenter(page);
+  await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
+  await page.mouse.up();
+  const modal = page.getByTestId("v2-person-details-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  const nameInput = page.getByTestId("v2-person-name-input");
+  await nameInput.fill(child);
+  await page.getByTestId("v2-person-create").click();
+  const committed = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${child}"`) })
+    .first();
+  await expect(committed).toBeVisible({ timeout: 15_000 });
+});
+
+test("v2 empty→family release opens person details modal and creates spouse", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const ts = Date.now();
+  const a = `Sam${ts}`;
+  const b = `Tess${ts}`;
+  const spouse = `Uma${ts}`;
+  await addOrphan(page, a);
+  await addOrphan(page, b);
+  const sam = await nodeByText(page, a);
+  await pressAndDrag(page, sam.cx, sam.cy, sam.cx + 280, sam.cy);
+  await page.mouse.up();
+  const tess = await nodeByText(page, b);
+  await pressAndDragFromFamily(page, { cx: tess.cx, cy: tess.cy });
+  await page.mouse.up();
+  await waitForRealFamily(page);
+  const fc2 = await familyCenter(page);
+  const vp = page.viewportSize();
+  const startX = vp ? vp.width - 80 : fc2.cx + 300;
+  const startY = vp ? Math.floor(vp.height / 2) : fc2.cy;
+  await pressAndDrag(page, startX, startY, fc2.cx, fc2.cy);
+  await page.mouse.up();
+  const modal = page.getByTestId("v2-person-details-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  const nameInput = page.getByTestId("v2-person-name-input");
+  await nameInput.fill(spouse);
+  await page.getByTestId("v2-person-create").click();
+  const committed = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${spouse}"`) })
+    .first();
+  await expect(committed).toBeVisible({ timeout: 15_000 });
+});
+
 test("v2 person→empty release creates stub family", async ({ page }) => {
   await page.goto("/v2");
   await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -47,6 +47,7 @@ export const en: Record<string, string> = {
     // Common buttons
     'common.cancel': 'Cancel',
     'common.save': 'Save',
+    'common.create': 'Create',
     'common.delete': 'Delete',
     'common.add': 'Add',
     'common.back': 'Back',
@@ -256,9 +257,8 @@ export const en: Record<string, string> = {
     'v2.tipCreateChild': 'Create child',
     'v2.tipAttachSpouse': 'Attach as spouse',
     'v2.tipAttachChild': 'Attach as child',
-    'v2.placeholderName': '?',
-    'v2.createChildTitle': 'Create child',
-    'v2.createChildLabel': 'Name',
+    'v2.createSpouseTitle': 'Add spouse',
+    'v2.createChildTitle': 'Add child',
     'v2.panModeOn': 'Pan canvas',
     'v2.panModeOff': 'Exit pan mode',
 };
@@ -278,6 +278,7 @@ export const ru: Record<string, string> = {
     // Common buttons
     'common.cancel': 'Отмена',
     'common.save': 'Сохранить',
+    'common.create': 'Создать',
     'common.delete': 'Удалить',
     'common.add': 'Добавить',
     'common.back': 'Назад',
@@ -487,9 +488,8 @@ export const ru: Record<string, string> = {
     'v2.tipCreateChild': 'Создать потомка',
     'v2.tipAttachSpouse': 'Присоединить супруга',
     'v2.tipAttachChild': 'Присоединить потомка',
-    'v2.placeholderName': '?',
-    'v2.createChildTitle': 'Создать потомка',
-    'v2.createChildLabel': 'Имя',
+    'v2.createSpouseTitle': 'Добавить супруга',
+    'v2.createChildTitle': 'Добавить потомка',
     'v2.panModeOn': 'Перемещать холст',
     'v2.panModeOff': 'Выйти из режима перемещения',
 };

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -2,7 +2,6 @@
     import { onMount, untrack } from "svelte";
     import { AppController, type MutationResult } from "../appController";
     import type {
-        CreateNewPerson,
         FamilyDescription,
         PersonDefinition,
         PersonDescription,
@@ -322,31 +321,24 @@
         title: string,
         pinAt?: { x: number; y: number },
     ) {
-        if (!stemmaIndex) return;
-        const family = stemmaIndex.family(familyId);
-        if (!family) return;
-        const existingParents: PersonDefinition[] = family.parents.map((id) => ({ type: "ExistingPerson", id }));
-        const existingChildren: PersonDefinition[] = family.children.map((id) => ({ type: "ExistingPerson", id }));
+        if (!stemmaIndex?.family(familyId)) return;
         personEditModal?.showCreatePerson({
             title,
             oncreate: ({ description, pin, photoUpload }) => {
-                const newPerson: CreateNewPerson = {
-                    type: "CreateNewPerson",
-                    name: description.name,
-                    ...(description.birthDate ? { birthDate: description.birthDate } : {}),
-                    ...(description.deathDate ? { deathDate: description.deathDate } : {}),
-                    ...(description.bio ? { bio: description.bio } : {}),
-                };
-                const parents = role === "parent" ? [...existingParents, newPerson] : existingParents;
-                const children = role === "child" ? [...existingChildren, newPerson] : existingChildren;
+                const family = stemmaIndex?.family(familyId);
+                if (!family) return;
+                const existingParents: PersonDefinition[] = family.parents.map((id) => ({ type: "ExistingPerson", id }));
+                const existingChildren: PersonDefinition[] = family.children.map((id) => ({ type: "ExistingPerson", id }));
+                const parents = role === "parent" ? [...existingParents, description] : existingParents;
+                const children = role === "child" ? [...existingChildren, description] : existingChildren;
                 void withPendingAdd(
-                    newPerson.name,
+                    description.name,
                     () => controller.updateFamily(familyId, parents, children, { silent: true }),
                     pinAt,
                     (newPersonIds) => {
                         const newId = newPersonIds[0];
                         if (newId && (photoUpload || pin)) {
-                            controller.savePerson(newId, newPerson, pin, photoUpload, false);
+                            controller.savePerson(newId, description, pin, photoUpload, false);
                         }
                     },
                 );

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -205,6 +205,7 @@
         name: string,
         op: () => Promise<MutationResult>,
         pinAt?: { x: number; y: number },
+        afterCommit?: (newPersonIds: string[]) => void,
     ): Promise<void> {
         const tempId = `pending-${crypto.randomUUID()}`;
         pendingAdds = [...pendingAdds, { tempId, name }];
@@ -216,6 +217,7 @@
                     stemmaChart?.setNodePosition(normalizeId("person", id), pinAt.x, pinAt.y),
                 );
             }
+            afterCommit?.(result.newPersonIds);
         } catch {
             // surfaced through controller.err
         } finally {
@@ -281,10 +283,6 @@
         controller.updateFamily(familyId, parents, children, { silent: true }).catch(() => {});
     }
 
-    function placeholderPerson(): CreateNewPerson {
-        return { type: "CreateNewPerson", name: $t("v2.placeholderName") };
-    }
-
     function spawnStubFamily(sourcePersonId: string, svgX: number, svgY: number) {
         const tempId = `pending-family-${crypto.randomUUID()}`;
         stemmaChart?.setNodePosition(normalizeId("family", tempId), svgX, svgY);
@@ -318,44 +316,39 @@
         }
     }
 
-    function createSpouseForFamily(familyId: string, pinAt?: { x: number; y: number }) {
+    function createPersonInFamily(
+        familyId: string,
+        role: "parent" | "child",
+        title: string,
+        pinAt?: { x: number; y: number },
+    ) {
         if (!stemmaIndex) return;
         const family = stemmaIndex.family(familyId);
         if (!family) return;
         const existingParents: PersonDefinition[] = family.parents.map((id) => ({ type: "ExistingPerson", id }));
         const existingChildren: PersonDefinition[] = family.children.map((id) => ({ type: "ExistingPerson", id }));
-        const newPerson = placeholderPerson();
-        void withPendingAdd(
-            newPerson.name,
-            () =>
-                controller.updateFamily(familyId, [...existingParents, newPerson], existingChildren, { silent: true }),
-            pinAt,
-        );
-    }
-
-    function openCreateChildPrompt(familyId: string, pinAt?: { x: number; y: number }) {
-        promptModal?.prompt({
-            title: $t("v2.createChildTitle"),
-            label: $t("v2.createChildLabel"),
-            confirmLabel: $t("common.add"),
-            testid: "v2-create-child-modal",
-            onaccept: (name) => {
-                if (!stemmaIndex) return;
-                const family = stemmaIndex.family(familyId);
-                if (!family) return;
-                const existingParents: PersonDefinition[] = family.parents.map((id) => ({ type: "ExistingPerson", id }));
-                const existingChildren: PersonDefinition[] = family.children.map((id) => ({ type: "ExistingPerson", id }));
-                const newChild: CreateNewPerson = { type: "CreateNewPerson", name };
+        personEditModal?.showCreatePerson({
+            title,
+            oncreate: ({ description, pin, photoUpload }) => {
+                const newPerson: CreateNewPerson = {
+                    type: "CreateNewPerson",
+                    name: description.name,
+                    ...(description.birthDate ? { birthDate: description.birthDate } : {}),
+                    ...(description.deathDate ? { deathDate: description.deathDate } : {}),
+                    ...(description.bio ? { bio: description.bio } : {}),
+                };
+                const parents = role === "parent" ? [...existingParents, newPerson] : existingParents;
+                const children = role === "child" ? [...existingChildren, newPerson] : existingChildren;
                 void withPendingAdd(
-                    name,
-                    () =>
-                        controller.updateFamily(
-                            familyId,
-                            existingParents,
-                            [...existingChildren, newChild],
-                            { silent: true },
-                        ),
+                    newPerson.name,
+                    () => controller.updateFamily(familyId, parents, children, { silent: true }),
                     pinAt,
+                    (newPersonIds) => {
+                        const newId = newPersonIds[0];
+                        if (newId && (photoUpload || pin)) {
+                            controller.savePerson(newId, newPerson, pin, photoUpload, false);
+                        }
+                    },
                 );
             },
         });
@@ -654,7 +647,7 @@
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "family") {
-                createSpouseForFamily(overInfo.ref.id, startCenter);
+                createPersonInFamily(overInfo.ref.id, "parent", $t("v2.createSpouseTitle"), startCenter);
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "person") {
@@ -663,7 +656,7 @@
             }
             if (source.kind === "family" && !overInfo && !isPendingId(source.id)) {
                 const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
-                openCreateChildPrompt(source.id, releaseSvg);
+                createPersonInFamily(source.id, "child", $t("v2.createChildTitle"), releaseSvg);
                 return;
             }
         };

--- a/frontend/src/v2/components/V2PersonDetailsModal.svelte
+++ b/frontend/src/v2/components/V2PersonDetailsModal.svelte
@@ -27,6 +27,18 @@
     } from "../../components/person_details_modal/PersonDetailsModal.svelte";
     import V2Modal from "./V2Modal.svelte";
 
+    export type CreatePersonPayload = {
+        description: {
+            type: "CreateNewPerson";
+            name: string;
+            birthDate: string | null;
+            deathDate: string | null;
+            bio: string;
+        };
+        pin: boolean;
+        photoUpload: Blob | null;
+    };
+
     type Props = {
         editMode?: boolean;
         onpersonUpdated?: (payload: UpdatePerson) => void;
@@ -42,6 +54,10 @@
     }: Props = $props();
 
     let open = $state(false);
+    let mode = $state<"view" | "create">("view");
+    let createTitle = $state<string | null>(null);
+    let activeCreateCallback: ((payload: CreatePersonPayload) => void) | null = null;
+    const isCreate = $derived(mode === "create");
     let birthInputEl = $state<HTMLInputElement | null>(null);
     let deathInputEl = $state<HTMLInputElement | null>(null);
     let photoFileInputEl = $state<HTMLInputElement | null>(null);
@@ -54,7 +70,7 @@
     let bio = $state("");
     let id = $state("");
     let personReadOnly = $state(false);
-    const editingAllowed = $derived(editMode && !personReadOnly);
+    const editingAllowed = $derived(isCreate || (editMode && !personReadOnly));
     const readOnly = $derived(!editingAllowed);
     let photoUrl = $state<string | null>(null);
     let photoErrString = $state<string | null>(null);
@@ -171,6 +187,8 @@
     }
 
     export function showPersonDetails(p: ShowPerson) {
+        mode = "view";
+        createTitle = null;
         id = p.description.id;
         name = p.description.name;
         unknown = isUnknownPerson(p.description.name);
@@ -199,8 +217,40 @@
         });
     }
 
+    export function showCreatePerson(opts: { title?: string; oncreate: (payload: CreatePersonPayload) => void }) {
+        mode = "create";
+        createTitle = opts.title ?? null;
+        activeCreateCallback = opts.oncreate;
+        id = "";
+        name = "";
+        unknown = false;
+        birthDate = null;
+        deathDate = null;
+        bio = "";
+        pinned = false;
+        personReadOnly = false;
+        bioTab = "edit";
+        originalPhotoUrl = null;
+        photoUrl = null;
+        photoErrString = null;
+        if (photoFileInputEl) photoFileInputEl.value = "";
+        resetCropState();
+        resetPendingPhoto();
+
+        birthDateErrString = null;
+        deathDateErrString = null;
+
+        open = true;
+
+        queueMicrotask(() => {
+            if (birthInputEl) birthInputEl.value = "";
+            if (deathInputEl) deathInputEl.value = "";
+        });
+    }
+
     function close() {
         open = false;
+        activeCreateCallback = null;
     }
 
     export function dismiss() {
@@ -209,19 +259,30 @@
 
     function save() {
         if (saveDisabled) return;
-        onpersonUpdated?.({
-            id,
-            description: {
-                type: "CreateNewPerson",
-                name: unknown ? "" : name,
-                birthDate: dateToIsoLocalTime(birthDate),
-                deathDate: dateToIsoLocalTime(deathDate),
-                bio,
-            },
-            pin: pinned,
-            photoUpload: pendingPhotoBlob,
-            photoRemove: pendingPhotoRemove,
-        });
+        const description = {
+            type: "CreateNewPerson" as const,
+            name: unknown ? "" : name,
+            birthDate: dateToIsoLocalTime(birthDate),
+            deathDate: dateToIsoLocalTime(deathDate),
+            bio,
+        };
+        if (mode === "create") {
+            const cb = activeCreateCallback;
+            activeCreateCallback = null;
+            cb?.({
+                description,
+                pin: pinned,
+                photoUpload: pendingPhotoBlob,
+            });
+        } else {
+            onpersonUpdated?.({
+                id,
+                description,
+                pin: pinned,
+                photoUpload: pendingPhotoBlob,
+                photoRemove: pendingPhotoRemove,
+            });
+        }
         close();
     }
 
@@ -405,7 +466,7 @@
 
 <V2Modal
     {open}
-    title={cropping ? $t("person.photoAdjustTitle") : $t("person.title")}
+    title={cropping ? $t("person.photoAdjustTitle") : isCreate ? (createTitle ?? $t("v2.addPerson")) : $t("person.title")}
     size="lg"
     scroll
     dismissOnBackdrop={!cropping}
@@ -615,6 +676,15 @@
                 onclick={confirmCrop}
                 data-testid="v2-person-crop-save"
             >{$t("common.save")}</button>
+        {:else if isCreate}
+            <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.cancel")}</button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                disabled={saveDisabled}
+                onclick={save}
+                data-testid="v2-person-create"
+            >{$t("common.create")}</button>
         {:else if editingAllowed}
             <button
                 type="button"

--- a/frontend/src/v2/components/V2PersonDetailsModal.svelte
+++ b/frontend/src/v2/components/V2PersonDetailsModal.svelte
@@ -25,16 +25,11 @@
         ShowPerson,
         UpdatePerson,
     } from "../../components/person_details_modal/PersonDetailsModal.svelte";
+    import type { CreateNewPerson } from "../../model";
     import V2Modal from "./V2Modal.svelte";
 
     export type CreatePersonPayload = {
-        description: {
-            type: "CreateNewPerson";
-            name: string;
-            birthDate: string | null;
-            deathDate: string | null;
-            bio: string;
-        };
+        description: CreateNewPerson;
         pin: boolean;
         photoUpload: Blob | null;
     };
@@ -186,71 +181,49 @@
         }
     }
 
-    export function showPersonDetails(p: ShowPerson) {
-        mode = "view";
-        createTitle = null;
-        id = p.description.id;
-        name = p.description.name;
-        unknown = isUnknownPerson(p.description.name);
-        birthDate = p.description.birthDate ? new Date(p.description.birthDate) : null;
-        deathDate = p.description.deathDate ? new Date(p.description.deathDate) : null;
-        bio = p.description.bio ?? "";
-        pinned = p.pin;
-        personReadOnly = p.description.readOnly ?? false;
-        bioTab = "preview";
-        originalPhotoUrl = p.description.photoUrl ?? null;
+    function resetFormState(p: ShowPerson | null) {
+        id = p?.description.id ?? "";
+        name = p?.description.name ?? "";
+        unknown = p ? isUnknownPerson(p.description.name) : false;
+        birthDate = p?.description.birthDate ? new Date(p.description.birthDate) : null;
+        deathDate = p?.description.deathDate ? new Date(p.description.deathDate) : null;
+        bio = p?.description.bio ?? "";
+        pinned = p?.pin ?? false;
+        personReadOnly = p?.description.readOnly ?? false;
+        bioTab = p ? "preview" : "edit";
+        originalPhotoUrl = p?.description.photoUrl ?? null;
         photoUrl = originalPhotoUrl;
         photoErrString = null;
         if (photoFileInputEl) photoFileInputEl.value = "";
         resetCropState();
         resetPendingPhoto();
-
         birthDateErrString = null;
         deathDateErrString = null;
-
-        open = true;
-
-        // Sync the imask inputs once they exist
         queueMicrotask(() => {
             if (birthInputEl) birthInputEl.value = dateToMaskedDateStr(birthDate) ?? "";
             if (deathInputEl) deathInputEl.value = dateToMaskedDateStr(deathDate) ?? "";
         });
     }
 
+    export function showPersonDetails(p: ShowPerson) {
+        mode = "view";
+        createTitle = null;
+        resetFormState(p);
+        open = true;
+    }
+
     export function showCreatePerson(opts: { title?: string; oncreate: (payload: CreatePersonPayload) => void }) {
         mode = "create";
         createTitle = opts.title ?? null;
         activeCreateCallback = opts.oncreate;
-        id = "";
-        name = "";
-        unknown = false;
-        birthDate = null;
-        deathDate = null;
-        bio = "";
-        pinned = false;
-        personReadOnly = false;
-        bioTab = "edit";
-        originalPhotoUrl = null;
-        photoUrl = null;
-        photoErrString = null;
-        if (photoFileInputEl) photoFileInputEl.value = "";
-        resetCropState();
-        resetPendingPhoto();
-
-        birthDateErrString = null;
-        deathDateErrString = null;
-
+        resetFormState(null);
         open = true;
-
-        queueMicrotask(() => {
-            if (birthInputEl) birthInputEl.value = "";
-            if (deathInputEl) deathInputEl.value = "";
-        });
     }
 
     function close() {
         open = false;
         activeCreateCallback = null;
+        resetPendingPhoto();
     }
 
     export function dismiss() {


### PR DESCRIPTION
## Summary
- Drag flows that previously created a person via lightweight prompt (family→empty "create child") or auto-generated placeholder name (empty→family "create spouse") now open `V2PersonDetailsModal` in create mode so users can enter name, dates, bio, photo, and pin before commit.
- V2Fab "Add person" and V2BulkAddTray remain quick-input paths (unchanged).
- Drag-end position from #153 still pins the spawned node.

Closes #154

## Test plan
- [x] `npm run check` (frontend type check)
- [x] `npm test` (frontend jest, 136/136)
- [x] `npx playwright test v2_drag_ux.spec.ts` (11/11, includes 2 new tests for family→empty and empty→family create flows)
- [x] `npx playwright test v2_modal` (12/12, existing modal flows still green)
- [ ] Manual: drag from family into empty space → person details modal opens, fill name + bio + photo, click Create, child commits at drop position
- [ ] Manual: drag from empty space onto a family → modal opens, Create adds spouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)