### PR TITLE
Exit v2 pan mode on Escape

### DIFF
--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -737,6 +737,13 @@
             return tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable;
         };
         const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                if (isTypingTarget(e.target)) return;
+                if (panMode && !activeGestureSource && !document.querySelector(".v2-modal-panel")) {
+                    panMode = false;
+                }
+                return;
+            }
             if (e.code !== "Space" || e.repeat) return;
             if (isTypingTarget(e.target)) return;
             spacePan = true;


### PR DESCRIPTION
## Summary
- Pressing ESC while v2 pan mode is active toggles `panMode` off
- Guarded by typing-target, active drag gesture, and open modal checks so existing ESC behavior (modal close, drag cancel, search clear) is unaffected

Closes #170

## Test plan
- [x] `npm test` (frontend)
- [x] `npm run check` (svelte-check)
- [ ] Manual: ESC in pan mode exits; ESC during drag still cancels drag; ESC with modal open still closes modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)