### PR TITLE
v2 pending-family follow-ups: positioning, two-parent guard, mobile, cleanup

### DIFF
--- a/e2e/tests/v2_drag_ux.spec.ts
+++ b/e2e/tests/v2_drag_ux.spec.ts
@@ -168,6 +168,48 @@ test("v2 dragging second person onto pending family promotes it to real family",
   await expect(page.locator("svg#chart g[id^='family_']:not([id*='pending-'])")).toHaveCount(1, { timeout: 10_000 });
 });
 
+test("v2 empty→person drag onto person that already has 2 parents is blocked", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const ts = Date.now();
+  const dad = `Dad${ts}`;
+  const mom = `Mom${ts}`;
+  const kid = `Kid${ts}`;
+  await addOrphan(page, dad);
+  await addOrphan(page, mom);
+  await addOrphan(page, kid);
+  const dadNode = await nodeByText(page, dad);
+  await pressAndDrag(page, dadNode.cx, dadNode.cy, dadNode.cx + 260, dadNode.cy + 80);
+  await page.mouse.up();
+  const pending = page.locator("svg#chart g[id^='family_pending-family-']").first();
+  await expect(pending).toBeVisible({ timeout: 3_000 });
+  const pendingBb = await pending.locator("circle").boundingBox();
+  if (!pendingBb) throw new Error("no pending family bbox");
+  const momNode = await nodeByText(page, mom);
+  await pressAndDrag(page, momNode.cx, momNode.cy, pendingBb.x + pendingBb.width / 2, pendingBb.y + pendingBb.height / 2);
+  await page.mouse.up();
+  const realFam = page.locator("svg#chart g[id^='family_']:not([id*='pending-'])").first();
+  await expect(realFam).toBeVisible({ timeout: 10_000 });
+  const realBb = await realFam.locator("circle").boundingBox();
+  if (!realBb) throw new Error("no real family bbox");
+  const kidNode = await nodeByText(page, kid);
+  await pressAndDrag(page, realBb.x + realBb.width / 2, realBb.y + realBb.height / 2, kidNode.cx, kidNode.cy);
+  await page.mouse.up();
+  await page.waitForTimeout(1_000);
+  const familiesBefore = await familyCount(page);
+  const kidNode2 = await nodeByText(page, kid);
+  const startX = kidNode2.cx + 220;
+  const startY = kidNode2.cy + 140;
+  await pressAndDrag(page, startX, startY, kidNode2.cx, kidNode2.cy);
+  const tip = page.getByTestId("v2-drag-tip");
+  await expect(tip).toBeHidden({ timeout: 1_500 });
+  await expect(page.locator("svg#chart .v2-drop-target")).toHaveCount(0);
+  await page.mouse.up();
+  expect(await familyCount(page)).toBe(familiesBefore);
+});
+
 test("v2 drag link line renders arrow marker at cursor end", async ({ page }) => {
   await page.goto("/v2");
   await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });

--- a/e2e/tests/v2_drag_ux.spec.ts
+++ b/e2e/tests/v2_drag_ux.spec.ts
@@ -210,6 +210,23 @@ test("v2 empty→person drag onto person that already has 2 parents is blocked",
   expect(await familyCount(page)).toBe(familiesBefore);
 });
 
