### PR TITLE
Add v3 plan doc and track subdirectory CLAUDE.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,3 @@ coverage/
 # CSS artifacts (generated)
 .sass-cache/
 *.css.map
-
-# Ignore CLAUDE.md in subdirectories (keep root CLAUDE.md)
-**/CLAUDE.md
-!/CLAUDE.md

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,67 @@
+# Frontend — v2 canvas drag scenario matrix
+
+Edit-mode pointer drag on the v2 SVG canvas. The user presses mouse-down on a node (or empty canvas), drags, and releases on a node (or empty canvas). Source kind × target kind determines outcome.
+
+Six valid gestures exist. Any other (FROM, TO) pair is a no-op.
+
+### The six gestures
+
+| #  | FROM    | TO      | Outcome                                                                                                    |
+|----|---------|---------|------------------------------------------------------------------------------------------------------------|
+| 1  | family  | empty   | Modal — create new Person as child of the dragged Family.                                                  |
+| 2  | empty   | family  | Modal — create new Person as spouse (parent) of the target Family.                                         |
+| 3  | person  | empty   | Silent — create pending Family with the dragged Person as the sole parent (front-end only, not yet sent). |
+| 4  | empty   | person  | Silent — create pending Family with the target Person as the sole child (front-end only, not yet sent).   |
+| 5  | person  | family  | Silent — attach dragged Person to target Family as spouse (parent). Promotes pending Family if target is pending. |
+| 6  | family  | person  | Silent — attach target Person to dragged Family as child. Promotes pending Family if source is pending.   |
+
+No-op gestures (explicitly): person→person, family→family, empty→empty.
+
+### Pending families
+
+- Gestures 3/4 create a front-end-only `PendingFamily` record (`pending-family-<uuid>`) merged into `displayedStemma`. No backend call.
+- Pending families render as readOnly family nodes. They are valid drop targets/sources for gestures 1/2/5/6.
+- When a second member is added (gestures 1/2 modal save, 5/6 attach), `promotePendingFamily` calls `controller.createFamily(parents, children)` with the combined member list and removes the pending entry on success. Backend rejects single-member families (`IncompleteFamily`), so promotion is required before backend sees the family.
+- Pending families do not survive stemma switch / sign-out: state lives in `pendingFamilies` in `V2App.svelte`.
+
+### Modal titles
+
+| Gesture            | i18n key                  | English          | Russian             |
+|--------------------|---------------------------|------------------|---------------------|
+| 1 family → empty   | `v2.createChildTitle`     | Add child        | Добавить потомка    |
+| 2 empty → family   | `v2.createSpouseTitle`    | Add spouse       | Добавить супруга    |
+
+### Drag tooltip text (hover hint while dragging)
+
+| Source ↘ Hover     | Tip key                    |
+|--------------------|----------------------------|
+| person, family     | `v2.tipAttachSpouse`       |
+| person, no target  | `v2.tipCreateFamily`       |
+| family, no target  | `v2.tipCreateChild`        |
+| family, person     | `v2.tipAttachChild`        |
+| empty, family      | `v2.tipCreateSpouse`       |
+| empty, person      | `v2.tipCreateFamily`       |
+
+### Notes
+
+- "Silent" means no modal — the link or pending family appears immediately. Pending visuals come from `pendingAdds` / `pendingFamilies` in `V2App.svelte`.
+- Disallowed links (cycle, duplicate spouse, too many parents, member already in pending family) are filtered via `StemmaIndex.canAddParent` / `canAddChild` and `findPendingFamily` membership checks. Hovering an invalid target shows the `v2-drop-disallowed` class.
+
+### Code locations
+
+- Drag state machine: `V2App.svelte` — `$effect` near `// Canvas pointer gesture` (mousedown/mousemove/mouseup).
+- Outcome dispatch: `onMouseUp` inside that effect.
+- Tooltip text per gesture: `computeTipText`.
+- Compatibility check: `targetCompatibility` + `classifyForDrop`.
+- Silent attach: `attachPersonToFamily` (promotes pending family on second-member add).
+- Modal create + extend existing family: `createPersonInFamily` (gestures 1, 2; also promotes pending family).
+- Pending family creation: `createPendingFamilyForPerson` (gestures 3, 4).
+- Pending family promotion: `promotePendingFamily` + `clearPendingFamily`.
+
+### Known constraints
+
+- `requestSanitizer.ts` drops fields with empty-string values. If a request type has a required field that may legitimately be empty (e.g. `name` for an "unknown" person), do not route it through the sanitizer or the backend rejects with `RequestDeserializationProblem`.
+
+### Related
+
+- v3 (in development) layers explicit ghost-node affordances on top of v2's drag gestures. See `src/v3/CLAUDE.md`.

