### PR TITLE
Highlight valid/invalid drop targets during v2 drag

### DIFF
--- a/frontend/src/stemmaIndex.test.ts
+++ b/frontend/src/stemmaIndex.test.ts
@@ -108,6 +108,52 @@ test("calculates max generation", () => {
     expect(maxGeneration).toEqual(4)
 })
 
+describe("canAddParent / canAddChild", () => {
+    const jjIndex = () => new StemmaIndex(jjFamily)
+
+    test("canAddParent rejects when family already has two parents", () => {
+        // family 1: parents [jane, john] — full
+        expect(jjIndex().canAddParent("1", joseph)).toEqual({ ok: false, reason: "twoParents" })
+    })
+
+    test("canAddParent allows adding a parent to a single-parent family", () => {
+        // family 3: parents [july] — has room
+        expect(jjIndex().canAddParent("3", john)).toEqual({ ok: true })
+    })
+
+    test("canAddParent rejects if person is already a member of the family", () => {
+        // family 3 (parents [july], children [jake]) — july would be duplicate parent, jake duplicate child
+        expect(jjIndex().canAddParent("3", july)).toEqual({ ok: false, reason: "alreadyMember" })
+        expect(jjIndex().canAddParent("3", jake)).toEqual({ ok: false, reason: "alreadyMember" })
+    })
+
+    test("canAddParent rejects when person is a descendant of the family (cycle)", () => {
+        // family 5: parents [joseph], children [july]; jeff is descendant of family 5 via july→jake→james→jeff
+        expect(jjIndex().canAddParent("5", jeff)).toEqual({ ok: false, reason: "cycle" })
+    })
+
+    test("canAddChild rejects if person already in family", () => {
+        // family 1 has jane as parent, josh as child
+        expect(jjIndex().canAddChild("1", jane)).toEqual({ ok: false, reason: "alreadyMember" })
+        expect(jjIndex().canAddChild("1", josh)).toEqual({ ok: false, reason: "alreadyMember" })
+    })
+
+    test("canAddChild rejects when family is a descendant of the person (cycle)", () => {
+        // family 4 (parents [james], children [jeff]) is descendant of joseph (joseph→f5→july→f3→jake→f2→james→f4)
+        expect(jjIndex().canAddChild("4", joseph)).toEqual({ ok: false, reason: "cycle" })
+    })
+
+    test("canAddChild allows valid addition", () => {
+        // family 4: parents [james], children [jeff]; josh has no descendant families
+        expect(jjIndex().canAddChild("4", josh)).toEqual({ ok: true })
+    })
+
+    test("returns unknownFamily for missing id", () => {
+        expect(jjIndex().canAddParent("zzz", jane)).toEqual({ ok: false, reason: "unknownFamily" })
+        expect(jjIndex().canAddChild("zzz", jane)).toEqual({ ok: false, reason: "unknownFamily" })
+    })
+})
+
 test("lineage skips empty families", () => {
     let mashaFamily = stemma({
         families: [

--- a/frontend/src/stemmaIndex.ts
+++ b/frontend/src/stemmaIndex.ts
@@ -23,6 +23,8 @@ type FamilyMembers = {
 }
 
 
+export type AddCheck = { ok: true } | { ok: false, reason: "twoParents" | "alreadyMember" | "cycle" | "unknownFamily" }
+
 export class StemmaIndex {
     private _parentToChildren: Map<string, DirectedFamilyDescription[]>
     private _childToParents: Map<string, DirectedFamilyDescription[]>
@@ -34,6 +36,8 @@ export class StemmaIndex {
     private _namesakes: Map<string, string[]>
     private _lineage: Map<string, Generation>
     private _maxGeneration: number
+    private _descendantFamiliesOfPerson: Map<string, Set<string>>
+    private _descendantPeopleOfFamily: Map<string, Set<string>>
 
     private groupByKey<K, V>(array: Array<readonly [K, V]>) {
         return array.reduce((store, item) => {
@@ -67,6 +71,43 @@ export class StemmaIndex {
         this._people = new Map(stemma.people.map(p => [p.id, p]))
         this._lineage = new Map(stemma.people.map(p => [p.id, this.buildLineage(p)]))
         this._maxGeneration = Math.max(...[...this._lineage.values()].map(p => p.generation));
+
+        const dependeesByPerson = new Map(
+            stemma.people.map(p => [p.id, this.computeLineage(p.id, this._parentToChildren)])
+        )
+        this._descendantFamiliesOfPerson = new Map(
+            stemma.people.map(p => [p.id, new Set(dependeesByPerson.get(p.id)!.families)])
+        )
+        this._descendantPeopleOfFamily = new Map(
+            stemma.families.map(f => {
+                const peopleSet = new Set<string>()
+                for (const child of f.children ?? []) {
+                    peopleSet.add(child)
+                    const childDesc = dependeesByPerson.get(child)
+                    if (childDesc) for (const rel of childDesc.relativies) peopleSet.add(rel)
+                }
+                return [f.id, peopleSet]
+            })
+        )
+    }
+
+    canAddParent(familyId: string, personId: string): AddCheck {
+        const family = this._families.get(familyId)
+        if (!family) return { ok: false, reason: "unknownFamily" }
+        if ((family.parents?.length ?? 0) >= 2) return { ok: false, reason: "twoParents" }
+        if (family.parents?.includes(personId)) return { ok: false, reason: "alreadyMember" }
+        if (family.children?.includes(personId)) return { ok: false, reason: "alreadyMember" }
+        if (this._descendantPeopleOfFamily.get(familyId)?.has(personId)) return { ok: false, reason: "cycle" }
+        return { ok: true }
+    }
+
+    canAddChild(familyId: string, personId: string): AddCheck {
+        const family = this._families.get(familyId)
+        if (!family) return { ok: false, reason: "unknownFamily" }
+        if (family.children?.includes(personId)) return { ok: false, reason: "alreadyMember" }
+        if (family.parents?.includes(personId)) return { ok: false, reason: "alreadyMember" }
+        if (this._descendantFamiliesOfPerson.get(personId)?.has(familyId)) return { ok: false, reason: "cycle" }
+        return { ok: true }
     }
 
     private computeLineage(personId: string, relation: Map<string, DirectedFamilyDescription[]>) {

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -92,6 +92,7 @@
     let selectedFamilyEl = $state<Element | null>(null);
     let familySheetOpen = $state(false);
     let dragTip = $state<{ text: string; x: number; y: number } | null>(null);
+    let activeGestureSource = $state<SourceRef | null>(null);
 
     let personEditModal = $state<ReturnType<typeof V2PersonDetailsModal> | null>(null);
     let aboutModal = $state<ReturnType<typeof V2AboutModal> | null>(null);
@@ -450,6 +451,7 @@
             gesture = null;
             document.body.classList.remove("v2-linking");
             dragTip = null;
+            activeGestureSource = null;
         };
 
         const targetCompatibility = (
@@ -457,12 +459,20 @@
             overInfo: { ref: NodeRef } | null,
         ): "valid" | "noop" | "create-empty" => {
             if (source.kind === "person") {
-                if (overInfo?.ref.kind === "family") return "valid";
+                if (overInfo?.ref.kind === "family") {
+                    if (isPendingId(overInfo.ref.id)) return "valid";
+                    const c = displayedStemmaIndex?.canAddParent(overInfo.ref.id, source.id);
+                    return c?.ok ? "valid" : "noop";
+                }
                 if (!overInfo) return "create-empty";
                 return "noop";
             }
             if (source.kind === "family") {
-                if (overInfo?.ref.kind === "person") return "valid";
+                if (overInfo?.ref.kind === "person") {
+                    if (isPendingId(source.id)) return "valid";
+                    const c = displayedStemmaIndex?.canAddChild(source.id, overInfo.ref.id);
+                    return c?.ok ? "valid" : "noop";
+                }
                 if (!overInfo) return "create-empty";
                 return "noop";
             }
@@ -568,6 +578,7 @@
             if (!gesture.active) {
                 if (Math.hypot(dx, dy) <= 6) return;
                 gesture.active = true;
+                activeGestureSource = gesture.source;
                 document.body.classList.add("v2-linking");
                 const mainG = svgEl.querySelector("g.main") as SVGGElement | null;
                 if (mainG) {
@@ -667,6 +678,47 @@
             window.removeEventListener("mouseup", onMouseUp);
             window.removeEventListener("keydown", onKeyDown);
             cleanup();
+        };
+    });
+
+    function classifyForDrop(src: SourceRef, g: Element): "v2-drop-allowed" | "v2-drop-disallowed" | null {
+        const id = denormalizeId(g.id);
+        const kind: "person" | "family" = g.id.startsWith("person_") ? "person" : "family";
+        if (kind === "person" && isPendingPersonId(id)) return null;
+        if (src.kind === "person") {
+            if (kind !== "family") return null;
+            if (isPendingId(id)) return "v2-drop-allowed";
+            const c = displayedStemmaIndex?.canAddParent(id, src.id);
+            if (!c) return null;
+            return c.ok ? "v2-drop-allowed" : "v2-drop-disallowed";
+        }
+        if (src.kind === "family") {
+            if (kind !== "person") return null;
+            if (src.id === id) return null;
+            if (isPendingId(src.id)) return "v2-drop-allowed";
+            const c = displayedStemmaIndex?.canAddChild(src.id, id);
+            if (!c) return null;
+            return c.ok ? "v2-drop-allowed" : "v2-drop-disallowed";
+        }
+        return null;
+    }
+
+    $effect(() => {
+        const src = activeGestureSource;
+        if (!src || src.kind === "empty") return;
+        void displayedStemmaIndex;
+        void pendingFamilies;
+        const svgEl = document.getElementById("chart");
+        if (!svgEl) return;
+        svgEl.querySelectorAll("g[id^='person_'], g[id^='family_']").forEach((g) => {
+            g.classList.remove("v2-drop-allowed", "v2-drop-disallowed");
+            const cls = classifyForDrop(src, g);
+            if (cls) g.classList.add(cls);
+        });
+        return () => {
+            svgEl.querySelectorAll("g.v2-drop-allowed, g.v2-drop-disallowed").forEach((g) => {
+                g.classList.remove("v2-drop-allowed", "v2-drop-disallowed");
+            });
         };
     });
 
@@ -1288,6 +1340,21 @@
     @keyframes v2-pending-pulse {
         0%, 100% { stroke-opacity: 1; }
         50% { stroke-opacity: 0.35; }
+    }
+
+    :global(g.v2-drop-disallowed) {
+        opacity: 0.3;
+        filter: saturate(0.2);
+        pointer-events: none;
+    }
+
+    :global(g.v2-drop-allowed > circle) {
+        animation: v2-drop-allowed-pulse 1.8s ease-in-out infinite;
+    }
+
+    @keyframes v2-drop-allowed-pulse {
+        0%, 100% { stroke-opacity: 1; }
+        50% { stroke-opacity: 0.45; }
     }
 
     :global(g.v2-drop-target > circle) {

--- a/frontend/src/v2/ghostHelpers.ts
+++ b/frontend/src/v2/ghostHelpers.ts
@@ -1,8 +1,1 @@
-import type { FamilyDescription } from "../model";
-
 export type GhostFamilyAction = "addChild" | "addParent";
-
-export function canAddParentToFamily(family: FamilyDescription | null | undefined): boolean {
-    if (!family) return true;
-    return (family.parents?.length ?? 0) < 2;
-}


### PR DESCRIPTION
## Summary
- StemmaIndex gains `canAddParent(fid, pid)` / `canAddChild(fid, pid)` predicates returning `{ ok, reason }` (parent cap, dupe member, cycle). Backed by precomputed descendant maps.
- During an active v2 edit-mode drag, every `g[id^='person_'|'family_']` node is classed `v2-drop-allowed` (subtle stroke-opacity pulse) or `v2-drop-disallowed` (dim + desaturate, pointer-events:none) based on the role it would play. Re-classifies on stemma mutation.
- Same predicates wired into `targetCompatibility`, so cycle/full-family attempts are blocked at the gesture level (not just visually).
- Pending stub families always allowed until the 2nd participant is attached.
- Drops the now-unused `ghostHelpers.canAddParentToFamily`.

Closes #155

## Test plan
- [x] `npm test` (frontend, 144 passing — 8 new predicate tests)
- [x] `npm run check` (svelte-check clean)
- [ ] Manual: drag a person onto a 2-parent family — node visibly dims and drop is blocked.
- [ ] Manual: drag a descendant onto an ancestor family (cycle) — disallowed visual + drop blocked.
- [ ] Manual: drag onto a pending stub family — allowed and completes stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)