### PR TITLE
Make v2 person→empty drag a no-op (#179)

### DIFF
--- a/e2e/tests/v2_drag_ux.spec.ts
+++ b/e2e/tests/v2_drag_ux.spec.ts
@@ -1,13 +1,6 @@
 import { expect, test } from "./_fixtures";
 import type { Locator, Page } from "@playwright/test";
 
-const TIP = {
-  createSpouse: /Create spouse|Создать супруга/,
-  createChild: /Create child|Создать потомка/,
-  attachSpouse: /Attach as spouse|Присоединить супруга/,
-  attachChild: /Attach as child|Присоединить потомка/,
-};
-
 async function createFreshStemma(page: Page) {
   const stemmaBtn = page.getByTestId("v2-chip-stemma-btn");
   await expect(stemmaBtn).toBeVisible({ timeout: 10_000 });
@@ -20,7 +13,6 @@ async function createFreshStemma(page: Page) {
   const input = modal.locator("input");
   await input.fill(`drag-ux-${Date.now()}`);
   await modal.locator("button.btn-primary").click();
-  // Wait for backend create + state settle
   await page.waitForTimeout(2_500);
 }
 
@@ -44,27 +36,6 @@ async function addOrphan(page: Page, name: string) {
   await expect(committed).toBeVisible({ timeout: 15_000 });
 }
 
-async function fillCreatePersonModal(page: Page, name: string) {
-  const modal = page.getByTestId("v2-person-details-modal");
-  await expect(modal).toBeVisible({ timeout: 5_000 });
-  await page.getByTestId("v2-person-name-input").fill(name);
-  await page.getByTestId("v2-person-create").click();
-}
-
-async function seedFamilyForPerson(
-  page: Page,
-  person: { cx: number; cy: number },
-  spouseName: string,
-) {
-  // Gesture 3 (person → empty): creates a family where the dragged person and
-  // the new modal person are both parents (no children). Empty→person is a
-  // no-op (#180), so this is the only drag-based path to seed a family.
-  await pressAndDrag(page, person.cx, person.cy, person.cx + 280, person.cy + 80);
-  await page.mouse.up();
-  await fillCreatePersonModal(page, spouseName);
-  await waitForRealFamily(page);
-}
-
 type NodeRef = { id: string; locator: Locator; cx: number; cy: number };
 
 async function nodeByText(page: Page, text: string): Promise<NodeRef> {
@@ -76,15 +47,6 @@ async function nodeByText(page: Page, text: string): Promise<NodeRef> {
   const bb = await circle.boundingBox();
   if (!bb) throw new Error("no bbox for " + text);
   return { id, locator: group, cx: bb.x + bb.width / 2, cy: bb.y + bb.height / 2 };
-}
-
-async function familyCenter(page: Page, index = 0): Promise<{ cx: number; cy: number }> {
-  const family = page.locator("svg#chart g[id^='family_']").nth(index);
-  await expect(family).toBeVisible({ timeout: 10_000 });
-  const circle = family.locator("circle");
-  const bb = await circle.boundingBox();
-  if (!bb) throw new Error("no family bbox");
-  return { cx: bb.x + bb.width / 2, cy: bb.y + bb.height / 2 };
 }
 
 async function familyCount(page: Page): Promise<number> {
@@ -99,185 +61,7 @@ async function pressAndDrag(page: Page, fromX: number, fromY: number, toX: numbe
   await page.waitForTimeout(100);
 }
 
-async function pressAndDragFromFamily(
-  page: Page,
-  to: { cx: number; cy: number },
-  index = 0,
-) {
-  const family = page.locator("svg#chart g[id^='family_']").nth(index);
-  await expect(family).toBeVisible({ timeout: 10_000 });
-  const bb = await family.locator("circle").boundingBox();
-  if (!bb) throw new Error("no family bbox");
-  const cx = bb.x + bb.width / 2;
-  const cy = bb.y + bb.height / 2;
-  await page.mouse.move(cx, cy);
-  await page.mouse.down();
-  await page.mouse.move(cx + 30, cy + 30, { steps: 4 });
-  await page.mouse.move(to.cx, to.cy, { steps: 12 });
-  await page.waitForTimeout(100);
-}
-
-async function waitForRealFamily(page: Page) {
-  await expect(page.locator("svg#chart g[id^='family_pending-']")).toHaveCount(0, { timeout: 15_000 });
-  await expect(page.locator("svg#chart g[id^='family_']")).toHaveCount(1, { timeout: 15_000 });
-}
-
-async function expectTip(page: Page, re: RegExp) {
-  const tip = page.getByTestId("v2-drag-tip");
-  await expect(tip).toBeVisible({ timeout: 5_000 });
-  await expect(tip).toHaveText(re);
-}
-
 test.describe.configure({ mode: "serial" });
-
-test.describe("v2 drag tooltips", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/v2");
-    await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
-    await createFreshStemma(page);
-    await enterEditMode(page);
-  });
-
-  test("person → empty tooltip: Create spouse", async ({ page }) => {
-    const name = `Alice${Date.now()}`;
-    await addOrphan(page, name);
-    const alice = await nodeByText(page, name);
-    await pressAndDrag(page, alice.cx, alice.cy, alice.cx + 260, alice.cy + 80);
-    await expectTip(page, TIP.createSpouse);
-    await page.keyboard.press("Escape");
-    await page.mouse.up();
-  });
-
-  // person → family attach-as-spouse tooltip is not exercised: the only
-  // drag-buildable family already has two parents (gesture 3 fills both
-  // slots), so canAddParent fails and the family becomes v2-drop-disallowed
-  // — pointer-events: none, no tip. Coverage moves to a unit test if needed.
-
-  test("family → person tooltip: Attach as child", async ({ page }) => {
-    const ts = Date.now();
-    const a = `Carl${ts}`;
-    const c = `Eve${ts}`;
-    const seed = `CarlChild${ts}`;
-    await addOrphan(page, a);
-    await addOrphan(page, c);
-    const carl = await nodeByText(page, a);
-    await seedFamilyForPerson(page, carl, seed);
-    const eve = await nodeByText(page, c);
-    await pressAndDragFromFamily(page, eve);
-    await expectTip(page, TIP.attachChild);
-    await page.keyboard.press("Escape");
-    await page.mouse.up();
-  });
-
-  test("family → empty tooltip: Create child", async ({ page }) => {
-    const ts = Date.now();
-    const a = `Fred${ts}`;
-    const seed = `FredChild${ts}`;
-    await addOrphan(page, a);
-    const fred = await nodeByText(page, a);
-    await seedFamilyForPerson(page, fred, seed);
-    const fc2 = await familyCenter(page);
-    await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
-    await expectTip(page, TIP.createChild);
-    await page.keyboard.press("Escape");
-    await page.mouse.up();
-  });
-
-  test("empty → family tooltip: Create spouse", async ({ page }) => {
-    const ts = Date.now();
-    const a = `Henry${ts}`;
-    const seed = `HenryChild${ts}`;
-    await addOrphan(page, a);
-    const henry = await nodeByText(page, a);
-    await seedFamilyForPerson(page, henry, seed);
-    const fc2 = await familyCenter(page);
-    const vp = page.viewportSize();
-    const startX = vp ? vp.width - 80 : fc2.cx + 300;
-    const startY = vp ? Math.floor(vp.height / 2) : fc2.cy;
-    await pressAndDrag(page, startX, startY, fc2.cx, fc2.cy);
-    await expectTip(page, TIP.createSpouse);
-    await page.keyboard.press("Escape");
-    await page.mouse.up();
-  });
-
-});
-
-test("v2 family→empty release opens person details modal and creates child", async ({ page }) => {
-  await page.goto("/v2");
-  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
-  await createFreshStemma(page);
-  await enterEditMode(page);
-  const ts = Date.now();
-  const a = `Pat${ts}`;
-  const seed = `PatChild${ts}`;
-  const child = `Rita${ts}`;
-  await addOrphan(page, a);
-  const pat = await nodeByText(page, a);
-  await seedFamilyForPerson(page, pat, seed);
-  const fc2 = await familyCenter(page);
-  await pressAndDragFromFamily(page, { cx: fc2.cx + 250, cy: fc2.cy + 200 });
-  await page.mouse.up();
-  await fillCreatePersonModal(page, child);
-  const committed = page
-    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
-    .filter({ has: page.locator(`text="${child}"`) })
-    .first();
-  await expect(committed).toBeVisible({ timeout: 15_000 });
-});
-
-test("v2 person→empty release opens person details modal and creates spouse", async ({ page }) => {
-  await page.goto("/v2");
-  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
-  await createFreshStemma(page);
-  await enterEditMode(page);
-  const name = `Mira${Date.now()}`;
-  const spouse = `MiraSpouse${Date.now()}`;
-  await addOrphan(page, name);
-  expect(await familyCount(page)).toBe(0);
-  const mira = await nodeByText(page, name);
-  await pressAndDrag(page, mira.cx, mira.cy, mira.cx + 260, mira.cy + 80);
-  await page.mouse.up();
-  await fillCreatePersonModal(page, spouse);
-  await waitForRealFamily(page);
-  const committed = page
-    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
-    .filter({ has: page.locator(`text="${spouse}"`) })
-    .first();
-  await expect(committed).toBeVisible({ timeout: 15_000 });
-});
-
-test("v2 empty→person release is a no-op (#180)", async ({ page }) => {
-  await page.goto("/v2");
-  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
-  await createFreshStemma(page);
-  await enterEditMode(page);
-  const name = `Noel${Date.now()}`;
-  await addOrphan(page, name);
-  expect(await familyCount(page)).toBe(0);
-  const noel = await nodeByText(page, name);
-  const startX = noel.cx + 280;
-  const startY = noel.cy + 150;
-  await expectNoOpDrag(page, startX, startY, noel.cx, noel.cy);
-});
-
-test("v2 Esc cancels gesture before drop", async ({ page }) => {
-  await page.goto("/v2");
-  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
-  await createFreshStemma(page);
-  await enterEditMode(page);
-  const name = `Nora${Date.now()}`;
-  await addOrphan(page, name);
-  const baselineFamilies = await familyCount(page);
-  const nora = await nodeByText(page, name);
-  await page.mouse.move(nora.cx, nora.cy);
-  await page.mouse.down();
-  await page.mouse.move(nora.cx + 60, nora.cy + 60, { steps: 6 });
-  await expect(page.getByTestId("v2-drag-tip")).toBeVisible({ timeout: 3_000 });
-  await page.keyboard.press("Escape");
-  await expect(page.getByTestId("v2-drag-tip")).toBeHidden({ timeout: 2_000 });
-  await page.mouse.up();
-  expect(await familyCount(page)).toBe(baselineFamilies);
-});
 
 async function expectNoOpDrag(
   page: Page,
@@ -288,15 +72,11 @@ async function expectNoOpDrag(
 ) {
   const baselineFamilies = await familyCount(page);
   await pressAndDrag(page, startX, startY, endX, endY);
-  // Tooltip must be hidden while hovering an invalid target.
   const tip = page.getByTestId("v2-drag-tip");
   await expect(tip).toBeHidden({ timeout: 1_500 });
-  // No SVG group should be marked as a valid drop target.
   await expect(page.locator("svg#chart .v2-drop-target")).toHaveCount(0);
   await page.mouse.up();
-  // No detail/create modal should open on release.
   await expect(page.getByTestId("v2-person-details-modal")).toHaveCount(0);
-  // Family count unchanged.
   expect(await familyCount(page)).toBe(baselineFamilies);
 }
 
@@ -315,64 +95,45 @@ test("v2 person → person drag is a no-op (no tip, no modal, no DB change)", as
   await expectNoOpDrag(page, alpha.cx, alpha.cy, bravo.cx, bravo.cy);
 });
 
-test("v2 family → family drag is a no-op (no tip, no modal, no DB change)", async ({ page }) => {
-  await page.goto("/v2");
-  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
-  await createFreshStemma(page);
-  await enterEditMode(page);
-  const ts = Date.now();
-  // Seed family #1 around personA.
-  const personA = `Cleo${ts}`;
-  const childA = `CleoChild${ts}`;
-  await addOrphan(page, personA);
-  const cleo = await nodeByText(page, personA);
-  await seedFamilyForPerson(page, cleo, childA);
-  // Seed family #2 around personB, well separated horizontally.
-  const personB = `Dion${ts}`;
-  const childB = `DionChild${ts}`;
-  await page.getByTestId("v2-add-person-fab").click();
-  await page.getByTestId("v2-person-name-input").fill(personB);
-  await page.getByTestId("v2-person-create").click();
-  const dionCommitted = page
-    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
-    .filter({ has: page.locator(`text="${personB}"`) })
-    .first();
-  await expect(dionCommitted).toBeVisible({ timeout: 15_000 });
-  const dion = await nodeByText(page, personB);
-  // Gesture 3 (person → empty) — second family with dion + childB as parents.
-  await pressAndDrag(page, dion.cx, dion.cy, dion.cx + 280, dion.cy + 80);
-  await page.mouse.up();
-  await fillCreatePersonModal(page, childB);
-  await expect(page.locator("svg#chart g[id^='family_pending-']")).toHaveCount(0, { timeout: 15_000 });
-  await expect(page.locator("svg#chart g[id^='family_']")).toHaveCount(2, { timeout: 15_000 });
-  const f0 = await familyCenter(page, 0);
-  const f1 = await familyCenter(page, 1);
-  // Drag from family 0 to family 1.
-  const baselineFamilies = await familyCount(page);
-  await pressAndDrag(page, f0.cx, f0.cy, f1.cx, f1.cy);
-  const tip = page.getByTestId("v2-drag-tip");
-  await expect(tip).toBeHidden({ timeout: 1_500 });
-  await expect(page.locator("svg#chart .v2-drop-target")).toHaveCount(0);
-  await page.mouse.up();
-  await expect(page.getByTestId("v2-person-details-modal")).toHaveCount(0);
-  expect(await familyCount(page)).toBe(baselineFamilies);
-});
-
 test("v2 empty → empty drag is a no-op (no tip, no modal, no DB change)", async ({ page }) => {
   await page.goto("/v2");
   await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
   await createFreshStemma(page);
   await enterEditMode(page);
-  // Add an orphan just so the chart has a node and a stable empty region.
   const name = `Solo${Date.now()}`;
   await addOrphan(page, name);
   const solo = await nodeByText(page, name);
-  // Drag from one empty point to another, well clear of `solo`.
   const startX = solo.cx + 320;
   const startY = solo.cy + 220;
   const endX = solo.cx - 320;
   const endY = solo.cy + 220;
   await expectNoOpDrag(page, startX, startY, endX, endY);
+});
+
+test("v2 person→empty release is a no-op (#179)", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const name = `Mira${Date.now()}`;
+  await addOrphan(page, name);
+  expect(await familyCount(page)).toBe(0);
+  const mira = await nodeByText(page, name);
+  await expectNoOpDrag(page, mira.cx, mira.cy, mira.cx + 280, mira.cy + 80);
+});
+
+test("v2 empty→person release is a no-op (#180)", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const name = `Noel${Date.now()}`;
+  await addOrphan(page, name);
+  expect(await familyCount(page)).toBe(0);
+  const noel = await nodeByText(page, name);
+  const startX = noel.cx + 280;
+  const startY = noel.cy + 150;
+  await expectNoOpDrag(page, startX, startY, noel.cx, noel.cy);
 });
 
 test("v2 drag link line renders arrow marker at cursor end", async ({ page }) => {

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -58,7 +58,6 @@
     let signedIn = $state(e2eAutoLoginEnabled || initialCached !== null);
 
     type PendingAdd = { tempId: string; name: string };
-    type PendingFamily = { tempId: string; parents: string[]; children: string[]; x?: number; y?: number };
 
     let editMode = $state(false);
     let panMode = $state(false);
@@ -67,15 +66,10 @@
     let pendingRemovedPersonIds = $state<Set<string>>(new Set());
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let pendingAdds = $state<PendingAdd[]>([]);
-    let pendingFamilies = $state<PendingFamily[]>([]);
     let trayOpen = $state(false);
 
     function isPendingId(id: string): boolean {
         return id.startsWith("pending-");
-    }
-
-    function isPendingPersonId(id: string): boolean {
-        return id.startsWith("pending-") && !id.startsWith("pending-family-");
     }
 
     let ownedStemmas = $state<StemmaDescription[]>([]);
@@ -115,7 +109,6 @@
                 pendingRemovedPersonIds = new Set();
                 pendingRemovedFamilyIds = new Set();
                 pendingAdds = [];
-                pendingFamilies = [];
             }
         }),
         controller.ownedStemmas.subscribe((os) => (ownedStemmas = os)),
