### PR TITLE
Allow deleting current v2 stemma and auto-switch

### DIFF
--- a/frontend/src/appController.ts
+++ b/frontend/src/appController.ts
@@ -115,10 +115,27 @@ export class AppController {
     removeStemma(stemmaId: string) {
         this.isWorking.set(true)
         this.err.set(null)
+        const wasCurrent = get(this.currentStemmaId) === stemmaId
         this.model
             .removeStemma(stemmaId)
             .then((result) => {
                 this.ownedStemmas.set(result.stemmas)
+                if (!wasCurrent) return
+                if (result.stemmas.length === 0) {
+                    this.stemma.set(null)
+                    this.stemmaIndex.set(null)
+                    this.pinnedStorage.set(null)
+                    this.highlight.set(null)
+                    this.settingsStorage.set(null)
+                    this.setCurrentStemmaId(null)
+                    return
+                }
+                const nextId = selectStemmaId(result.stemmas, this.loadLastStemmaId(), null)
+                return this.model.getStemma(nextId).then((next) => {
+                    this.refreshIndexes(next, nextId)
+                    this.setCurrentStemmaId(nextId)
+                    this.stemma.set(next)
+                })
             })
             .catch(err => {
                 this.err.set(err)

--- a/frontend/src/v2/components/V2Chip.svelte
+++ b/frontend/src/v2/components/V2Chip.svelte
@@ -95,7 +95,7 @@
                             onclick={(e) => trigger(onstemmaClone, s, e)}
                             data-testid="v2-chip-clone"
                         ><i class="bi bi-copy"></i></button>
-                        {#if s.removable && s.id !== currentStemmaId}
+                        {#if s.removable}
                             <button
                                 type="button"
                                 class="row-btn danger"


### PR DESCRIPTION
## Summary
- Drop the `s.id !== currentStemmaId` guard on the v2 chip trash button so the delete affordance is visible on the open stemma (previously the button silently vanished, which read as a missing feature).
- After a current-stemma delete, `AppController.removeStemma` now picks the next stemma via `selectStemmaId` and loads it, or clears all stemma stores when the last one was removed.

## Test plan
- [x] `npm test` (frontend)
- [x] `npm run check` (svelte-check)
- [ ] Manual: delete a non-current stemma — list updates, current view unchanged.
- [ ] Manual: delete the current stemma with siblings — auto-switches to the next one.
- [ ] Manual: delete the last stemma — empty-state shown, no stale graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)