### PR TITLE
Fix v2 mobile touch pan and Firefox bottom-bar FAB clipping

### DIFF
--- a/frontend/src/v2/V2App.svelte
+++ b/frontend/src/v2/V2App.svelte
@@ -1383,6 +1383,7 @@
         position: relative;
         width: 100vw;
         height: 100vh;
+        height: 100dvh;
         overflow: hidden;
         background: #f8f9fa;
     }
@@ -1394,6 +1395,7 @@
 
     :global(.v2-canvas-layer #chart) {
         min-height: 100vh;
+        min-height: 100dvh;
         padding: 0 !important;
         user-select: none;
         -webkit-user-select: none;
@@ -1456,16 +1458,16 @@
 
     .v2-bottom-right {
         position: absolute;
-        bottom: 24px;
-        right: 20px;
+        bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+        right: calc(20px + env(safe-area-inset-right, 0px));
         pointer-events: auto;
         z-index: 100;
     }
 
     .v2-bottom-left {
         position: absolute;
-        bottom: 16px;
-        left: 16px;
+        bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+        left: calc(16px + env(safe-area-inset-left, 0px));
         pointer-events: auto;
         z-index: 100;
     }


### PR DESCRIPTION
## Summary
- Stop the canvas link gesture from firing alongside d3.zoom on touch, so two-finger / drag pans no longer trigger phantom links.
- Switch the v2 layout from `100vh` to `100dvh` (with fallback) and offset bottom-anchored chrome by `env(safe-area-inset-*)`, so mobile Firefox's bottom URL bar no longer hides the edit FAB.

## Test plan
- [x] `npm test` (frontend Jest, 151 passed)
- [x] `npm run check` (svelte-check clean)
- [ ] Manual: open in mobile Firefox, confirm edit FAB sits above the bottom URL bar
- [ ] Manual: drag/zoom on a touch device, confirm no spurious links created

🤖 Generated with [Claude Code](https://claude.com/claude-code)