@@ -147,20 +140,10 @@
 
     const displayedStemma = $derived.by<Stemma | null>(() => {
         if (!stemma) return null;
-        if (pendingAdds.length === 0 && pendingFamilies.length === 0) return stemma;
+        if (pendingAdds.length === 0) return stemma;
         return {
             ...stemma,
             people: [...stemma.people, ...pendingAdds.map(pendingPersonDescription)],
-            families: [
-                ...stemma.families,
-                ...pendingFamilies.map((pf) => ({
-                    type: "FamilyDescription" as const,
-                    id: pf.tempId,
-                    parents: pf.parents,
-                    children: pf.children,
-                    readOnly: true,
-                })),
-            ],
         };
     });
 
@@ -180,7 +163,6 @@
         void pendingRemovedPersonIds;
         void pendingRemovedFamilyIds;
         void pendingAdds;
-        void pendingFamilies;
         queueMicrotask(applyPendingClasses);
     });
 
@@ -198,7 +180,6 @@
         pendingRemovedPersonIds.forEach((id) => markCircle(normalizeId("person", id), "v2-pending-remove"));
         pendingRemovedFamilyIds.forEach((id) => markCircle(normalizeId("family", id), "v2-pending-remove"));
         pendingAdds.forEach((p) => markCircle(normalizeId("person", p.tempId), "v2-pending-add"));
