### PR TITLE
Fix v2 drag-to-create person flow (#168)

### DIFF
--- a/e2e/tests/v2_drag_ux.spec.ts
+++ b/e2e/tests/v2_drag_ux.spec.ts
@@ -34,17 +34,33 @@ async function enterEditMode(page: Page) {
 
 async function addOrphan(page: Page, name: string) {
   await page.getByTestId("v2-add-person-fab").click();
-  const nameInput = page.getByTestId("v2-name-input");
+  const nameInput = page.getByTestId("v2-person-name-input");
   await expect(nameInput).toBeVisible();
   await nameInput.fill(name);
-  await page.getByTestId("v2-name-confirm").click();
-  // Wait for the backend-committed g (real id, not "pending-*") to appear.
-  // toHaveCount(0) on the optimistic class races: it passes before the class lands.
+  await page.getByTestId("v2-person-create").click();
   const committed = page
     .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
     .filter({ has: page.locator(`text="${name}"`) })
     .first();
   await expect(committed).toBeVisible({ timeout: 15_000 });
+}
+
+async function fillCreatePersonModal(page: Page, name: string) {
+  const modal = page.getByTestId("v2-person-details-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  await page.getByTestId("v2-person-name-input").fill(name);
+  await page.getByTestId("v2-person-create").click();
+}
+
+async function buildFamilyByDraggingParentToEmpty(
+  page: Page,
+  parent: { cx: number; cy: number },
+  childName: string,
+) {
+  await pressAndDrag(page, parent.cx, parent.cy, parent.cx + 280, parent.cy);
+  await page.mouse.up();
+  await fillCreatePersonModal(page, childName);
+  await waitForRealFamily(page);
 }
 
 type NodeRef = { id: string; locator: Locator; cx: number; cy: number };
@@ -99,22 +115,6 @@ async function pressAndDragFromFamily(
   await page.waitForTimeout(100);
 }
 
-async function dropPersonOnFamily(
-  page: Page,
-  from: { cx: number; cy: number },
-  fc: { cx: number; cy: number },
-) {
-  await page.mouse.move(from.cx, from.cy);
-  await page.mouse.down();
-  await page.mouse.move(from.cx + 30, from.cy + 30, { steps: 4 });
-  await page.mouse.move(fc.cx, fc.cy, { steps: 12 });
-  await page.mouse.up();
-}
-
-// After dropping a second person onto a stub family, V2App removes the pending
-// family locally and calls createFamily on the backend (2-second artificial
-// delay in the dev REST server). Wait for the real family g to appear so we
-// don't read coordinates from a stub that's about to be replaced.
 async function waitForRealFamily(page: Page) {
   await expect(page.locator("svg#chart g[id^='family_pending-']")).toHaveCount(0, { timeout: 15_000 });
   await expect(page.locator("svg#chart g[id^='family_']")).toHaveCount(1, { timeout: 15_000 });
@@ -150,14 +150,11 @@ test.describe("v2 drag tooltips", () => {
     const ts = Date.now();
     const a = `Anna${ts}`;
     const b = `Boris${ts}`;
+    const c = `AnnaChild${ts}`;
     await addOrphan(page, a);
     await addOrphan(page, b);
     const anna = await nodeByText(page, a);
-    // Build stub family by dragging Anna into empty space
-    await pressAndDrag(page, anna.cx, anna.cy, anna.cx + 280, anna.cy);
-    await page.mouse.up();
-    await expect(page.locator("svg#chart g[id^='family_']")).toHaveCount(1, { timeout: 5_000 });
-    // Tooltip check while dragging Boris onto stub family
+    await buildFamilyByDraggingParentToEmpty(page, anna, c);
     const boris = await nodeByText(page, b);
     const fc = await familyCenter(page);
     await pressAndDrag(page, boris.cx, boris.cy, fc.cx, fc.cy);
@@ -169,19 +166,12 @@ test.describe("v2 drag tooltips", () => {
   test("family → person tooltip: Attach as child", async ({ page }) => {
     const ts = Date.now();
     const a = `Carl${ts}`;
-    const b = `Dan${ts}`;
     const c = `Eve${ts}`;
+    const seed = `CarlChild${ts}`;
     await addOrphan(page, a);
-    await addOrphan(page, b);
     await addOrphan(page, c);
     const carl = await nodeByText(page, a);
-    await pressAndDrag(page, carl.cx, carl.cy, carl.cx + 280, carl.cy);
-    await page.mouse.up();
-    await expect(page.locator("svg#chart g[id^='family_']")).toHaveCount(1, { timeout: 5_000 });
-    const dan = await nodeByText(page, b);
-    const fc = await familyCenter(page);
-    await dropPersonOnFamily(page, dan, fc);
-    await waitForRealFamily(page);
+    await buildFamilyByDraggingParentToEmpty(page, carl, seed);
     const eve = await nodeByText(page, c);
     await pressAndDragFromFamily(page, eve);
     await expectTip(page, TIP.attachChild);
@@ -192,16 +182,10 @@ test.describe("v2 drag tooltips", () => {
   test("family → empty tooltip: Create child", async ({ page }) => {
     const ts = Date.now();
     const a = `Fred${ts}`;
-    const b = `Gina${ts}`;
+    const seed = `FredChild${ts}`;
     await addOrphan(page, a);
-    await addOrphan(page, b);
     const fred = await nodeByText(page, a);
-    await pressAndDrag(page, fred.cx, fred.cy, fred.cx + 280, fred.cy);
-    await page.mouse.up();
-    const gina = await nodeByText(page, b);
-    const fc = await familyCenter(page);
-    await dropPersonOnFamily(page, gina, fc);
-    await waitForRealFamily(page);
+    await buildFamilyByDraggingParentToEmpty(page, fred, seed);
     const fc2 = await familyCenter(page);
     await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
     await expectTip(page, TIP.createChild);
@@ -212,18 +196,11 @@ test.describe("v2 drag tooltips", () => {
   test("empty → family tooltip: Create spouse", async ({ page }) => {
     const ts = Date.now();
     const a = `Henry${ts}`;
-    const b = `Ida${ts}`;
+    const seed = `HenryChild${ts}`;
     await addOrphan(page, a);
-    await addOrphan(page, b);
     const henry = await nodeByText(page, a);
-    await pressAndDrag(page, henry.cx, henry.cy, henry.cx + 280, henry.cy);
-    await page.mouse.up();
-    const ida = await nodeByText(page, b);
-    const fc = await familyCenter(page);
-    await dropPersonOnFamily(page, ida, fc);
-    await waitForRealFamily(page);
+    await buildFamilyByDraggingParentToEmpty(page, henry, seed);
     const fc2 = await familyCenter(page);
-    // Start far from any node in known-empty svg area
     const vp = page.viewportSize();
     const startX = vp ? vp.width - 80 : fc2.cx + 300;
     const startY = vp ? Math.floor(vp.height / 2) : fc2.cy;
@@ -253,25 +230,15 @@ test("v2 family→empty release opens person details modal and creates child", a
   await enterEditMode(page);
   const ts = Date.now();
   const a = `Pat${ts}`;
-  const b = `Quinn${ts}`;
+  const seed = `PatChild${ts}`;
   const child = `Rita${ts}`;
   await addOrphan(page, a);
-  await addOrphan(page, b);
   const pat = await nodeByText(page, a);
-  await pressAndDrag(page, pat.cx, pat.cy, pat.cx + 280, pat.cy);
-  await page.mouse.up();
-  const quinn = await nodeByText(page, b);
-  const fc = await familyCenter(page);
-  await dropPersonOnFamily(page, quinn, fc);
-  await waitForRealFamily(page);
+  await buildFamilyByDraggingParentToEmpty(page, pat, seed);
   const fc2 = await familyCenter(page);
   await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
   await page.mouse.up();
-  const modal = page.getByTestId("v2-person-details-modal");
-  await expect(modal).toBeVisible({ timeout: 5_000 });
-  const nameInput = page.getByTestId("v2-person-name-input");
-  await nameInput.fill(child);
-  await page.getByTestId("v2-person-create").click();
+  await fillCreatePersonModal(page, child);
   const committed = page
     .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
     .filter({ has: page.locator(`text="${child}"`) })
@@ -286,28 +253,18 @@ test("v2 empty→family release opens person details modal and creates spouse", 
   await enterEditMode(page);
   const ts = Date.now();
   const a = `Sam${ts}`;
-  const b = `Tess${ts}`;
+  const seed = `SamChild${ts}`;
   const spouse = `Uma${ts}`;
   await addOrphan(page, a);
-  await addOrphan(page, b);
   const sam = await nodeByText(page, a);
-  await pressAndDrag(page, sam.cx, sam.cy, sam.cx + 280, sam.cy);
-  await page.mouse.up();
-  const tess = await nodeByText(page, b);
-  await pressAndDragFromFamily(page, { cx: tess.cx, cy: tess.cy });
-  await page.mouse.up();
-  await waitForRealFamily(page);
+  await buildFamilyByDraggingParentToEmpty(page, sam, seed);
   const fc2 = await familyCenter(page);
   const vp = page.viewportSize();
   const startX = vp ? vp.width - 80 : fc2.cx + 300;
   const startY = vp ? Math.floor(vp.height / 2) : fc2.cy;
   await pressAndDrag(page, startX, startY, fc2.cx, fc2.cy);
   await page.mouse.up();
-  const modal = page.getByTestId("v2-person-details-modal");
-  await expect(modal).toBeVisible({ timeout: 5_000 });
-  const nameInput = page.getByTestId("v2-person-name-input");
-  await nameInput.fill(spouse);
-  await page.getByTestId("v2-person-create").click();
+  await fillCreatePersonModal(page, spouse);
   const committed = page
     .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
     .filter({ has: page.locator(`text="${spouse}"`) })
@@ -315,18 +272,48 @@ test("v2 empty→family release opens person details modal and creates spouse", 
   await expect(committed).toBeVisible({ timeout: 15_000 });
 });
 
-test("v2 person→empty release creates stub family", async ({ page }) => {
+test("v2 person→empty release opens person details modal and creates child", async ({ page }) => {
   await page.goto("/v2");
   await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
   await createFreshStemma(page);
   await enterEditMode(page);
   const name = `Mira${Date.now()}`;
+  const child = `MiraChild${Date.now()}`;
   await addOrphan(page, name);
   expect(await familyCount(page)).toBe(0);
   const mira = await nodeByText(page, name);
   await pressAndDrag(page, mira.cx, mira.cy, mira.cx + 260, mira.cy + 80);
   await page.mouse.up();
-  await expect(page.locator("svg#chart g[id^='family_']")).toHaveCount(1, { timeout: 5_000 });
+  await fillCreatePersonModal(page, child);
+  await waitForRealFamily(page);
+  const committed = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${child}"`) })
+    .first();
+  await expect(committed).toBeVisible({ timeout: 15_000 });
+});
+
+test("v2 empty→person release opens person details modal and creates parent", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const name = `Noel${Date.now()}`;
+  const parent = `NoelParent${Date.now()}`;
+  await addOrphan(page, name);
+  expect(await familyCount(page)).toBe(0);
+  const noel = await nodeByText(page, name);
+  const startX = noel.cx + 280;
+  const startY = noel.cy + 150;
+  await pressAndDrag(page, startX, startY, noel.cx, noel.cy);
+  await page.mouse.up();
+  await fillCreatePersonModal(page, parent);
+  await waitForRealFamily(page);
+  const committed = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${parent}"`) })
+    .first();
+  await expect(committed).toBeVisible({ timeout: 15_000 });
 });
 
 test("v2 Esc cancels gesture before drop", async ({ page }) => {

--- a/e2e/tests/v2_search.spec.ts
+++ b/e2e/tests/v2_search.spec.ts
@@ -13,10 +13,10 @@ test("v2 search: find person, focus tree, handle no-match", async ({ page }) => 
     // Add one person so search is populated.
     await editFab.click();
     await page.getByTestId("v2-add-person-fab").click();
-    const nameInput = page.getByTestId("v2-name-input");
+    const nameInput = page.getByTestId("v2-person-name-input");
     await expect(nameInput).toBeVisible();
     await nameInput.fill("Searchable");
-    await page.getByTestId("v2-name-confirm").click();
+    await page.getByTestId("v2-person-create").click();
     await expect(svg).toBeVisible({ timeout: 15_000 });
     await expect(svg.locator("text").filter({ hasText: "Searchable" })).toBeVisible({ timeout: 15_000 });
   }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -259,6 +259,7 @@ export const en: Record<string, string> = {
     'v2.tipAttachChild': 'Attach as child',
     'v2.createSpouseTitle': 'Add spouse',
     'v2.createChildTitle': 'Add child',
+    'v2.createParentTitle': 'Add parent',
     'v2.panModeOn': 'Pan canvas',
     'v2.panModeOff': 'Exit pan mode',
 };
@@ -490,6 +491,7 @@ export const ru: Record<string, string> = {
     'v2.tipAttachChild': 'Присоединить потомка',
     'v2.createSpouseTitle': 'Добавить супруга',
     'v2.createChildTitle': 'Добавить потомка',
+    'v2.createParentTitle': 'Добавить родителя',
     'v2.panModeOn': 'Перемещать холст',
     'v2.panModeOff': 'Выйти из режима перемещения',
 };

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -264,10 +264,6 @@
         role: "parent" | "child",
         pinAt?: { x: number; y: number },
     ) {
-        if (isPendingId(familyId)) {
-            completeStubFamily(familyId, personId, role);
-            return;
-        }
         if (!stemmaIndex) return;
         const family = stemmaIndex.family(familyId);
         if (!family) return;
@@ -283,37 +279,50 @@
         controller.updateFamily(familyId, parents, children, { silent: true }).catch(() => {});
     }
 
-    function spawnStubFamily(sourcePersonId: string, svgX: number, svgY: number) {
-        const tempId = `pending-family-${crypto.randomUUID()}`;
-        stemmaChart?.setNodePosition(normalizeId("family", tempId), svgX, svgY);
-        pendingFamilies = [...pendingFamilies, { tempId, parents: [sourcePersonId], children: [], x: svgX, y: svgY }];
-    }
-
-    function completeStubFamily(stubFamilyId: string, personId: string, role: "parent" | "child") {
-        const stub = pendingFamilies.find((p) => p.tempId === stubFamilyId);
-        if (!stub) return;
-        if (stub.parents.includes(personId) || stub.children.includes(personId)) return;
-        const newParents = role === "parent" ? [...stub.parents, personId] : stub.parents;
-        const newChildren = role === "child" ? [...stub.children, personId] : stub.children;
-        if (newParents.length + newChildren.length >= 2) {
-            const pos = stub.x != null && stub.y != null ? { x: stub.x, y: stub.y } : null;
-            pendingFamilies = pendingFamilies.filter((p) => p.tempId !== stubFamilyId);
-            const parents: PersonDefinition[] = newParents.map((id) => ({ type: "ExistingPerson", id }));
-            const children: PersonDefinition[] = newChildren.map((id) => ({ type: "ExistingPerson", id }));
-            controller
-                .createFamily(parents, children, { silent: true })
-                .then((result) => {
-                    if (!pos) return;
-                    result.newFamilyIds.forEach((id) =>
-                        stemmaChart?.setNodePosition(normalizeId("family", id), pos.x, pos.y),
-                    );
-                })
-                .catch(() => {});
-        } else {
-            pendingFamilies = pendingFamilies.map((p) =>
-                p.tempId === stubFamilyId ? { ...stub, parents: newParents, children: newChildren } : p,
-            );
-        }
+    function createPersonAsCounterpart(
+        existingPersonId: string,
+        newPersonRole: "parent" | "child",
+        title: string,
+        pinAt: { x: number; y: number },
+    ) {
+        personEditModal?.showCreatePerson({
+            title,
+            oncreate: ({ description, pin, photoUpload }) => {
+                const tempPersonId = `pending-${crypto.randomUUID()}`;
+                const tempFamilyId = `pending-family-${crypto.randomUUID()}`;
+                const tempParents = newPersonRole === "parent" ? [tempPersonId] : [existingPersonId];
+                const tempChildren = newPersonRole === "child" ? [tempPersonId] : [existingPersonId];
+                pendingAdds = [...pendingAdds, { tempId: tempPersonId, name: description.name }];
+                pendingFamilies = [
+                    ...pendingFamilies,
+                    { tempId: tempFamilyId, parents: tempParents, children: tempChildren, x: pinAt.x, y: pinAt.y },
+                ];
+                stemmaChart?.setNodePosition(normalizeId("person", tempPersonId), pinAt.x, pinAt.y);
+                stemmaChart?.setNodePosition(normalizeId("family", tempFamilyId), pinAt.x, pinAt.y);
+                const existingRef: PersonDefinition = { type: "ExistingPerson", id: existingPersonId };
+                const parents: PersonDefinition[] = newPersonRole === "parent" ? [description] : [existingRef];
+                const children: PersonDefinition[] = newPersonRole === "child" ? [description] : [existingRef];
+                controller
+                    .createFamily(parents, children, { silent: true })
+                    .then((result) => {
+                        const newPersonId = result.newPersonIds[0];
+                        if (newPersonId) {
+                            stemmaChart?.setNodePosition(normalizeId("person", newPersonId), pinAt.x, pinAt.y);
+                            if (photoUpload || pin) {
+                                controller.savePerson(newPersonId, description, pin, photoUpload, false);
+                            }
+                        }
+                        result.newFamilyIds.forEach((id) =>
+                            stemmaChart?.setNodePosition(normalizeId("family", id), pinAt.x, pinAt.y),
+                        );
+                    })
+                    .catch(() => {})
+                    .finally(() => {
+                        pendingAdds = pendingAdds.filter((p) => p.tempId !== tempPersonId);
+                        pendingFamilies = pendingFamilies.filter((p) => p.tempId !== tempFamilyId);
+                    });
+            },
+        });
     }
 
     function createPersonInFamily(
@@ -649,7 +658,7 @@
             }
             if (source.kind === "person" && !overInfo) {
                 const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
-                spawnStubFamily(source.id, releaseSvg.x, releaseSvg.y);
+                createPersonAsCounterpart(source.id, "child", $t("v2.createChildTitle"), releaseSvg);
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "family") {
@@ -657,7 +666,7 @@
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "person") {
-                spawnStubFamily(overInfo.ref.id, startCenter.x, startCenter.y);
+                createPersonAsCounterpart(overInfo.ref.id, "parent", $t("v2.createParentTitle"), startCenter);
                 return;
             }
             if (source.kind === "family" && !overInfo && !isPendingId(source.id)) {
@@ -822,12 +831,6 @@
         selectedFamilyEl = null;
     }
 
-    function runCreateOrphanPerson(name: string) {
-        void withPendingAdd(name, () =>
-            controller.createOrphanPerson({ type: "CreateNewPerson", name }, { silent: true }),
-        );
-    }
-
     function setWith<T>(s: Set<T>, v: T): Set<T> {
         return s.has(v) ? s : new Set([...s, v]);
     }
@@ -948,14 +951,21 @@
     }
 
     function openAddPerson() {
-        promptModal?.prompt({
+        personEditModal?.showCreatePerson({
             title: $t("v2.addPerson"),
-            label: $t("v2.namePlaceholder"),
-            confirmLabel: $t("common.add"),
-            testid: "v2-name-modal",
-            inputTestid: "v2-name-input",
-            confirmTestid: "v2-name-confirm",
-            onaccept: (name) => runCreateOrphanPerson(name),
+            oncreate: ({ description, pin, photoUpload }) => {
+                void withPendingAdd(
+                    description.name,
+                    () => controller.createOrphanPerson(description, { silent: true }),
+                    undefined,
+                    (newPersonIds) => {
+                        const newId = newPersonIds[0];
+                        if (newId && (photoUpload || pin)) {
+                            controller.savePerson(newId, description, pin, photoUpload, false);
+                        }
+                    },
+                );
+            },
         });
     }
 


### PR DESCRIPTION
## Summary
- Drag arrow from **empty → person** now opens the full PersonDetails modal; the dropped person becomes the **child** of the new family, and the modal-created person is the parent.
- Drag arrow from **person → empty** now opens the full PersonDetails modal; the source person becomes the **parent** of the new family, and the modal-created person is the child.
- The FAB `Add person` action also routes through the full PersonDetails modal — the short name-only modal is no longer used for person creation.
- Removed the stub-family two-step workflow (`spawnStubFamily` / `completeStubFamily`); families are now created in one shot from modal submit.
- Added `v2.createParentTitle` i18n string.

Closes #168

## Test plan
- [ ] `npm run check` (frontend)
- [ ] `npm test` (frontend unit)
- [ ] Manual: drag from a person into empty space → modal appears, fill name → new family (source = parent, new = child).
- [ ] Manual: drag from empty space onto an existing person → modal appears → new family (dropped person = child, new = parent).
- [ ] Manual: FAB `Add person` opens full PersonDetails modal with name + dates + bio + photo.
- [ ] e2e `v2_drag_ux.spec.ts` covers both new modal paths plus existing family↔person attach flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)