+test("v2 exiting edit mode purges single-member pending families", async ({ page }) => {
+  await page.goto("/v2");
+  await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const name = `Rhea${Date.now()}`;
+  await addOrphan(page, name);
+  const rhea = await nodeByText(page, name);
+  await pressAndDrag(page, rhea.cx, rhea.cy, rhea.cx + 280, rhea.cy + 80);
+  await page.mouse.up();
+  await expect(page.locator("svg#chart g[id^='family_pending-family-']")).toHaveCount(1, { timeout: 3_000 });
+  await page.getByTestId("v2-edit-fab").click();
+  await expect(page.locator(".v2-edit-mode")).toHaveCount(0);
+  await expect(page.locator("svg#chart g[id^='family_pending-family-']")).toHaveCount(0, { timeout: 3_000 });
+  expect(await familyCount(page)).toBe(0);
+});
+
 test("v2 drag link line renders arrow marker at cursor end", async ({ page }) => {
   await page.goto("/v2");
   await expect(page.locator("[data-testid='v2-empty-state'], svg#chart")).toBeVisible({ timeout: 30_000 });

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -441,7 +441,7 @@ export const ru: Record<string, string> = {
     'v2.createNew': 'Создать нового',
     'v2.stubFamily': 'Новая семья (не сохранена)',
     'v2.editMode': 'Режим редактирования',
-    'v2.editModeBanner': 'РЕЖИМ ПРАВКИ',
+    'v2.editModeBanner': 'ПРАВКА',
     'v2.signOut': 'Выйти',
     'v2.about': 'О проекте',
     'v2.settings': 'Настройки',

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -324,7 +324,7 @@
         return { ref: { kind, id }, el: g };
     }
 
-    function familyHasPerson(family: FamilyDescription, pid: string): boolean {
+    function familyHasPerson(family: { parents: string[]; children: string[] }, pid: string): boolean {
         return family.parents.includes(pid) || family.children.includes(pid);
     }
 
@@ -336,7 +336,7 @@
     ) {
         const pending = findPendingFamily(familyId);
         if (pending) {
-            if (pending.parents.includes(personId) || pending.children.includes(personId)) return;
+            if (familyHasPerson(pending, personId)) return;
             if (pinAt) {
                 stemmaChart?.setNodePosition(normalizeId("person", personId), pinAt.x, pinAt.y);
             }

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -86,6 +86,14 @@
         return pendingFamilies.find((f) => f.tempId === id);
     }
 
+    function parentCountOf(personId: string): number {
+        if (!displayedStemmaIndex) return 0;
+        return displayedStemmaIndex
+            .relatedFamilies(personId)
+            .filter((f) => f.children.includes(personId))
+            .reduce((sum, f) => sum + f.parents.length, 0);
+    }
+
     let ownedStemmas = $state<StemmaDescription[]>([]);
     let currentStemmaId = $state<string | null>(null);
     let stemma = $state<Stemma | null>(null);
@@ -542,7 +550,10 @@
             }
             if (source.kind === "empty") {
                 if (overInfo?.ref.kind === "family") return "valid";
-                if (overInfo?.ref.kind === "person") return "valid";
+                if (overInfo?.ref.kind === "person") {
+                    if (parentCountOf(overInfo.ref.id) >= 2) return "noop";
+                    return "valid";
+                }
                 return "noop";
             }
             return "noop";
@@ -702,7 +713,7 @@
             }
             const mainG = svgEl.querySelector("g.main") as SVGGElement | null;
             updateEndpointPreview(mainG, svgPt, overInfo);
-            const tipText = computeTipText(overInfo, gesture.source);
+            const tipText = compat === "noop" ? null : computeTipText(overInfo, gesture.source);
             dragTip = tipText ? { text: tipText, x: e.clientX, y: e.clientY } : null;
         };
 
@@ -739,6 +750,7 @@
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "person") {
+                if (parentCountOf(overInfo.ref.id) >= 2) return;
                 createPendingFamilyForPerson(overInfo.ref.id, "child", startCenter);
                 return;
             }

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -559,9 +559,7 @@
             return "noop";
         };
 
-        const onMouseDown = (e: MouseEvent) => {
-            if (e.button !== 0) return;
-            if (panActive) return;
+        const onPointerStart = (e: PointerEvent) => {
             const targetG = (e.target as Element | null)?.closest?.("g[id^='person_'], g[id^='family_']") as SVGGElement | null;
             let source: SourceRef;
             let center: { x: number; y: number };
@@ -592,15 +590,8 @@
                 endpointPreview: null,
                 lastTarget: null,
             };
-            // Apply linking cursor + selection lock immediately so that
-            // browsers don't latch the I-beam from the initial mousedown
-            // over an SVG text label for the rest of the drag.
             document.body.classList.add("v2-linking");
-            // Prevent native text selection / drag of svg labels — selection
-            // can hijack the gesture (mouseup replaced by dragend) and
-            // visually litters the chart with highlighted text.
             e.preventDefault();
-            e.stopImmediatePropagation();
         };
 
         const computeTipText = (overInfo: { ref: NodeRef } | null, source: SourceRef): string | null => {
@@ -663,7 +654,7 @@
             }
         };
 
