### PR TITLE
Reject v2 child-family additions when person already has a parent

### DIFF
--- a/frontend/src/stemmaIndex.test.ts
+++ b/frontend/src/stemmaIndex.test.ts
@@ -143,9 +143,35 @@ describe("canAddParent / canAddChild", () => {
         expect(jjIndex().canAddChild("4", joseph)).toEqual({ ok: false, reason: "cycle" })
     })
 
-    test("canAddChild allows valid addition", () => {
-        // family 4: parents [james], children [jeff]; josh has no descendant families
-        expect(jjIndex().canAddChild("4", josh)).toEqual({ ok: true })
+    test("canAddChild rejects when person already has a parent family", () => {
+        // jill is already a child of family 1; adding her as child of family 5 must be rejected
+        expect(jjIndex().canAddChild("5", jill)).toEqual({ ok: false, reason: "alreadyChild" })
+    })
+
+    test("canAddChild allows addition when person is parentless and not a descendant", () => {
+        // Custom stemma: alice is unrelated, no parent family; add as child of bob+carol's family
+        const alice = "a"
+        const bob = "b"
+        const carol = "c"
+        const fixture = stemma({
+            people: [
+                person({ id: alice, name: "alice", readOnly: false }),
+                person({ id: bob, name: "bob", readOnly: false }),
+                person({ id: carol, name: "carol", readOnly: false }),
+            ],
+            families: [
+                family({ id: "1", parents: [bob, carol], children: [], readOnly: false }),
+            ],
+        })
+        expect(new StemmaIndex(fixture).canAddChild("1", alice)).toEqual({ ok: true })
+    })
+
+    test("hasParentFamily returns true only when person is a child in a non-empty family", () => {
+        const idx = jjIndex()
+        expect(idx.hasParentFamily(jane)).toBe(false) // jane is only a parent
+        expect(idx.hasParentFamily(josh)).toBe(true)  // child of f1
+        expect(idx.hasParentFamily(jill)).toBe(true)  // child of f1
+        expect(idx.hasParentFamily(joseph)).toBe(false) // only parent of f5
     })
 
     test("returns unknownFamily for missing id", () => {

--- a/frontend/src/stemmaIndex.ts
+++ b/frontend/src/stemmaIndex.ts
@@ -23,7 +23,7 @@ type FamilyMembers = {
 }
 
 
-export type AddCheck = { ok: true } | { ok: false, reason: "twoParents" | "alreadyMember" | "cycle" | "unknownFamily" }
+export type AddCheck = { ok: true } | { ok: false, reason: "twoParents" | "alreadyMember" | "cycle" | "unknownFamily" | "alreadyChild" }
 
 export class StemmaIndex {
     private _parentToChildren: Map<string, DirectedFamilyDescription[]>
@@ -107,7 +107,12 @@ export class StemmaIndex {
         if (family.children?.includes(personId)) return { ok: false, reason: "alreadyMember" }
         if (family.parents?.includes(personId)) return { ok: false, reason: "alreadyMember" }
         if (this._descendantFamiliesOfPerson.get(personId)?.has(familyId)) return { ok: false, reason: "cycle" }
+        if (this.hasParentFamily(personId)) return { ok: false, reason: "alreadyChild" }
         return { ok: true }
+    }
+
+    hasParentFamily(personId: string): boolean {
+        return this._childToParents.has(personId)
     }
 
     private computeLineage(personId: string, relation: Map<string, DirectedFamilyDescription[]>) {

--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -86,14 +86,6 @@
         return pendingFamilies.find((f) => f.tempId === id);
     }
 
-    function parentCountOf(personId: string): number {
-        if (!displayedStemmaIndex) return 0;
-        return displayedStemmaIndex
-            .relatedFamilies(personId)
-            .filter((f) => f.children.includes(personId))
-            .reduce((sum, f) => sum + f.parents.length, 0);
-    }
-
     function personNameOf(personId: string): string {
         return displayedStemmaIndex?.person(personId)?.name || "?";
     }
@@ -569,6 +561,7 @@
                         if (!pending) return "noop";
                         if (pending.parents.includes(overInfo.ref.id) || pending.children.includes(overInfo.ref.id))
                             return "noop";
+                        if (displayedStemmaIndex?.hasParentFamily(overInfo.ref.id)) return "noop";
                         return "valid";
                     }
                     const c = displayedStemmaIndex?.canAddChild(source.id, overInfo.ref.id);
@@ -580,7 +573,7 @@
             if (source.kind === "empty") {
                 if (overInfo?.ref.kind === "family") return "valid";
                 if (overInfo?.ref.kind === "person") {
-                    if (parentCountOf(overInfo.ref.id) >= 2) return "noop";
+                    if (displayedStemmaIndex?.hasParentFamily(overInfo.ref.id)) return "noop";
                     return "valid";
                 }
                 return "noop";
@@ -799,7 +792,7 @@
                 return;
             }
             if (source.kind === "empty" && overInfo?.ref.kind === "person") {
-                if (parentCountOf(overInfo.ref.id) >= 2) return;
+                if (displayedStemmaIndex?.hasParentFamily(overInfo.ref.id)) return;
                 createPendingFamilyForPerson(overInfo.ref.id, "child", startCenter);
                 return;
             }
@@ -864,9 +857,9 @@
             if (isPendingFamilyId(src.id)) {
                 const pending = findPendingFamily(src.id);
                 if (!pending) return null;
-                return pending.parents.includes(id) || pending.children.includes(id)
-                    ? "v2-drop-disallowed"
-                    : "v2-drop-allowed";
+                if (pending.parents.includes(id) || pending.children.includes(id)) return "v2-drop-disallowed";
+                if (displayedStemmaIndex?.hasParentFamily(id)) return "v2-drop-disallowed";
+                return "v2-drop-allowed";
             }
             const c = displayedStemmaIndex?.canAddChild(src.id, id);
             if (!c) return null;


### PR DESCRIPTION
## Summary
- Backend `_check_no_child_conflicts` already rejected a second parent family for the same child (`ChildAlreadyBelongsToFamily`), but the v2 UI let users stage the bad state visually — dragging `empty → person` on an existing child created a second pending family, and `family → person` attachments had no guard either.
- Added `StemmaIndex.hasParentFamily(personId)` (O(1) on the precomputed `_childToParents` map) and a new `AddCheck` reason `"alreadyChild"`.
- Wired it into `canAddChild`, the v2 `targetCompatibility` paths (empty source + pending-family source), the `empty → person` dispatch, and `classifyForDrop`. Removed the obsolete `parentCountOf` helper.
- Also covers the prior commit on this branch (pin pending family synchronously + label by children when parent unknown).

## Test plan
- [x] `npm test` (frontend Jest, 151 tests)
- [x] `npm run check` (svelte-check, 0 errors / 0 warnings)
- [ ] Manual: drag from empty onto a person who already has parents — gesture must show disallowed marker. Drag from a pending family node onto an existing child — same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)