### PR TITLE
Stop v2 link gesture firing alongside d3.zoom pan on touch

### DIFF
--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -818,7 +818,15 @@
             e.stopImmediatePropagation();
             onPointerStart(e);
         };
+        // touchstart fires before pointerdown, so d3.zoom would start a pan in parallel
+        // with the link gesture; swallow single-finger touch, let pinch through.
+        const onTouchStartCapture = (e: TouchEvent) => {
+            if (panActive) return;
+            if (e.touches.length !== 1) return;
+            e.stopPropagation();
+        };
         svgEl.addEventListener("pointerdown", onPointerDownCapture, true);
+        svgEl.addEventListener("touchstart", onTouchStartCapture, true);
         window.addEventListener("pointermove", onPointerMove);
         window.addEventListener("pointerup", onPointerEnd);
         window.addEventListener("pointercancel", onCancel);
@@ -827,6 +835,7 @@
         window.addEventListener("blur", onCancel);
         return () => {
             svgEl.removeEventListener("pointerdown", onPointerDownCapture, true);
+            svgEl.removeEventListener("touchstart", onTouchStartCapture, true);
             window.removeEventListener("pointermove", onPointerMove);
             window.removeEventListener("pointerup", onPointerEnd);
             window.removeEventListener("pointercancel", onCancel);


### PR DESCRIPTION
## Summary
- On mobile, `touchstart` reached d3.zoom's `touchstart.zoom` before the V2 `pointerdown` capture handler fired, so a canvas pan ran in parallel with the link-drag gesture (background AND nodes moved at once).
- Add a capture-phase `touchstart` listener on the svg that swallows single-finger touches when not in `panMode`; multi-touch (pinch zoom) still propagates to d3.zoom.

## Test plan
- [x] `npm test` (frontend, 151 passed)
- [x] `npm run check` (frontend, 0 errors)
- [ ] Manual: on a touch device, drag an empty area or a node in edit mode — only the link gesture should run, no background pan
- [ ] Manual: with panMode toggled on, single-finger drag still pans the canvas
- [ ] Manual: two-finger pinch still zooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)