-        pendingFamilies.forEach((p) => markCircle(normalizeId("family", p.tempId), "v2-pending-add"));
     }
 
     async function withPendingAdd(
@@ -229,10 +210,6 @@
         return `pending-${crypto.randomUUID()}`;
     }
 
-    function newPendingFamilyId(): string {
-        return `pending-family-${crypto.randomUUID()}`;
-    }
-
     function clientToSvgPoint(svgEl: SVGSVGElement, clientX: number, clientY: number): { x: number; y: number } {
         const pt = svgEl.createSVGPoint();
         pt.x = clientX;
@@ -258,7 +235,7 @@
         if (!g) return null;
         const kind = g.id.startsWith("person_") ? "person" : "family";
         const id = denormalizeId(g.id);
-        if (kind === "person" && isPendingPersonId(id)) return null;
+        if (kind === "person" && isPendingId(id)) return null;
         return { ref: { kind, id }, el: g };
     }
 
@@ -285,57 +262,6 @@
         const parents = role === "parent" ? [...existingParents, incoming] : existingParents;
         const children = role === "child" ? [...existingChildren, incoming] : existingChildren;
         controller.updateFamily(familyId, parents, children, { silent: true }).catch(() => {});
-    }
-
-    function createSpouseForPerson(
-        existingPersonId: string,
-        existingCenter: { x: number; y: number },
-        title: string,
-        dropAt: { x: number; y: number },
-    ) {
-        // Family marker goes at the midpoint between the existing person and the
-        // drop point so it doesn't overlap the new spouse circle.
-        const familyAt = { x: (existingCenter.x + dropAt.x) / 2, y: (existingCenter.y + dropAt.y) / 2 };
-        personEditModal?.showCreatePerson({
-            title,
-            oncreate: ({ description, pin, photoUpload }) => {
-                const tempPersonId = newPendingPersonId();
-                const tempFamilyId = newPendingFamilyId();
-                pendingAdds = [...pendingAdds, { tempId: tempPersonId, name: description.name }];
-                pendingFamilies = [
-                    ...pendingFamilies,
-                    {
-                        tempId: tempFamilyId,
-                        parents: [existingPersonId, tempPersonId],
-                        children: [],
-                        x: familyAt.x,
-                        y: familyAt.y,
-                    },
-                ];
-                stemmaChart?.setNodePosition(normalizeId("person", tempPersonId), dropAt.x, dropAt.y);
-                stemmaChart?.setNodePosition(normalizeId("family", tempFamilyId), familyAt.x, familyAt.y);
-                const existingRef: PersonDefinition = { type: "ExistingPerson", id: existingPersonId };
-                controller
-                    .createFamily([existingRef, description], [], { silent: true })
-                    .then((result) => {
-                        const newPersonId = result.newPersonIds[0];
-                        if (newPersonId) {
-                            stemmaChart?.setNodePosition(normalizeId("person", newPersonId), dropAt.x, dropAt.y);
-                            if (photoUpload || pin) {
-                                controller.savePerson(newPersonId, description, pin, photoUpload, false);
-                            }
-                        }
-                        result.newFamilyIds.forEach((id) =>
-                            stemmaChart?.setNodePosition(normalizeId("family", id), familyAt.x, familyAt.y),
-                        );
-                    })
-                    .catch(() => {})
-                    .finally(() => {
-                        pendingAdds = pendingAdds.filter((p) => p.tempId !== tempPersonId);
-                        pendingFamilies = pendingFamilies.filter((p) => p.tempId !== tempFamilyId);
-                    });
-            },
-        });
     }
 
     function createPersonInFamily(
@@ -394,7 +320,7 @@
             const fid = denormalizeId(g.id);
             g.classList.remove("v2-drop-target");
             if (!pid || !fid) return;
-            if (isPendingPersonId(pid)) return;
+            if (isPendingId(pid)) return;
             e.preventDefault();
             const dropSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
             attachPersonToFamily(pid, fid, "parent", dropSvg);
@@ -417,7 +343,6 @@
         if (!svgEl) return;
 
         const PERSON_PREVIEW_R = 15;
-        const FAMILY_PREVIEW_R = 7;
 
         let gesture: {
             source: SourceRef;
@@ -486,7 +411,6 @@
                     const c = displayedStemmaIndex?.canAddParent(overInfo.ref.id, source.id);
                     return c?.ok ? "valid" : "noop";
                 }
-                if (!overInfo) return "create-empty";
                 return "noop";
             }
             if (source.kind === "family") {
@@ -515,7 +439,7 @@
             if (targetG) {
                 const kind = targetG.id.startsWith("person_") ? "person" : "family";
                 const sourceId = denormalizeId(targetG.id);
-                if (kind === "person" && isPendingPersonId(sourceId)) return;
+                if (kind === "person" && isPendingId(sourceId)) return;
                 const c = nodeCenter(targetG);
                 if (!c) return;
                 source = { kind, id: sourceId };
@@ -551,8 +475,7 @@
 
         const computeTipText = (overInfo: { ref: NodeRef } | null, source: SourceRef): string | null => {
             if (source.kind === "person") {
-                if (!overInfo) return $t("v2.tipCreateSpouse");
-                if (overInfo.ref.kind === "family") return $t("v2.tipAttachSpouse");
+                if (overInfo?.ref.kind === "family") return $t("v2.tipAttachSpouse");
                 return null;
             }
             if (source.kind === "family") {
@@ -573,14 +496,14 @@
             overInfo: { ref: NodeRef } | null,
         ) => {
             if (!gesture) return;
-            if (overInfo || gesture.source.kind === "empty") {
+            if (overInfo || gesture.source.kind !== "family") {
                 if (gesture.endpointPreview) {
                     gesture.endpointPreview.style.display = "none";
                 }
                 return;
             }
-            const previewKind = gesture.source.kind === "person" ? "family" : "person";
-            const r = previewKind === "person" ? PERSON_PREVIEW_R : FAMILY_PREVIEW_R;
+            const previewKind = "person";
+            const r = PERSON_PREVIEW_R;
             if (!gesture.endpointPreview && mainG) {
                 const p = document.createElementNS(SVG_NS, "circle") as SVGCircleElement;
                 p.setAttribute("class", `v2-endpoint-preview v2-endpoint-${previewKind}`);
@@ -667,11 +590,6 @@
                 attachPersonToFamily(overInfo.ref.id, source.id, "child", tgtCenter);
                 return;
             }
-            if (source.kind === "person" && !overInfo) {
-                const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
-                createSpouseForPerson(source.id, startCenter, $t("v2.createSpouseTitle"), releaseSvg);
-                return;
-            }
             if (source.kind === "empty" && overInfo?.ref.kind === "family") {
                 createPersonInFamily(overInfo.ref.id, "parent", $t("v2.createSpouseTitle"), startCenter);
                 return;
@@ -719,7 +637,7 @@
     function classifyForDrop(src: SourceRef, g: Element): "v2-drop-allowed" | "v2-drop-disallowed" | null {
         const id = denormalizeId(g.id);
         const kind: "person" | "family" = g.id.startsWith("person_") ? "person" : "family";
-        if (kind === "person" && isPendingPersonId(id)) return null;
+        if (kind === "person" && isPendingId(id)) return null;
         if (src.kind === "person") {
             if (kind !== "family") return null;
             if (isPendingId(id)) return "v2-drop-allowed";
@@ -742,7 +660,6 @@
         const src = activeGestureSource;
         if (!src || src.kind === "empty") return;
         void displayedStemmaIndex;
-        void pendingFamilies;
         const svgEl = document.getElementById("chart");
         if (!svgEl) return;
         svgEl.querySelectorAll("g[id^='person_'], g[id^='family_']").forEach((g) => {


### PR DESCRIPTION
## Summary
- Person→empty (gesture 3) now classifies as noop: no tip, no drop-target highlight, no endpoint preview, no modal, no family creation.
- `createSpouseForPerson` deleted along with the `PendingFamily` state/type/plumbing — no remaining code path appends pending families. `isPendingPersonId` collapses into `isPendingId`. `FAMILY_PREVIEW_R` and the family-preview branch of `updateEndpointPreview` are gone.
- `frontend/CLAUDE.md` (gitignored) scenario matrix shrinks to four gestures; person→empty joins the explicit no-op list.
- e2e suite: the `person→empty release` test is inverted to assert no-op (#179). Tests that depended on drag-seeded families (tooltip coverage for gestures 1/2/4/5, family→empty release, family→family no-op, Esc-cancel) are removed — gesture 3 was their only seed path, mirroring the cleanup done in #180.

Closes #179.

## Test plan
- [x] `npm run check` in `frontend/` — 0 errors.
- [x] `npm test` in `frontend/` — 19 suites, 149 tests pass.
- [x] `npm run build` in `frontend/` — bundle builds.
- [x] `npm test` in `e2e/` — 23/23 pass, including the four no-op release tests and the arrow-marker render test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)