### PR TITLE
Fix v2 person→empty drag to create spouse (#175)

### DIFF
--- a/e2e/tests/v2_drag_ux.spec.ts
+++ b/e2e/tests/v2_drag_ux.spec.ts
@@ -52,14 +52,17 @@ async function fillCreatePersonModal(page: Page, name: string) {
   await page.getByTestId("v2-person-create").click();
 }
 
-async function buildFamilyByDraggingParentToEmpty(
+async function seedFamilyForPerson(
   page: Page,
-  parent: { cx: number; cy: number },
-  childName: string,
+  person: { cx: number; cy: number },
+  parentName: string,
 ) {
-  await pressAndDrag(page, parent.cx, parent.cy, parent.cx + 280, parent.cy);
+  // Gesture 4 (empty → person): creates a family with the new person as parent
+  // and the dragged-onto person as child. Leaves the spouse slot open so
+  // downstream "attach spouse" / "create spouse" tests have room.
+  await pressAndDrag(page, person.cx + 280, person.cy, person.cx, person.cy);
   await page.mouse.up();
-  await fillCreatePersonModal(page, childName);
+  await fillCreatePersonModal(page, parentName);
   await waitForRealFamily(page);
 }
 
@@ -136,12 +139,12 @@ test.describe("v2 drag tooltips", () => {
     await enterEditMode(page);
   });
 
-  test("person → empty tooltip: Create family", async ({ page }) => {
+  test("person → empty tooltip: Create spouse", async ({ page }) => {
     const name = `Alice${Date.now()}`;
     await addOrphan(page, name);
     const alice = await nodeByText(page, name);
     await pressAndDrag(page, alice.cx, alice.cy, alice.cx + 260, alice.cy + 80);
-    await expectTip(page, TIP.createFamily);
+    await expectTip(page, TIP.createSpouse);
     await page.keyboard.press("Escape");
     await page.mouse.up();
   });
@@ -154,7 +157,7 @@ test.describe("v2 drag tooltips", () => {
     await addOrphan(page, a);
     await addOrphan(page, b);
     const anna = await nodeByText(page, a);
-    await buildFamilyByDraggingParentToEmpty(page, anna, c);
+    await seedFamilyForPerson(page, anna, c);
     const boris = await nodeByText(page, b);
     const fc = await familyCenter(page);
     await pressAndDrag(page, boris.cx, boris.cy, fc.cx, fc.cy);
@@ -171,7 +174,7 @@ test.describe("v2 drag tooltips", () => {
     await addOrphan(page, a);
     await addOrphan(page, c);
     const carl = await nodeByText(page, a);
-    await buildFamilyByDraggingParentToEmpty(page, carl, seed);
+    await seedFamilyForPerson(page, carl, seed);
     const eve = await nodeByText(page, c);
     await pressAndDragFromFamily(page, eve);
     await expectTip(page, TIP.attachChild);
@@ -185,7 +188,7 @@ test.describe("v2 drag tooltips", () => {
     const seed = `FredChild${ts}`;
     await addOrphan(page, a);
     const fred = await nodeByText(page, a);
-    await buildFamilyByDraggingParentToEmpty(page, fred, seed);
+    await seedFamilyForPerson(page, fred, seed);
     const fc2 = await familyCenter(page);
     await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
     await expectTip(page, TIP.createChild);
@@ -199,7 +202,7 @@ test.describe("v2 drag tooltips", () => {
     const seed = `HenryChild${ts}`;
     await addOrphan(page, a);
     const henry = await nodeByText(page, a);
-    await buildFamilyByDraggingParentToEmpty(page, henry, seed);
+    await seedFamilyForPerson(page, henry, seed);
     const fc2 = await familyCenter(page);
     const vp = page.viewportSize();
     const startX = vp ? vp.width - 80 : fc2.cx + 300;
@@ -234,7 +237,7 @@ test("v2 family→empty release opens person details modal and creates child", a
   const child = `Rita${ts}`;
   await addOrphan(page, a);
   const pat = await nodeByText(page, a);
-  await buildFamilyByDraggingParentToEmpty(page, pat, seed);
+  await seedFamilyForPerson(page, pat, seed);
   const fc2 = await familyCenter(page);
   await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
   await page.mouse.up();
@@ -257,7 +260,7 @@ test("v2 empty→family release opens person details modal and creates spouse", 
   const spouse = `Uma${ts}`;
   await addOrphan(page, a);
   const sam = await nodeByText(page, a);
-  await buildFamilyByDraggingParentToEmpty(page, sam, seed);
+  await seedFamilyForPerson(page, sam, seed);
   const fc2 = await familyCenter(page);
   const vp = page.viewportSize();
   const startX = vp ? vp.width - 80 : fc2.cx + 300;
@@ -272,23 +275,23 @@ test("v2 empty→family release opens person details modal and creates spouse", 
   await expect(committed).toBeVisible({ timeout: 15_000 });
 });
 
-test("v2 person→empty release opens person details modal and creates child", async ({ page }) => {
+test("v2 person→empty release opens person details modal and creates spouse", async ({ page }) => {
   await page.goto("/v2");
   await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
   await createFreshStemma(page);
   await enterEditMode(page);
   const name = `Mira${Date.now()}`;
-  const child = `MiraChild${Date.now()}`;
+  const spouse = `MiraSpouse${Date.now()}`;
   await addOrphan(page, name);
   expect(await familyCount(page)).toBe(0);
   const mira = await nodeByText(page, name);
   await pressAndDrag(page, mira.cx, mira.cy, mira.cx + 260, mira.cy + 80);
   await page.mouse.up();
-  await fillCreatePersonModal(page, child);
+  await fillCreatePersonModal(page, spouse);
   await waitForRealFamily(page);
   const committed = page
     .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
-    .filter({ has: page.locator(`text="${child}"`) })
+    .filter({ has: page.locator(`text="${spouse}"`) })
     .first();
   await expect(committed).toBeVisible({ timeout: 15_000 });
 });

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -279,9 +279,24 @@
         controller.updateFamily(familyId, parents, children, { silent: true }).catch(() => {});
     }
 
+    function counterpartFamilyShape<T>(
+        role: "parent" | "child" | "spouse",
+        existing: T,
+        incoming: T,
+    ): { parents: T[]; children: T[] } {
+        switch (role) {
+            case "spouse":
+                return { parents: [existing, incoming], children: [] };
+            case "parent":
+                return { parents: [incoming], children: [existing] };
+            case "child":
+                return { parents: [existing], children: [incoming] };
+        }
+    }
+
     function createPersonAsCounterpart(
         existingPersonId: string,
-        newPersonRole: "parent" | "child",
+        newPersonRole: "parent" | "child" | "spouse",
         title: string,
         pinAt: { x: number; y: number },
     ) {
@@ -290,18 +305,26 @@
             oncreate: ({ description, pin, photoUpload }) => {
                 const tempPersonId = `pending-${crypto.randomUUID()}`;
                 const tempFamilyId = `pending-family-${crypto.randomUUID()}`;
-                const tempParents = newPersonRole === "parent" ? [tempPersonId] : [existingPersonId];
-                const tempChildren = newPersonRole === "child" ? [tempPersonId] : [existingPersonId];
+                const tempShape = counterpartFamilyShape(newPersonRole, existingPersonId, tempPersonId);
                 pendingAdds = [...pendingAdds, { tempId: tempPersonId, name: description.name }];
                 pendingFamilies = [
                     ...pendingFamilies,
-                    { tempId: tempFamilyId, parents: tempParents, children: tempChildren, x: pinAt.x, y: pinAt.y },
+                    {
+                        tempId: tempFamilyId,
+                        parents: tempShape.parents,
+                        children: tempShape.children,
+                        x: pinAt.x,
+                        y: pinAt.y,
+                    },
                 ];
                 stemmaChart?.setNodePosition(normalizeId("person", tempPersonId), pinAt.x, pinAt.y);
                 stemmaChart?.setNodePosition(normalizeId("family", tempFamilyId), pinAt.x, pinAt.y);
                 const existingRef: PersonDefinition = { type: "ExistingPerson", id: existingPersonId };
-                const parents: PersonDefinition[] = newPersonRole === "parent" ? [description] : [existingRef];
-                const children: PersonDefinition[] = newPersonRole === "child" ? [description] : [existingRef];
+                const { parents, children } = counterpartFamilyShape<PersonDefinition>(
+                    newPersonRole,
+                    existingRef,
+                    description,
+                );
                 controller
                     .createFamily(parents, children, { silent: true })
                     .then((result) => {
@@ -539,7 +562,7 @@
 
         const computeTipText = (overInfo: { ref: NodeRef } | null, source: SourceRef): string | null => {
             if (source.kind === "person") {
-                if (!overInfo) return $t("v2.tipCreateFamily");
+                if (!overInfo) return $t("v2.tipCreateSpouse");
                 if (overInfo.ref.kind === "family") return $t("v2.tipAttachSpouse");
                 return null;
             }
@@ -658,7 +681,7 @@
             }
             if (source.kind === "person" && !overInfo) {
                 const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
-                createPersonAsCounterpart(source.id, "child", $t("v2.createChildTitle"), releaseSvg);
+                createPersonAsCounterpart(source.id, "spouse", $t("v2.createSpouseTitle"), releaseSvg);
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "family") {


### PR DESCRIPTION
## Summary
- Gesture 3 (person → empty) now creates a spouse-family (parents=[existing, new], children=[]) with the "Add spouse" modal title and "Create spouse" tip, per the canonical v2 drag matrix.
- `createPersonAsCounterpart` extended with a `"spouse"` role; ternary chains collapsed into a small `counterpartFamilyShape` helper used for both the pending preview and the API call.
- E2E `seedFamilyForPerson` helper switched from gesture 3 to gesture 4 so the seeded family has an open spouse slot for downstream tests.

Closes #175

## Test plan
- [x] frontend: `npm run check` (0 errors, 0 warnings)
- [x] frontend: `npm test` (144/144)
- [x] e2e: `npm test` (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)