--- a/frontend/src/v3/CLAUDE.md
+++ b/frontend/src/v3/CLAUDE.md
@@ -1,0 +1,69 @@
+# v3 — Explicit ghost-node affordances
+
+v3 is a fork of v2 that adds **explicit "ghost" affordances** for adding spouses, parents, and children, while preserving v2's drag gestures unchanged. Goal: discoverability for new users without removing power-user gestures.
+
+## Concept
+
+When a person or family is **focused**, dashed "ghost" nodes appear around it:
+
+| Focused entity | Ghost(s)                                                         |
+| -------------- | ---------------------------------------------------------------- |
+| Person         | spouse-ghost (`v3.addAnotherSpouse`) — always present            |
+| Person         | parent-ghost (`v3.addParent`) — only if person has no parents    |
+| Family         | child-ghost (`v3.addChild`) — always present                     |
+
+Clicking a ghost opens the same create-person modal used by v2 pending-family promotion. On confirm, ghost materializes into a real person + family; focus stays on original node so user can add more.
+
+## Focus model
+
+- State: `focusedId: { kind: "person" | "family", id: string } | null`.
+- **Desktop**: hovering bounding box sets focus (~150 ms debounce on leave to prevent flicker). Click on real node = edit modal.
+- **Mobile**: short-tap (<500 ms) on real node = focus. Long-tap (≥500 ms) = edit modal. Tap elsewhere / pan = blur. ESC blurs on desktop.
+
+## Physics
+
+- All non-focused real nodes frozen via `fx, fy = current`.
+- Focused real node also frozen (anchored at tap position — no jump).
+- Ghosts: unfrozen. Initial seed: spouse to right of person, parent above, child below family. d3 collision force pushes ghosts into empty space against frozen neighbors. Sim stops on blur, ghosts despawn.
+
+## Visual
+
+- Dashed border + ~0.6 opacity — same language as v2 pending family (`ef1b738`).
+- Dashed edge from focused node to ghost.
+- Centered "+" icon + i18n label.
+- Fade-in/out 200 ms on focus change.
+
+## Coexist with v2 gestures
+
+- Drag gestures from v2 untouched (link gesture `9c48496`, pending-family pin `ef1b738`).
+- Ghosts = scaffolding for newcomers; gestures = power users.
+- Both fire same backend mutations.
+
+## i18n keys
+
+New v3-only keys (add to both `en` and `ru` in `frontend/src/i18n.ts`):
+
+- `v3.addAnotherSpouse` — "Add another spouse" / "Добавить ещё супруга"
+- `v3.addParent` — "Add parent" / "Добавить родителя"
+- `v3.addChild` — "Add child" / "Добавить потомка"
+
+Existing `v2.*` keys (modal titles, drag tips) stay shared with v2 — same text.
+
+## Ticket breakdown
+
+Work runs one ticket at a time. Each ticket is independently shippable and behind the `/v3` route only.
+
+1. **Bootstrap v3 route** — rename V2→V3 inside `frontend/src/v3/`, css `v2-`→`v3-`, route `/v3` in `main.ts`. No behavior change; v3 is byte-identical UX to v2 at this point.
+2. **Focus state machine** — `focusedId` store + hover (desktop) / short-tap (mobile) detection. No UI; add a debug outline on focused node only.
+3. **Ghost render** — derive ghost list from `focusedId`, render dashed spouse/parent/child placeholders at static seed positions. No physics yet, no click handler.
+4. **Frozen-tree physics for ghosts** — freeze all non-ghost nodes, run d3 sim over ghost subset with collision force. Sim starts on focus, stops on blur.
+5. **Ghost click → create modal** — wire ghost click to v3 create-person modal, reuse `promotePendingFamily` flow. On confirm: materialize person + family, keep focus on origin.
+6. **Mobile long-press = edit modal** — disambiguate short-tap (focus) vs long-tap (edit) on touch. Desktop click on focused node already = edit.
+7. **i18n strings** — add `v3.addAnotherSpouse`, `v3.addParent`, `v3.addChild` to both `en` and `ru`.
+8. **Polish** — fade-in/out animation, blur on ESC / pan / empty-tap, focus survives zoom.
+
+## Out of scope
+
+- Removing v2 gestures.
+- Reworking v2 pending-family flow.
+- New backend endpoints — all mutations go through existing `RequestHandler` cases.


### PR DESCRIPTION
## Summary
- Removes the blanket `**/CLAUDE.md` `.gitignore` rule so per-directory docs can live in the repo.
- Adds `frontend/src/v3/CLAUDE.md` — the v3 plan for explicit ghost-node affordances (focus model, ghost taxonomy, physics, i18n) that drives issues #193–#200.
- Promotes `frontend/CLAUDE.md` (v2 canvas drag scenario matrix) into the repo and strips its `<claude-mem-context>` wrapper.
- Deletes empty/stale `CLAUDE.md` shells under `frontend/src/`, `frontend/src/components/`, `frontend/public/`, `e2e/`, `e2e/tests/`, `e2e/scripts/`, `.github/workflows/`.

## Out of scope
- v3 implementation. The `frontend/src/v3/` folder also contains a raw copy of v2 (`V2*.svelte`) staged locally; those files are intentionally **not** in this PR and ship under #193.

## Test plan
- [ ] `frontend/CLAUDE.md` renders on GitHub without the `<claude-mem-context>` tag.
- [ ] `frontend/src/v3/CLAUDE.md` renders cleanly.
- [ ] `git check-ignore frontend/CLAUDE.md` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)