-        const onMouseMove = (e: MouseEvent) => {
+        const onPointerMove = (e: PointerEvent) => {
             if (!gesture) return;
             const dx = e.clientX - gesture.startClientX;
             const dy = e.clientY - gesture.startClientY;
@@ -717,7 +708,7 @@
             dragTip = tipText ? { text: tipText, x: e.clientX, y: e.clientY } : null;
         };
 
-        const onMouseUp = (e: MouseEvent) => {
+        const onPointerEnd = (e: PointerEvent) => {
             if (!gesture) return;
             const wasActive = gesture.active;
             const source = gesture.source;
@@ -763,25 +754,28 @@
         const onCancel = () => cleanup();
         // d3.drag attaches a pointerdown listener to each node g and restarts
         // the force simulation on press, which would scramble pinned positions
-        // mid-gesture. Swallow pointerdown at the svg root in edit mode so the
-        // d3 handler never sees it; V2's mousedown listener handles the gesture.
-        const onPointerDown = (e: PointerEvent) => {
-            if (e.button !== 0) return;
+        // mid-gesture. Capturing pointerdown at the svg root and stopping
+        // propagation prevents the d3 handler from ever seeing it, and the
+        // same handler starts V2's linking gesture. Single path covers mouse,
+        // pen, and touch.
+        const onPointerDownCapture = (e: PointerEvent) => {
             if (panActive) return;
+            if (e.pointerType === "mouse" && e.button !== 0) return;
             e.stopImmediatePropagation();
+            onPointerStart(e);
         };
-        svgEl.addEventListener("pointerdown", onPointerDown, true);
-        svgEl.addEventListener("mousedown", onMouseDown, true);
-        window.addEventListener("mousemove", onMouseMove);
-        window.addEventListener("mouseup", onMouseUp);
+        svgEl.addEventListener("pointerdown", onPointerDownCapture, true);
+        window.addEventListener("pointermove", onPointerMove);
+        window.addEventListener("pointerup", onPointerEnd);
+        window.addEventListener("pointercancel", onCancel);
         window.addEventListener("keydown", onKeyDown);
         window.addEventListener("contextmenu", onCancel);
         window.addEventListener("blur", onCancel);
         return () => {
-            svgEl.removeEventListener("pointerdown", onPointerDown, true);
-            svgEl.removeEventListener("mousedown", onMouseDown, true);
-            window.removeEventListener("mousemove", onMouseMove);
-            window.removeEventListener("mouseup", onMouseUp);
+            svgEl.removeEventListener("pointerdown", onPointerDownCapture, true);
+            window.removeEventListener("pointermove", onPointerMove);
+            window.removeEventListener("pointerup", onPointerEnd);
+            window.removeEventListener("pointercancel", onCancel);
             window.removeEventListener("keydown", onKeyDown);
             window.removeEventListener("contextmenu", onCancel);
             window.removeEventListener("blur", onCancel);
@@ -842,10 +836,13 @@
     });
 
     $effect(() => {
-        if (!editMode) {
-            panMode = false;
-            spacePan = false;
-        }
+        if (editMode) return;
+        panMode = false;
+        spacePan = false;
+        untrack(() => {
+            const filtered = pendingFamilies.filter((p) => p.parents.length + p.children.length >= 2);
+            if (filtered.length !== pendingFamilies.length) pendingFamilies = filtered;
+        });
     });
 
     $effect(() => {
@@ -1338,6 +1335,10 @@
         user-select: none;
         -webkit-user-select: none;
         -webkit-user-drag: none;
+    }
+
+    :global(.v2-edit-mode .v2-canvas-layer #chart) {
+        touch-action: none;
     }
 
     :global(.v2-canvas-layer #chart text) {

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -735,20 +735,11 @@
             }
             if (source.kind === "person" && !overInfo) {
                 const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
-                const familyAt = {
-                    x: (startCenter.x + releaseSvg.x) / 2,
-                    y: (startCenter.y + releaseSvg.y) / 2,
-                };
-                createPendingFamilyForPerson(source.id, "parent", familyAt);
+                createPendingFamilyForPerson(source.id, "parent", releaseSvg);
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "person") {
-                const tgtCenter = nodeCenter(overInfo.el) ?? startCenter;
-                const familyAt = {
-                    x: (startCenter.x + tgtCenter.x) / 2,
-                    y: (startCenter.y + tgtCenter.y) / 2,
-                };
-                createPendingFamilyForPerson(overInfo.ref.id, "child", familyAt);
+                createPendingFamilyForPerson(overInfo.ref.id, "child", startCenter);
                 return;
             }
         };


### PR DESCRIPTION
## Summary
- Pin pending family at the empty-drag endpoint (release point for person→empty, press point for empty→person) instead of the midpoint.
- Block empty→person gesture when the target already has ≥2 parents (`parentCountOf`); hide tip on noop targets in general.
- Shorten Russian edit-mode watermark to "ПРАВКА" so adjacent SVG pattern tiles no longer overlap.
- Convert canvas gesture to pointer events (mouse + pen + touch) and merge the d3.drag swallow into the same captured handler; add `touch-action: none` on `#chart` in edit mode so mobile drag actually starts the linking gesture.
- Purge single-member pending families on edit-mode exit (`untrack`-wrapped to avoid effect self-loop).
- Reuse `familyHasPerson` for pending-vs-real membership check via a structural `{parents, children}` parameter type.

## Test plan
- [x] `npm run check` (svelte-check): 0 errors, 0 warnings
- [x] `npm test` (frontend jest): 149/149
- [x] `npx playwright test tests/v2_drag_ux.spec.ts`: 8/8 (includes new edit-exit-purge test, two-parent block test)
- [ ] Manual mobile (iOS Safari / Android Chrome): in edit mode, drag from a person into empty area → pending family appears at release point, node doesn't move on press. Drag a second person onto the pending family → it promotes to a real family.
- [ ] Manual desktop: enter edit mode → drag person → empty (pending family appears at drop point) → exit edit mode → pending family vanishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)