### PR TITLE
Bootstrap v3 with explicit ghost-node affordances

### DIFF
--- a/e2e/tests/v3_ghost_smoke.spec.ts
+++ b/e2e/tests/v3_ghost_smoke.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "./_fixtures";
+import type { Page } from "@playwright/test";
+
+async function createFreshStemma(page: Page) {
+  const stemmaBtn = page.getByTestId("v3-chip-stemma-btn");
+  await expect(stemmaBtn).toBeVisible({ timeout: 10_000 });
+  await stemmaBtn.click();
+  const addBtn = page.getByTestId("v3-chip-add-stemma");
+  await expect(addBtn).toBeVisible({ timeout: 5_000 });
+  await addBtn.click();
+  const modal = page.getByTestId("v3-add-stemma-modal");
+  await expect(modal).toBeVisible({ timeout: 5_000 });
+  await modal.locator("input").fill(`v3-smoke-${Date.now()}`);
+  await modal.locator("button.btn-primary").click();
+  await page.waitForTimeout(2_500);
+}
+
+async function enterEditMode(page: Page) {
+  await page.getByTestId("v3-edit-fab").click();
+  await expect(page.locator(".v3-edit-mode")).toHaveCount(1);
+}
+
+async function leaveEditMode(page: Page) {
+  await page.getByTestId("v3-edit-fab").click();
+  await expect(page.locator(".v3-edit-mode")).toHaveCount(0);
+}
+
+async function addOrphan(page: Page, name: string) {
+  await page.getByTestId("v3-add-person-fab").click();
+  const nameInput = page.getByTestId("v3-person-name-input");
+  await expect(nameInput).toBeVisible();
+  await nameInput.fill(name);
+  await page.getByTestId("v3-person-create").click();
+  const committed = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${name}"`) })
+    .first();
+  await expect(committed).toBeVisible({ timeout: 15_000 });
+}
+
+test("/v3 route loads with v3 chrome", async ({ page }) => {
+  await page.goto("/v3");
+  await expect(page.getByTestId("v3-chip-stemma-btn")).toBeVisible({ timeout: 30_000 });
+});
+
+test("v3 hover in edit mode reveals ghost nodes; moving away clears them", async ({ page }) => {
+  await page.goto("/v3");
+  await expect(page.getByTestId("v3-chip-stemma-btn")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const name = `Hovered${Date.now()}`;
+  await addOrphan(page, name);
+  await page.waitForTimeout(500);
+
+  const group = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${name}"`) })
+    .first();
+
+  // Hover over the circle directly so the mousemove fires on the SVG and
+  // the distance-based hit detection can focus the node.
+  const circle = group.locator("circle").first();
+  await circle.hover({ force: true });
+  await page.waitForTimeout(400);
+
+  // An orphan person has no parent family, so three ghost branches render:
+  // spouse, parent, child → 3 ghost person nodes (g.v3-ghost) plus ghost
+  // family nodes (g.v3-ghost-family).  Assert on ghost persons only.
+  const ghosts = page.locator("svg#chart g.v3-ghost");
+  await expect(ghosts).toHaveCount(3, { timeout: 5_000 });
+
+  // Move pointer away from any node to trigger blur.
+  await page.mouse.move(5, 5);
+  await expect(ghosts).toHaveCount(0, { timeout: 3_000 });
+});
+
+test("v3 no ghosts in view mode", async ({ page }) => {
+  await page.goto("/v3");
+  await expect(page.getByTestId("v3-chip-stemma-btn")).toBeVisible({ timeout: 30_000 });
+  await createFreshStemma(page);
+  await enterEditMode(page);
+  const name = `ViewMode${Date.now()}`;
+  await addOrphan(page, name);
+  await leaveEditMode(page);
+  await page.waitForTimeout(500);
+
+  const group = page
+    .locator("svg#chart g[id^='person_']:not([id*='pending-'])")
+    .filter({ has: page.locator(`text="${name}"`) })
+    .first();
+
+  const circle = group.locator("circle").first();
+  await circle.hover({ force: true });
+  await page.waitForTimeout(400);
+
+  // In view mode no ghosts should ever appear.
+  const ghosts = page.locator("svg#chart g.v3-ghost");
+  await expect(ghosts).toHaveCount(0, { timeout: 2_000 });
+});

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -268,6 +268,11 @@ export const en: Record<string, string> = {
     'v2.createParentTitleOf': "Add {names}'s parent",
     'v2.panModeOn': 'Pan canvas',
     'v2.panModeOff': 'Exit pan mode',
+
+    // V3 ghost affordances
+    'v3.addAnotherSpouse': 'Add another spouse',
+    'v3.addParent': 'Add parent',
+    'v3.addChild': 'Add child',
 };
 
 export const ru: Record<string, string> = {
@@ -506,6 +511,11 @@ export const ru: Record<string, string> = {
     'v2.createParentTitleOf': 'Добавить родителя {names}',
     'v2.panModeOn': 'Перемещать холст',
     'v2.panModeOff': 'Выйти из режима перемещения',
+
+    // V3 ghost affordances
+    'v3.addAnotherSpouse': 'Добавить ещё супруга',
+    'v3.addParent': 'Добавить родителя',
+    'v3.addChild': 'Добавить потомка',
 };
 
 const dictionaries: Record<Locale, Record<string, string>> = { en, ru };

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { mount } from 'svelte';
 import App from './App.svelte';
 import V2App from './v2/V2App.svelte';
+import V3App from './v3/V3App.svelte';
 
 const target = document.getElementById('app');
 if (!target) {
@@ -12,7 +13,10 @@ const props = {
 	stemma_backend_url: "STEMMA_BACKEND_URL",
 };
 
-const app = window.location.pathname.startsWith("/v2")
+const pathname = window.location.pathname;
+const app = pathname.startsWith("/v3")
+	? mount(V3App, { target, props })
+	: pathname.startsWith("/v2")
 	? mount(V2App, { target, props })
 	: mount(App, { target, props });
 

--- a/frontend/src/v3/V3App.svelte
+++ b/frontend/src/v3/V3App.svelte
@@ -1,0 +1,2277 @@
+<script lang="ts">
+    import { onMount, untrack } from "svelte";
+    import { AppController, type MutationResult } from "../appController";
+    import type {
+        FamilyDescription,
+        PersonDefinition,
+        PersonDescription,
+        Stemma,
+        StemmaDescription,
+        TokenProvider,
+        User,
+    } from "../model";
+    import { StemmaIndex } from "../stemmaIndex";
+    import { HiglightLineages } from "../highlight";
+    import { PinnedPeopleStorage } from "../pinnedPeopleStorage";
+    import { ViewMode } from "../model";
+    import { LocalizedError, t } from "../i18n";
+    import { clearCredential, loadCredential, msUntilRefresh, saveCredential } from "../credentialStorage";
+    import { initializeGoogleAuth, refreshCredential } from "../googleAuth";
+    import Authenticate from "../components/Authenticate.svelte";
+    import FullStemma from "../components/FullStemma.svelte";
+    import V3Chip from "./components/V3Chip.svelte";
+    import V3LangSwitcher from "./components/V3LangSwitcher.svelte";
+    import V3Menu from "./components/V3Menu.svelte";
+    import V3Fab from "./components/V3Fab.svelte";
+    import V3Search from "./components/V3Search.svelte";
+    import V3EmptyState from "./components/V3EmptyState.svelte";
+    import V3Sheet from "./components/V3Sheet.svelte";
+    import V3FamilyCard from "./components/V3FamilyCard.svelte";
+    import V3BulkAddTray from "./components/V3BulkAddTray.svelte";
+    import V3AboutModal from "./components/V3AboutModal.svelte";
+    import V3SettingsModal from "./components/V3SettingsModal.svelte";
+    import V3ShareAccessModal from "./components/V3ShareAccessModal.svelte";
+    import V3PromptModal from "./components/V3PromptModal.svelte";
+    import V3ConfirmModal from "./components/V3ConfirmModal.svelte";
+    import V3PersonDetailsModal from "./components/V3PersonDetailsModal.svelte";
+    import StatsCard from "../components/stats_card/StatsCard.svelte";
+    import { buildInviteLink } from "../inviteLinkBuilder";
+    import { Circle2 } from "svelte-loading-spinners";
+    import * as d3 from "d3";
+    import { denormalizeId, normalizeId } from "../graphTools";
+    import { arrowPath, personR, familyR, labelFontSize } from "../graphStyles";
+    import {
+        focusedIdFromG,
+        isShortTap,
+        nearestNodeWithinRadius,
+        MOUSE_LEAVE_DEBOUNCE_MS,
+        FOCUS_RADIUS_SVG,
+        type FocusedId,
+    } from "./focusGesture";
+    import { deriveGhostBranches, immediateNeighborIds, type GhostKind } from "./ghostHelpers";
+
+    const PERSON_DRAG_MIME = "application/x-stemma-person";
+    const SVG_NS = "http://www.w3.org/2000/svg";
+
+    type NodeRef = { kind: "person" | "family"; id: string };
+    type SourceRef = { kind: "person"; id: string } | { kind: "family"; id: string } | { kind: "empty" };
+
+    type Props = {
+        google_client_id: string;
+        stemma_backend_url: string;
+    };
+
+    let { google_client_id, stemma_backend_url }: Props = $props();
+
+    const e2eAutoLoginEnabled = typeof E2E_AUTO_LOGIN !== "undefined" && E2E_AUTO_LOGIN === "1";
+    const initialCached = e2eAutoLoginEnabled ? null : loadCredential();
+    let signedIn = $state(e2eAutoLoginEnabled || initialCached !== null);
+
+    type PendingAdd = { tempId: string; name: string };
+    type PendingFamily = { tempId: string; parents: string[]; children: string[]; x?: number; y?: number };
+
+    let editMode = $state(false);
+    let panMode = $state(false);
+    let spacePan = $state(false);
+    const panActive = $derived(editMode && (panMode || spacePan));
+    let pendingRemovedPersonIds = $state<Set<string>>(new Set());
+    let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
+    let pendingAdds = $state<PendingAdd[]>([]);
+    let pendingFamilies = $state<PendingFamily[]>([]);
+    let trayOpen = $state(false);
+
+    function isPendingId(id: string): boolean {
+        return id.startsWith("pending-");
+    }
+
+    function isPendingFamilyId(id: string): boolean {
+        return id.startsWith("pending-family-");
+    }
+
+    function isPendingPersonId(id: string): boolean {
+        return isPendingId(id) && !isPendingFamilyId(id);
+    }
+
+    function findPendingFamily(id: string): PendingFamily | undefined {
+        return pendingFamilies.find((f) => f.tempId === id);
+    }
+
+    function personNameOf(personId: string): string {
+        return displayedStemmaIndex?.person(personId)?.name || "?";
+    }
+
+    function familyParentNames(familyId: string): string[] {
+        const f = displayedStemmaIndex?.family(familyId);
+        return f ? f.parents.map(personNameOf) : [];
+    }
+
+    function familyChildrenNames(familyId: string): string[] {
+        const f = displayedStemmaIndex?.family(familyId);
+        return f ? f.children.map(personNameOf) : [];
+    }
+
+    function joinNames(names: string[]): string {
+        if (names.length === 0) return "?";
+        if (names.length === 1) return names[0];
+        const conj = $t("v2.namesJoin");
+        if (names.length === 2) return names.join(conj);
+        const sep = $t("v2.namesSeparator");
+        return names.slice(0, -1).join(sep) + conj + names[names.length - 1];
+    }
+
+    type FamilyAnchor = { names: string[]; via: "parents" | "children" };
+
+    function familyAnchor(familyId: string): FamilyAnchor {
+        const parents = familyParentNames(familyId);
+        if (parents.length > 0) return { names: parents, via: "parents" };
+        return { names: familyChildrenNames(familyId), via: "children" };
+    }
+
+    let ownedStemmas = $state<StemmaDescription[]>([]);
+    let currentStemmaId = $state<string | null>(null);
+    let stemma = $state<Stemma | null>(null);
+    let stemmaIndex = $state<StemmaIndex | null>(null);
+    let highlight = $state<HiglightLineages | null>(null);
+    let pinnedPeople = $state<PinnedPeopleStorage | null>(null);
+    let isWorking = $state<boolean>(false);
+    let error = $state<Error | null>(null);
+    let highlightVersion = $state(0);
+
+    let selectedFamilyId = $state<string | null>(null);
+    let selectedFamilyEl = $state<Element | null>(null);
+    let familySheetOpen = $state(false);
+    let dragTip = $state<{ text: string; x: number; y: number } | null>(null);
+    let activeGestureSource = $state<SourceRef | null>(null);
+    let focusedId = $state<FocusedId | null>(null);
+    /** Live SVG-space positions of all rendered ghost nodes (persons + families). Updated each sim tick. */
+    let ghostSimPositions = $state<Array<{ x: number; y: number }>>([]);
+
+    let personEditModal = $state<ReturnType<typeof V3PersonDetailsModal> | null>(null);
+    let aboutModal = $state<ReturnType<typeof V3AboutModal> | null>(null);
+    let settingsModal = $state<ReturnType<typeof V3SettingsModal> | null>(null);
+    let shareAccessModal = $state<ReturnType<typeof V3ShareAccessModal> | null>(null);
+    let promptModal = $state<ReturnType<typeof V3PromptModal> | null>(null);
+    let confirmModal = $state<ReturnType<typeof V3ConfirmModal> | null>(null);
+    let stemmaChart = $state<ReturnType<typeof FullStemma> | null>(null);
+
+    const controller = new AppController(untrack(() => stemma_backend_url));
+
+    let lastStemmaIdSeen: string | null = null;
+    const subscriptions = [
+        controller.currentStemmaId.subscribe((s) => (currentStemmaId = s)),
+        controller.stemma.subscribe((s) => {
+            const switchedStemma = currentStemmaId !== lastStemmaIdSeen;
+            lastStemmaIdSeen = currentStemmaId;
+            stemma = s;
+            if (s === null || switchedStemma) {
+                pendingRemovedPersonIds = new Set();
+                pendingRemovedFamilyIds = new Set();
+                pendingAdds = [];
+                pendingFamilies = [];
+            }
+        }),
+        controller.ownedStemmas.subscribe((os) => (ownedStemmas = os)),
+        controller.stemmaIndex.subscribe((si) => (stemmaIndex = si)),
+        controller.highlight.subscribe((hg) => (highlight = hg)),
+        controller.pinnedStorage.subscribe((pp) => (pinnedPeople = pp)),
+        controller.isWorking.subscribe((iw) => (isWorking = iw)),
+        controller.err.subscribe((e) => (error = e)),
+        controller.invitationToken.subscribe((tkn) => {
+            if (!tkn) return;
+            const link = buildInviteLink(window.location.origin, tkn);
+            void navigator.clipboard?.writeText(link).catch(() => {});
+            shareAccessModal?.dismiss();
+        }),
+    ];
+
+    function pendingPersonDescription(p: PendingAdd): PersonDescription {
+        return {
+            type: "PersonDescription",
+            id: p.tempId,
+            name: p.name,
+            birthDate: null,
+            deathDate: null,
+            bio: null,
+            readOnly: true,
+            photoUrl: null,
+        };
+    }
+
+    const displayedStemma = $derived.by<Stemma | null>(() => {
+        if (!stemma) return null;
+        if (pendingAdds.length === 0 && pendingFamilies.length === 0) return stemma;
+        return {
+            ...stemma,
+            people: [...stemma.people, ...pendingAdds.map(pendingPersonDescription)],
+            families: [
+                ...stemma.families,
+                ...pendingFamilies.map((pf) => ({
+                    type: "FamilyDescription" as const,
+                    id: pf.tempId,
+                    parents: pf.parents,
+                    children: pf.children,
+                    readOnly: true,
+                })),
+            ],
+        };
+    });
+
+    const displayedStemmaIndex = $derived.by<StemmaIndex | null>(() => {
+        if (!displayedStemma) return null;
+        return new StemmaIndex(displayedStemma);
+    });
+
+    const orphanPeople = $derived.by<PersonDescription[]>(() => {
+        if (!stemma || !stemmaIndex) return [];
+        return stemma.people.filter((p) => stemmaIndex!.relatedFamilies(p.id).length === 0);
+    });
+
+
+    $effect(() => {
+        if (!stemmaChart) return;
+        void pendingRemovedPersonIds;
+        void pendingRemovedFamilyIds;
+        void pendingAdds;
+        void pendingFamilies;
+        queueMicrotask(applyPendingClasses);
+    });
+
+    function applyPendingClasses() {
+        const svgEl = document.getElementById("chart");
+        if (!svgEl) return;
+        svgEl.querySelectorAll("circle.v3-pending-remove, circle.v3-pending-add").forEach((el) => {
+            el.classList.remove("v3-pending-remove", "v3-pending-add");
+        });
+        const markCircle = (nodeId: string, cls: string) => {
+            const el = document.getElementById(nodeId);
+            const circle = el?.querySelector("circle");
+            if (circle) circle.classList.add(cls);
+        };
+        pendingRemovedPersonIds.forEach((id) => markCircle(normalizeId("person", id), "v3-pending-remove"));
+        pendingRemovedFamilyIds.forEach((id) => markCircle(normalizeId("family", id), "v3-pending-remove"));
+        pendingAdds.forEach((p) => markCircle(normalizeId("person", p.tempId), "v3-pending-add"));
+        pendingFamilies.forEach((p) => markCircle(normalizeId("family", p.tempId), "v3-pending-add"));
+    }
+
+    async function withPendingAdd(
+        name: string,
+        op: () => Promise<MutationResult>,
+        pinAt?: { x: number; y: number },
+        afterCommit?: (result: MutationResult) => void,
+    ): Promise<void> {
+        const tempId = newPendingPersonId();
+        pendingAdds = [...pendingAdds, { tempId, name }];
+        if (pinAt) stemmaChart?.setNodePosition(normalizeId("person", tempId), pinAt.x, pinAt.y);
+        try {
+            const result = await op();
+            if (pinAt) {
+                result.newPersonIds.forEach((id) =>
+                    stemmaChart?.setNodePosition(normalizeId("person", id), pinAt.x, pinAt.y),
+                );
+            }
+            afterCommit?.(result);
+        } catch {
+            // surfaced through controller.err
+        } finally {
+            pendingAdds = pendingAdds.filter((p) => p.tempId !== tempId);
+        }
+    }
+
+    function newPendingPersonId(): string {
+        return `pending-${crypto.randomUUID()}`;
+    }
+
+    function newPendingFamilyId(): string {
+        return `pending-family-${crypto.randomUUID()}`;
+    }
+
+    function createPendingFamilyForPerson(
+        personId: string,
+        role: "parent" | "child",
+        familyAt: { x: number; y: number },
+    ): PendingFamily {
+        const tempId = newPendingFamilyId();
+        const entry: PendingFamily = {
+            tempId,
+            parents: role === "parent" ? [personId] : [],
+            children: role === "child" ? [personId] : [],
+            x: familyAt.x,
+            y: familyAt.y,
+        };
+        stemmaChart?.setNodePosition(normalizeId("family", tempId), familyAt.x, familyAt.y);
+        pendingFamilies = [...pendingFamilies, entry];
+        return entry;
+    }
+
+    function composeFamilyMembers(
+        parentIds: string[],
+        childIds: string[],
+        incoming: PersonDefinition,
+        role: "parent" | "child",
+    ): { parents: PersonDefinition[]; children: PersonDefinition[] } {
+        const parentDefs: PersonDefinition[] = parentIds.map((id) => ({ type: "ExistingPerson", id }));
+        const childDefs: PersonDefinition[] = childIds.map((id) => ({ type: "ExistingPerson", id }));
+        return {
+            parents: role === "parent" ? [...parentDefs, incoming] : parentDefs,
+            children: role === "child" ? [...childDefs, incoming] : childDefs,
+        };
+    }
+
+    function promotePendingFamily(
+        pending: PendingFamily,
+        incoming: PersonDefinition,
+        role: "parent" | "child",
+    ): Promise<MutationResult> {
+        const { parents, children } = composeFamilyMembers(pending.parents, pending.children, incoming, role);
+        return controller.createFamily(parents, children, { silent: true });
+    }
+
+    function clearPendingFamily(tempId: string): void {
+        pendingFamilies = pendingFamilies.filter((p) => p.tempId !== tempId);
+    }
+
+    function pinPromotedFamily(pending: PendingFamily, newFid: string | undefined): void {
+        if (!newFid || pending.x === undefined || pending.y === undefined) return;
+        stemmaChart?.setNodePosition(normalizeId("family", newFid), pending.x, pending.y);
+    }
+
+    function clientToSvgPoint(svgEl: SVGSVGElement, clientX: number, clientY: number): { x: number; y: number } {
+        const pt = svgEl.createSVGPoint();
+        pt.x = clientX;
+        pt.y = clientY;
+        const mainG = svgEl.querySelector("g.main") as SVGGElement | null;
+        const ctm = mainG?.getScreenCTM();
+        if (!ctm) return { x: clientX, y: clientY };
+        const out = pt.matrixTransform(ctm.inverse());
+        return { x: out.x, y: out.y };
+    }
+
+    function nodeCenter(g: SVGGElement): { x: number; y: number } | null {
+        const t = g.getAttribute("transform");
+        if (!t) return null;
+        const match = t.match(/translate\(([-\d.]+)[,\s]+([-\d.]+)\)/);
+        if (!match) return null;
+        return { x: parseFloat(match[1]), y: parseFloat(match[2]) };
+    }
+
+    function findNodeUnder(x: number, y: number): { ref: NodeRef; el: SVGGElement } | null {
+        const el = document.elementFromPoint(x, y);
+        const g = el?.closest?.("g[id^='person_'], g[id^='family_']") as SVGGElement | null;
+        if (!g) return null;
+        const kind = g.id.startsWith("person_") ? "person" : "family";
+        const id = denormalizeId(g.id);
+        if (kind === "person" && isPendingId(id)) return null;
+        return { ref: { kind, id }, el: g };
+    }
+
+    function familyHasPerson(family: { parents: string[]; children: string[] }, pid: string): boolean {
+        return family.parents.includes(pid) || family.children.includes(pid);
+    }
+
+    function attachPersonToFamily(
+        personId: string,
+        familyId: string,
+        role: "parent" | "child",
+        pinAt?: { x: number; y: number },
+    ) {
+        const pending = findPendingFamily(familyId);
+        if (pending) {
+            if (familyHasPerson(pending, personId)) return;
+            if (pinAt) {
+                stemmaChart?.setNodePosition(normalizeId("person", personId), pinAt.x, pinAt.y);
+            }
+            const incoming: PersonDefinition = { type: "ExistingPerson", id: personId };
+            promotePendingFamily(pending, incoming, role)
+                .then((result) => {
+                    clearPendingFamily(familyId);
+                    pinPromotedFamily(pending, result.newFamilyIds[0]);
+                })
+                .catch(() => {});
+            return;
+        }
+        if (!stemmaIndex) return;
+        const family = stemmaIndex.family(familyId);
+        if (!family) return;
+        if (familyHasPerson(family, personId)) return;
+        if (pinAt) {
+            stemmaChart?.setNodePosition(normalizeId("person", personId), pinAt.x, pinAt.y);
+        }
+        const incoming: PersonDefinition = { type: "ExistingPerson", id: personId };
+        const { parents, children } = composeFamilyMembers(family.parents, family.children, incoming, role);
+        controller.updateFamily(familyId, parents, children, { silent: true }).catch(() => {});
+    }
+
+    function createPersonInFamily(
+        familyId: string,
+        role: "parent" | "child",
+        title: string,
+        pinAt?: { x: number; y: number },
+    ) {
+        const pending = findPendingFamily(familyId);
+        if (!pending && !stemmaIndex?.family(familyId)) return;
+        personEditModal?.showCreatePerson({
+            title,
+            oncreate: ({ description, pin, photoUpload }) => {
+                if (pending) {
+                    void withPendingAdd(
+                        description.name,
+                        () => promotePendingFamily(pending, description, role),
+                        pinAt,
+                        (result) => {
+                            clearPendingFamily(familyId);
+                            pinPromotedFamily(pending, result.newFamilyIds[0]);
+                            const newId = result.newPersonIds[0];
+                            if (newId && (photoUpload || pin)) {
+                                controller.savePerson(newId, description, pin, photoUpload, false);
+                            }
+                        },
+                    );
+                    return;
+                }
+                const family = stemmaIndex?.family(familyId);
+                if (!family) return;
+                const { parents, children } = composeFamilyMembers(family.parents, family.children, description, role);
+                void withPendingAdd(
+                    description.name,
+                    () => controller.updateFamily(familyId, parents, children, { silent: true }),
+                    pinAt,
+                    (result) => {
+                        const newId = result.newPersonIds[0];
+                        if (newId && (photoUpload || pin)) {
+                            controller.savePerson(newId, description, pin, photoUpload, false);
+                        }
+                    },
+                );
+            },
+        });
+    }
+
+    function onGhostClick(
+        kind: GhostKind,
+        focused: FocusedId | null,
+        ghostPos: { x: number; y: number },
+    ): void {
+        if (!focused) return;
+
+        if (kind === "child" && focused.kind === "family") {
+            createPersonInFamily(focused.id, "child", $t("v3.addChild"), ghostPos);
+            return;
+        }
+
+        if (kind === "child" && focused.kind === "person") {
+            const personId = focused.id;
+            personEditModal?.showCreatePerson({
+                title: $t("v3.addChild"),
+                oncreate: ({ description, pin, photoUpload }) => {
+                    const pending = createPendingFamilyForPerson(personId, "parent", ghostPos);
+                    void withPendingAdd(
+                        description.name,
+                        () => promotePendingFamily(pending, description, "child"),
+                        ghostPos,
+                        (result) => {
+                            clearPendingFamily(pending.tempId);
+                            pinPromotedFamily(pending, result.newFamilyIds[0]);
+                            const newId = result.newPersonIds[0];
+                            if (newId && (photoUpload || pin)) {
+                                controller.savePerson(newId, description, pin, photoUpload, false);
+                            }
+                        },
+                    );
+                },
+            });
+            return;
+        }
+
+        if (kind === "spouse" && focused.kind === "person") {
+            const personId = focused.id;
+            personEditModal?.showCreatePerson({
+                title: $t("v3.addAnotherSpouse"),
+                oncreate: ({ description, pin, photoUpload }) => {
+                    const pending = createPendingFamilyForPerson(personId, "parent", ghostPos);
+                    void withPendingAdd(
+                        description.name,
+                        () => promotePendingFamily(pending, description, "parent"),
+                        ghostPos,
+                        (result) => {
+                            clearPendingFamily(pending.tempId);
+                            pinPromotedFamily(pending, result.newFamilyIds[0]);
+                            const newId = result.newPersonIds[0];
+                            if (newId && (photoUpload || pin)) {
+                                controller.savePerson(newId, description, pin, photoUpload, false);
+                            }
+                        },
+                    );
+                },
+            });
+            return;
+        }
+
+        if (kind === "parent" && focused.kind === "person") {
+            const personId = focused.id;
+            personEditModal?.showCreatePerson({
+                title: $t("v3.addParent"),
+                oncreate: ({ description, pin, photoUpload }) => {
+                    const pending = createPendingFamilyForPerson(personId, "child", ghostPos);
+                    void withPendingAdd(
+                        description.name,
+                        () => promotePendingFamily(pending, description, "parent"),
+                        ghostPos,
+                        (result) => {
+                            clearPendingFamily(pending.tempId);
+                            pinPromotedFamily(pending, result.newFamilyIds[0]);
+                            const newId = result.newPersonIds[0];
+                            if (newId && (photoUpload || pin)) {
+                                controller.savePerson(newId, description, pin, photoUpload, false);
+                            }
+                        },
+                    );
+                },
+            });
+        }
+    }
+
+    // Desktop mouse focus (edit mode only): distance-based hit detection on
+    // mousemove.  Reads each real-node datum's (x, y) from the d3 simulation
+    // and focuses the nearest node within FOCUS_RADIUS_SVG user-space units.
+    // Uses the d3 zoom transform's scale (k) to convert the fixed SVG-space
+    // radius into a screen-space equivalent so the check stays view-independent.
+    $effect(() => {
+        if (!editMode || !stemmaChart) return;
+        const svgEl = document.getElementById("chart");
+        if (!svgEl) return;
+
+        let leaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const cancelLeave = () => {
+            if (leaveTimer !== null) {
+                clearTimeout(leaveTimer);
+                leaveTimer = null;
+            }
+        };
+
+        const onMouseMove = (e: MouseEvent) => {
+            if (e.buttons !== 0) return;
+            const mainG = svgEl.querySelector("g.main") as SVGGElement | null;
+            if (!mainG) return;
+            const svgPt = clientToSvgPoint(svgEl as unknown as SVGSVGElement, e.clientX, e.clientY);
+            const next = nearestNodeWithinRadius(mainG, svgPt.x, svgPt.y, FOCUS_RADIUS_SVG, isPendingId);
+            if (!next) {
+                const nearGhost = ghostSimPositions.some(
+                    (p) => Math.hypot(p.x - svgPt.x, p.y - svgPt.y) <= FOCUS_RADIUS_SVG,
+                );
+                if (nearGhost) {
+                    cancelLeave();
+                    return;
+                }
+                if (focusedId !== null && leaveTimer === null) {
+                    leaveTimer = setTimeout(() => {
+                        leaveTimer = null;
+                        focusedId = null;
+                    }, MOUSE_LEAVE_DEBOUNCE_MS);
+                }
+                return;
+            }
+            cancelLeave();
+            if (focusedId?.id !== next.id || focusedId?.kind !== next.kind) {
+                focusedId = next;
+            }
+        };
+
+        const onMouseLeave = (_e: MouseEvent) => {
+            cancelLeave();
+            leaveTimer = setTimeout(() => {
+                leaveTimer = null;
+                focusedId = null;
+            }, MOUSE_LEAVE_DEBOUNCE_MS);
+        };
+
+        svgEl.addEventListener("mousemove", onMouseMove);
+        svgEl.addEventListener("mouseleave", onMouseLeave);
+        return () => {
+            cancelLeave();
+            svgEl.removeEventListener("mousemove", onMouseMove);
+            svgEl.removeEventListener("mouseleave", onMouseLeave);
+        };
+    });
+
+    // Tracks ghost DOM elements that are currently fading out so they can be
+    // removed after the CSS transition completes even when a new focus takes
+    // over before the 200 ms window is up.
+    const GHOST_FADE_MS = 200;
+    let fadingOutGhostEls: Element[] = [];
+
+    function fadeOutAndRemove(els: Element[]): void {
+        if (els.length === 0) return;
+        for (const el of els) {
+            (el as HTMLElement | SVGElement).style.opacity = "0";
+        }
+        fadingOutGhostEls = [...fadingOutGhostEls, ...els];
+        setTimeout(() => {
+            for (const el of els) {
+                el.parentNode?.removeChild(el);
+            }
+            fadingOutGhostEls = fadingOutGhostEls.filter((e) => !els.includes(e));
+        }, GHOST_FADE_MS);
+    }
+
+    // Ghost nodes: render dashed affordance placeholders and run a d3 force
+    // simulation so they settle in empty space without overlapping real nodes.
+    // Each focused-person branch renders an intermediate ghost family node and
+    // an endpoint ghost person node.  Focused-family branches render only a
+    // ghost person (the family already exists).
+    $effect(() => {
+        // Read stemmaChart first so Svelte tracks it as a reactive dependency.
+        // Without this, the effect exits early on first mount (before the SVG
+        // is in the DOM) without ever reading focusedId/stemmaIndex, and those
+        // deps are never tracked — so a later mousemove that sets focusedId
+        // never re-triggers this effect.
+        if (!stemmaChart) return;
+        const svgEl = document.getElementById("chart") as unknown as SVGSVGElement | null;
+        const mainG = svgEl?.querySelector("g.main") as SVGGElement | null;
+        if (!svgEl || !mainG) return;
+
+        // Snapshot every real node position before any freeze decision.
+        // Keys are the d3 datum ids (same as normalizeId output).
+        type Snapshot = { x: number; y: number };
+        const positionSnapshot = new Map<string, Snapshot>();
+        d3.select("g.main").selectAll<SVGGElement, any>("g").each((d: any) => {
+            if (d && d.x != null && d.y != null) {
+                positionSnapshot.set(d.id, { x: d.x, y: d.y });
+            }
+        });
+
+        // Determine which nodes are immediate neighbors of the focused node.
+        // Neighbors participate in the ghost sim unfrozen so ghosts can push them.
+        // All other real nodes are frozen. The focused node itself is always frozen.
+        const neighborDomIds: Set<string> =
+            focusedId && stemmaIndex
+                ? new Set(
+                      immediateNeighborIds(focusedId, stemmaIndex).map(({ kind, id }) =>
+                          normalizeId(kind, id),
+                      ),
+                  )
+                : new Set<string>();
+
+        const focusDomId = focusedId ? normalizeId(focusedId.kind, focusedId.id) : null;
+
+        // Freeze non-neighbor real nodes (including the focused node).
+        d3.select("g.main").selectAll<SVGGElement, any>("g").each((d: any) => {
+            if (d && d.x != null && d.y != null) {
+                if (!neighborDomIds.has(d.id)) {
+                    d.fx = d.x;
+                    d.fy = d.y;
+                }
+            }
+        });
+
+        if (!focusedId || !stemmaIndex) return;
+
+        const branches = deriveGhostBranches(focusedId, stemmaIndex);
+        if (branches.length === 0) return;
+
+        const focusEl = focusDomId
+            ? (mainG.querySelector(`#${CSS.escape(focusDomId)}`) as SVGGElement | null)
+            : null;
+        const origin = focusEl ? nodeCenter(focusEl) : null;
+
+        const labels = $t;
+
+        // Collect real-node sim entries. Neighbors are unfrozen (no fx/fy) so
+        // the ghost collision force can push them. Frozen nodes have fx/fy set.
+        type SimNode = {
+            id: string;
+            x: number;
+            y: number;
+            fx?: number | null;
+            fy?: number | null;
+            seedX: number;
+            seedY: number;
+            isGhost: boolean;
+        };
+
+        const realSimNodes: SimNode[] = [];
+        // Keep a parallel map from dom-id → original d3 datum for neighbors so
+        // we can sync the ghost-sim positions back to the main sim's data objects.
+        const neighborDatumById = new Map<string, any>();
+        d3.select("g.main").selectAll<SVGGElement, any>("g").each((d: any) => {
+            if (d && d.x != null && d.y != null) {
+                const isNeighbor = neighborDomIds.has(d.id);
+                if (isNeighbor) neighborDatumById.set(d.id, d);
+                realSimNodes.push({
+                    id: d.id,
+                    x: d.x,
+                    y: d.y,
+                    fx: isNeighbor ? null : d.x,
+                    fy: isNeighbor ? null : d.y,
+                    seedX: d.x,
+                    seedY: d.y,
+                    isGhost: false,
+                });
+            }
+        });
+
+        // All DOM elements created for ghost nodes (for fade-out on teardown).
+        const allGhostEls: Element[] = [];
+
+        // Per-branch sim nodes for the d3 sim tick updates.
+        type BranchSimEntry = {
+            familySimNode: SimNode | null;
+            personSimNode: SimNode;
+            familyEl: SVGGElement | null;
+            personEl: SVGGElement;
+            edgeFocusToFamily: SVGLineElement | null;
+            edgeFamilyToPerson: SVGLineElement | null;
+            kind: GhostKind;
+        };
+        const branchEntries: BranchSimEntry[] = [];
+
+        const makeLine = (x1: number, y1: number, x2: number, y2: number): SVGLineElement => {
+            const line = document.createElementNS(SVG_NS, "line") as SVGLineElement;
+            line.setAttribute("class", "v3-ghost-edge");
+            line.setAttribute("x1", String(x1));
+            line.setAttribute("y1", String(y1));
+            line.setAttribute("x2", String(x2));
+            line.setAttribute("y2", String(y2));
+            line.style.opacity = "0";
+            mainG.appendChild(line);
+            allGhostEls.push(line);
+            return line;
+        };
+
+        const makeGhostFamilyEl = (id: string, x: number, y: number): SVGGElement => {
+            const gEl = document.createElementNS(SVG_NS, "g") as SVGGElement;
+            gEl.setAttribute("id", id);
+            gEl.setAttribute("class", "v3-ghost-family");
+            gEl.setAttribute("transform", `translate(${x},${y})`);
+            gEl.style.opacity = "0";
+            gEl.style.pointerEvents = "none";
+
+            const circle = document.createElementNS(SVG_NS, "circle") as SVGCircleElement;
+            circle.setAttribute("r", String(familyR));
+            gEl.appendChild(circle);
+
+            mainG.appendChild(gEl);
+            allGhostEls.push(gEl);
+            return gEl;
+        };
+
+        const makeGhostPersonEl = (id: string, x: number, y: number, labelKey: string): SVGGElement => {
+            const gEl = document.createElementNS(SVG_NS, "g") as SVGGElement;
+            gEl.setAttribute("id", id);
+            gEl.setAttribute("class", "v3-ghost");
+            gEl.setAttribute("transform", `translate(${x},${y})`);
+            gEl.style.opacity = "0";
+
+            const circle = document.createElementNS(SVG_NS, "circle") as SVGCircleElement;
+            circle.setAttribute("r", String(personR));
+            gEl.appendChild(circle);
+
+            const labelEl = document.createElementNS(SVG_NS, "text") as SVGTextElement;
+            labelEl.setAttribute("class", "v3-ghost-label");
+            labelEl.setAttribute("dx", String(-personR));
+            labelEl.setAttribute("dy", "40");
+            labelEl.style.fontSize = labelFontSize;
+            labelEl.textContent = labels(labelKey);
+            gEl.appendChild(labelEl);
+
+            mainG.appendChild(gEl);
+            allGhostEls.push(gEl);
+            return gEl;
+        };
+
+        for (const branch of branches) {
+            const personSeedX = origin ? origin.x + branch.personDx : branch.personDx;
+            const personSeedY = origin ? origin.y + branch.personDy : branch.personDy;
+
+            const capturedFocusedId = focusedId;
+            const capturedKind = branch.kind;
+
+            if (branch.familyId !== null) {
+                const familySeedX = origin ? origin.x + branch.familyDx : branch.familyDx;
+                const familySeedY = origin ? origin.y + branch.familyDy : branch.familyDy;
+
+                const edgeFocusToFamily = origin
+                    ? makeLine(origin.x, origin.y, familySeedX, familySeedY)
+                    : null;
+                const edgeFamilyToPerson = makeLine(familySeedX, familySeedY, personSeedX, personSeedY);
+
+                const familyEl = makeGhostFamilyEl(branch.familyId, familySeedX, familySeedY);
+                const personEl = makeGhostPersonEl(branch.personId, personSeedX, personSeedY, branch.labelKey);
+
+                const familySimNode: SimNode = {
+                    id: branch.familyId,
+                    x: familySeedX,
+                    y: familySeedY,
+                    seedX: familySeedX,
+                    seedY: familySeedY,
+                    isGhost: true,
+                };
+                const personSimNode: SimNode = {
+                    id: branch.personId,
+                    x: personSeedX,
+                    y: personSeedY,
+                    seedX: personSeedX,
+                    seedY: personSeedY,
+                    isGhost: true,
+                };
+
+                branchEntries.push({
+                    familySimNode,
+                    personSimNode,
+                    familyEl,
+                    personEl,
+                    edgeFocusToFamily,
+                    edgeFamilyToPerson,
+                    kind: capturedKind,
+                });
+
+                personEl.addEventListener("pointerup", (e: PointerEvent) => {
+                    e.stopPropagation();
+                    const ghostPos = { x: personSimNode.x, y: personSimNode.y };
+                    onGhostClick(capturedKind, capturedFocusedId, ghostPos);
+                });
+            } else {
+                const edgeFocusToPerson = origin
+                    ? makeLine(origin.x, origin.y, personSeedX, personSeedY)
+                    : null;
+                const personEl = makeGhostPersonEl(branch.personId, personSeedX, personSeedY, branch.labelKey);
+
+                const personSimNode: SimNode = {
+                    id: branch.personId,
+                    x: personSeedX,
+                    y: personSeedY,
+                    seedX: personSeedX,
+                    seedY: personSeedY,
+                    isGhost: true,
+                };
+
+                branchEntries.push({
+                    familySimNode: null,
+                    personSimNode,
+                    familyEl: null,
+                    personEl,
+                    edgeFocusToFamily: edgeFocusToPerson,
+                    edgeFamilyToPerson: null,
+                    kind: capturedKind,
+                });
+
+                personEl.addEventListener("pointerup", (e: PointerEvent) => {
+                    e.stopPropagation();
+                    const ghostPos = { x: personSimNode.x, y: personSimNode.y };
+                    onGhostClick(capturedKind, capturedFocusedId, ghostPos);
+                });
+            }
+        }
+
+        // Trigger fade-in: after the browser has painted the initial opacity:0
+        // state, remove the inline style so the CSS rule (opacity: 0.6) applies
+        // via the CSS transition. The cancelled flag prevents the RAF from
+        // fighting the fade-out if teardown runs before the first frame.
+        let fadeInCancelled = false;
+        requestAnimationFrame(() => {
+            if (fadeInCancelled) return;
+            for (const el of allGhostEls) {
+                (el as SVGElement).style.opacity = "";
+            }
+        });
+
+        // Run a separate simulation: real nodes (pinned) + ghost nodes (free).
+        // Forces: collision keeps ghosts from overlapping any node; forceX/forceY
+        // with low strength (0.15) anchor each ghost near its seed position so it
+        // doesn't drift to infinity.
+        const GHOST_RADIUS = 32;
+        const ghostSimNodes = branchEntries.flatMap((e) =>
+            e.familySimNode ? [e.familySimNode, e.personSimNode] : [e.personSimNode],
+        );
+        const allSimNodes = [...realSimNodes, ...ghostSimNodes];
+
+        const ghostSim = d3
+            .forceSimulation<SimNode>(allSimNodes)
+            .force("collide", d3.forceCollide<SimNode>().radius(GHOST_RADIUS).strength(0.8))
+            .force("seedX", d3.forceX<SimNode>((n) => n.seedX).strength((n) => (n.isGhost ? 0.15 : 0)))
+            .force("seedY", d3.forceY<SimNode>((n) => n.seedY).strength((n) => (n.isGhost ? 0.15 : 0)))
+            .alphaDecay(0.02)
+            .velocityDecay(0.6);
+
+        // Build a lookup from dom-id → ghost-sim node for neighbor updates in the tick.
+        const neighborSimNodeById = new Map<string, SimNode>();
+        for (const n of realSimNodes) {
+            if (neighborDomIds.has(n.id)) {
+                neighborSimNodeById.set(n.id, n);
+            }
+        }
+
+        ghostSim.on("tick", () => {
+            // Propagate neighbor positions to the DOM and back to the main sim datum.
+            for (const [domId, simNode] of neighborSimNodeById) {
+                const gEl = mainG.querySelector(`#${CSS.escape(domId)}`) as SVGGElement | null;
+                if (gEl) {
+                    gEl.setAttribute("transform", `translate(${simNode.x},${simNode.y})`);
+                }
+                // Sync position to the d3 datum so the main sim picks it up after blur.
+                const datum = neighborDatumById.get(domId);
+                if (datum) {
+                    datum.x = simNode.x;
+                    datum.y = simNode.y;
+                }
+            }
+
+            const nextPositions: Array<{ x: number; y: number }> = [];
+            for (const entry of branchEntries) {
+                const { familySimNode, personSimNode, familyEl, personEl, edgeFocusToFamily, edgeFamilyToPerson } = entry;
+
+                personEl.setAttribute("transform", `translate(${personSimNode.x},${personSimNode.y})`);
+                nextPositions.push({ x: personSimNode.x, y: personSimNode.y });
+
+                if (familySimNode && familyEl) {
+                    familyEl.setAttribute("transform", `translate(${familySimNode.x},${familySimNode.y})`);
+                    nextPositions.push({ x: familySimNode.x, y: familySimNode.y });
+                    if (edgeFocusToFamily && origin) {
+                        edgeFocusToFamily.setAttribute("x2", String(familySimNode.x));
+                        edgeFocusToFamily.setAttribute("y2", String(familySimNode.y));
+                    }
+                    if (edgeFamilyToPerson) {
+                        edgeFamilyToPerson.setAttribute("x1", String(familySimNode.x));
+                        edgeFamilyToPerson.setAttribute("y1", String(familySimNode.y));
+                        edgeFamilyToPerson.setAttribute("x2", String(personSimNode.x));
+                        edgeFamilyToPerson.setAttribute("y2", String(personSimNode.y));
+                    }
+                } else if (edgeFocusToFamily && origin) {
+                    edgeFocusToFamily.setAttribute("x2", String(personSimNode.x));
+                    edgeFocusToFamily.setAttribute("y2", String(personSimNode.y));
+                }
+            }
+            ghostSimPositions = nextPositions;
+        });
+
+        return () => {
+            fadeInCancelled = true;
+            ghostSim.stop();
+            ghostSimPositions = [];
+            fadeOutAndRemove(allGhostEls);
+
+            // Snap freed neighbors back to their pre-focus positions, then
+            // release them so the main sim can resume.  Strategy: pin each
+            // drifted neighbor at its snapshot coordinates for one sim tick
+            // (~250 ms transition via CSS on the SVG transform), then clear
+            // fx/fy.  This gives a visually elastic spring-back.
+            const SNAP_BACK_MS = 250;
+            d3.select("g.main").selectAll<SVGGElement, any>("g").each((d: any) => {
+                if (!d) return;
+                const snap = positionSnapshot.get(d.id);
+                if (neighborDomIds.has(d.id) && snap) {
+                    d.fx = snap.x;
+                    d.fy = snap.y;
+                    const gEl = mainG.querySelector(`#${CSS.escape(d.id)}`) as SVGGElement | null;
+                    if (gEl) {
+                        gEl.style.transition = `transform ${SNAP_BACK_MS}ms ease-out`;
+                        gEl.setAttribute("transform", `translate(${snap.x},${snap.y})`);
+                    }
+                    setTimeout(() => {
+                        d.x = snap.x;
+                        d.y = snap.y;
+                        d.fx = null;
+                        d.fy = null;
+                        if (gEl) gEl.style.transition = "";
+                    }, SNAP_BACK_MS);
+                } else {
+                    d.fx = null;
+                    d.fy = null;
+                }
+            });
+        };
+    });
+
+    // HTML5 DnD: tray chip → canvas family target. Tray person becomes spouse (parent).
+    $effect(() => {
+        if (!stemmaChart) return;
+        const svgEl = document.getElementById("chart") as unknown as SVGSVGElement | null;
+        if (!svgEl) return;
+
+        const onDragOver = (e: DragEvent) => {
+            if (!e.dataTransfer || !Array.from(e.dataTransfer.types).includes(PERSON_DRAG_MIME)) return;
+            const g = (e.target as Element | null)?.closest?.("g[id^='family_']") as SVGGElement | null;
+            if (!g) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "link";
+            g.classList.add("v3-drop-target");
+        };
+        const onDragLeave = (e: DragEvent) => {
+            const g = (e.target as Element | null)?.closest?.("g[id^='family_']") as SVGGElement | null;
+            g?.classList.remove("v3-drop-target");
+        };
+        const onDrop = (e: DragEvent) => {
+            const g = (e.target as Element | null)?.closest?.("g[id^='family_']") as SVGGElement | null;
+            if (!g || !e.dataTransfer) return;
+            const pid = e.dataTransfer.getData(PERSON_DRAG_MIME);
+            const fid = denormalizeId(g.id);
+            g.classList.remove("v3-drop-target");
+            if (!pid || !fid) return;
+            if (isPendingId(pid)) return;
+            e.preventDefault();
+            const dropSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
+            attachPersonToFamily(pid, fid, "parent", dropSvg);
+        };
+
+        svgEl.addEventListener("dragover", onDragOver);
+        svgEl.addEventListener("dragleave", onDragLeave);
+        svgEl.addEventListener("drop", onDrop);
+        return () => {
+            svgEl.removeEventListener("dragover", onDragOver);
+            svgEl.removeEventListener("dragleave", onDragLeave);
+            svgEl.removeEventListener("drop", onDrop);
+        };
+    });
+
+    // Canvas pointer gesture: drag person↔family. Empty source/target supported.
+    $effect(() => {
+        if (!editMode || !stemmaChart) return;
+        const svgEl = document.getElementById("chart") as unknown as SVGSVGElement | null;
+        if (!svgEl) return;
+
+        const PERSON_PREVIEW_R = 15;
+        const FAMILY_PREVIEW_R = 7;
+
+        let gesture: {
+            source: SourceRef;
+            sourceCenter: { x: number; y: number };
+            startClientX: number;
+            startClientY: number;
+            startMs: number;
+            active: boolean;
+            sourceGEl: SVGGElement | null;
+            sourceMarker: SVGCircleElement | null;
+            line: SVGLineElement | null;
+            endpointPreview: SVGCircleElement | null;
+            lastTarget: SVGGElement | null;
+        } | null = null;
+
+        const clearTargetHighlight = () => {
+            if (gesture?.lastTarget) gesture.lastTarget.classList.remove("v3-drop-target");
+        };
+
+        const removeSvgEl = (el: Element | null) => {
+            if (el && el.parentNode) el.parentNode.removeChild(el);
+        };
+
+        const ensureArrowMarker = () => {
+            if (svgEl.querySelector("defs > marker#v3-arrow")) return;
+            let defs = svgEl.querySelector("defs") as SVGDefsElement | null;
+            if (!defs) {
+                defs = document.createElementNS(SVG_NS, "defs") as SVGDefsElement;
+                svgEl.insertBefore(defs, svgEl.firstChild);
+            }
+            const marker = document.createElementNS(SVG_NS, "marker");
+            marker.setAttribute("id", "v3-arrow");
+            marker.setAttribute("viewBox", "0 0 10 6");
+            marker.setAttribute("refX", "10");
+            marker.setAttribute("refY", "3");
+            marker.setAttribute("markerWidth", "10");
+            marker.setAttribute("markerHeight", "6");
+            marker.setAttribute("markerUnits", "userSpaceOnUse");
+            marker.setAttribute("orient", "auto");
+            marker.setAttribute("fill", "#0d6efd");
+            const path = document.createElementNS(SVG_NS, "path");
+            path.setAttribute("d", arrowPath);
+            marker.appendChild(path);
+            defs.appendChild(marker);
+        };
+
+        const cleanup = () => {
+            document.body.classList.remove("v3-linking");
+            if (!gesture) return;
+            clearTargetHighlight();
+            removeSvgEl(gesture.line);
+            removeSvgEl(gesture.sourceMarker);
+            removeSvgEl(gesture.endpointPreview);
+            gesture.sourceGEl?.classList.remove("v3-gesture-source");
+            gesture = null;
+            dragTip = null;
+            activeGestureSource = null;
+        };
+
+        const targetCompatibility = (
+            source: SourceRef,
+            overInfo: { ref: NodeRef } | null,
+        ): "valid" | "noop" | "create-empty" => {
+            if (source.kind === "person") {
+                if (overInfo?.ref.kind === "family") {
+                    if (isPendingFamilyId(overInfo.ref.id)) {
+                        const pending = findPendingFamily(overInfo.ref.id);
+                        if (!pending) return "noop";
+                        if (pending.parents.includes(source.id) || pending.children.includes(source.id)) return "noop";
+                        return "valid";
+                    }
+                    const c = displayedStemmaIndex?.canAddParent(overInfo.ref.id, source.id);
+                    return c?.ok ? "valid" : "noop";
+                }
+                if (!overInfo) return "create-empty";
+                return "noop";
+            }
+            if (source.kind === "family") {
+                if (overInfo?.ref.kind === "person") {
+                    if (isPendingFamilyId(source.id)) {
+                        const pending = findPendingFamily(source.id);
+                        if (!pending) return "noop";
+                        if (pending.parents.includes(overInfo.ref.id) || pending.children.includes(overInfo.ref.id))
+                            return "noop";
+                        if (displayedStemmaIndex?.hasParentFamily(overInfo.ref.id)) return "noop";
+                        return "valid";
+                    }
+                    const c = displayedStemmaIndex?.canAddChild(source.id, overInfo.ref.id);
+                    return c?.ok ? "valid" : "noop";
+                }
+                if (!overInfo) return "create-empty";
+                return "noop";
+            }
+            if (source.kind === "empty") {
+                if (overInfo?.ref.kind === "family") return "valid";
+                if (overInfo?.ref.kind === "person") {
+                    if (displayedStemmaIndex?.hasParentFamily(overInfo.ref.id)) return "noop";
+                    return "valid";
+                }
+                return "noop";
+            }
+            return "noop";
+        };
+
+        const onPointerStart = (e: PointerEvent) => {
+            const targetG = (e.target as Element | null)?.closest?.("g[id^='person_'], g[id^='family_']") as SVGGElement | null;
+            let source: SourceRef;
+            let center: { x: number; y: number };
+            let sourceGEl: SVGGElement | null = null;
+            if (targetG) {
+                const kind = targetG.id.startsWith("person_") ? "person" : "family";
+                const sourceId = denormalizeId(targetG.id);
+                if (kind === "person" && isPendingPersonId(sourceId)) return;
+                const c = nodeCenter(targetG);
+                if (!c) return;
+                source = { kind, id: sourceId };
+                center = c;
+                sourceGEl = targetG;
+                stemmaChart?.popHover();
+            } else {
+                source = { kind: "empty" };
+                center = clientToSvgPoint(svgEl, e.clientX, e.clientY);
+            }
+            gesture = {
+                source,
+                sourceCenter: center,
+                startClientX: e.clientX,
+                startClientY: e.clientY,
+                startMs: Date.now(),
+                active: false,
+                sourceGEl,
+                sourceMarker: null,
+                line: null,
+                endpointPreview: null,
+                lastTarget: null,
+            };
+            document.body.classList.add("v3-linking");
+            e.preventDefault();
+        };
+
+        const computeTipText = (overInfo: { ref: NodeRef } | null, source: SourceRef): string | null => {
+            if (source.kind === "person") {
+                if (overInfo?.ref.kind === "family") {
+                    const anchor = familyAnchor(overInfo.ref.id);
+                    const key = anchor.via === "parents" ? "v2.tipIsSpouse" : "v2.tipIsParent";
+                    const param = anchor.via === "parents" ? "family" : "names";
+                    return $t(key, { person: personNameOf(source.id), [param]: joinNames(anchor.names) });
+                }
+                if (!overInfo) return $t("v2.tipPersonHasSpouse", { name: personNameOf(source.id) });
+                return null;
+            }
+            if (source.kind === "family") {
+                if (!overInfo) {
+                    const parents = familyParentNames(source.id);
+                    if (parents.length > 1) return $t("v2.tipParentsHaveChildren", { names: joinNames(parents) });
+                    return $t("v2.tipParentHasChildren", { name: joinNames(parents) });
+                }
+                if (overInfo.ref.kind === "person") {
+                    return $t("v2.tipIsChild", {
+                        person: personNameOf(overInfo.ref.id),
+                        family: joinNames(familyParentNames(source.id)),
+                    });
+                }
+                return null;
+            }
+            if (source.kind === "empty") {
+                if (overInfo?.ref.kind === "family") {
+                    const anchor = familyAnchor(overInfo.ref.id);
+                    if (anchor.via === "parents") {
+                        return $t("v2.tipPersonHasSpouse", { name: joinNames(anchor.names) });
+                    }
+                    const key = anchor.names.length > 1 ? "v2.tipChildrenHaveParent" : "v2.tipChildHasParent";
+                    const param = anchor.names.length > 1 ? "names" : "name";
+                    return $t(key, { [param]: joinNames(anchor.names) });
+                }
+                if (overInfo?.ref.kind === "person") {
+                    return $t("v2.tipPersonHasParents", { name: personNameOf(overInfo.ref.id) });
+                }
+                return null;
+            }
+            return null;
+        };
+
+        const updateEndpointPreview = (
+            mainG: SVGGElement | null,
+            svgPt: { x: number; y: number },
+            overInfo: { ref: NodeRef } | null,
+        ) => {
+            if (!gesture) return;
+            const src = gesture.source;
+            const hidePreview = () => {
+                if (gesture?.endpointPreview) gesture.endpointPreview.style.display = "none";
+            };
+            let previewKind: "person" | "family" | null = null;
+            if (!overInfo) {
+                if (src.kind === "family") previewKind = "person";
+                else if (src.kind === "person") previewKind = "family";
+            } else if (overInfo.ref.kind === "person" && src.kind === "empty") {
+                previewKind = "family";
+            }
+            if (!previewKind) {
+                hidePreview();
+                return;
+            }
+            const r = previewKind === "person" ? PERSON_PREVIEW_R : FAMILY_PREVIEW_R;
+            const previewClass = `v3-endpoint-preview v3-endpoint-${previewKind}`;
+            if (gesture.endpointPreview && gesture.endpointPreview.getAttribute("class") !== previewClass) {
+                gesture.endpointPreview.parentNode?.removeChild(gesture.endpointPreview);
+                gesture.endpointPreview = null;
+            }
+            if (!gesture.endpointPreview && mainG) {
+                const p = document.createElementNS(SVG_NS, "circle") as SVGCircleElement;
+                p.setAttribute("class", previewClass);
+                mainG.appendChild(p);
+                gesture.endpointPreview = p;
+            }
+            if (gesture.endpointPreview) {
+                gesture.endpointPreview.style.display = "";
+                gesture.endpointPreview.setAttribute("cx", String(svgPt.x));
+                gesture.endpointPreview.setAttribute("cy", String(svgPt.y));
+                gesture.endpointPreview.setAttribute("r", String(r));
+            }
+        };
+
+        const onPointerMove = (e: PointerEvent) => {
+            if (!gesture) return;
+            const dx = e.clientX - gesture.startClientX;
+            const dy = e.clientY - gesture.startClientY;
+            if (!gesture.active) {
+                if (Math.hypot(dx, dy) <= 6) return;
+                gesture.active = true;
+                activeGestureSource = gesture.source;
+                const mainG = svgEl.querySelector("g.main") as SVGGElement | null;
+                if (mainG) {
+                    ensureArrowMarker();
+                    const line = document.createElementNS(SVG_NS, "line") as SVGLineElement;
+                    line.setAttribute("class", "v3-link-line");
+                    line.setAttribute("x1", String(gesture.sourceCenter.x));
+                    line.setAttribute("y1", String(gesture.sourceCenter.y));
+                    line.setAttribute("x2", String(gesture.sourceCenter.x));
+                    line.setAttribute("y2", String(gesture.sourceCenter.y));
+                    line.setAttribute("marker-end", "url(#v3-arrow)");
+                    mainG.appendChild(line);
+                    gesture.line = line;
+                    if (gesture.source.kind === "empty") {
+                        const marker = document.createElementNS(SVG_NS, "circle") as SVGCircleElement;
+                        marker.setAttribute("class", "v3-empty-source-marker");
+                        marker.setAttribute("cx", String(gesture.sourceCenter.x));
+                        marker.setAttribute("cy", String(gesture.sourceCenter.y));
+                        marker.setAttribute("r", "8");
+                        mainG.appendChild(marker);
+                        gesture.sourceMarker = marker;
+                    }
+                }
+                gesture.sourceGEl?.classList.add("v3-gesture-source");
+            }
+            const svgPt = clientToSvgPoint(svgEl, e.clientX, e.clientY);
+            if (gesture.line) {
+                gesture.line.setAttribute("x2", String(svgPt.x));
+                gesture.line.setAttribute("y2", String(svgPt.y));
+            }
+            const overInfo = findNodeUnder(e.clientX, e.clientY);
+            const overG = overInfo?.el ?? null;
+            const compat = targetCompatibility(gesture.source, overInfo);
+            if (overG !== gesture.lastTarget) {
+                gesture.lastTarget?.classList.remove("v3-drop-target");
+                gesture.lastTarget = null;
+                if (overG && compat === "valid") {
+                    overG.classList.add("v3-drop-target");
+                    gesture.lastTarget = overG;
+                }
+            }
+            const mainG = svgEl.querySelector("g.main") as SVGGElement | null;
+            updateEndpointPreview(mainG, svgPt, overInfo);
+            const tipText = compat === "noop" ? null : computeTipText(overInfo, gesture.source);
+            dragTip = tipText ? { text: tipText, x: e.clientX, y: e.clientY } : null;
+        };
+
+        const onPointerEnd = (e: PointerEvent) => {
+            if (!gesture) return;
+            const wasActive = gesture.active;
+            const source = gesture.source;
+            const startCenter = gesture.sourceCenter;
+            const sourceGEl = gesture.sourceGEl;
+            const elapsed = Date.now() - gesture.startMs;
+            const moved = Math.hypot(e.clientX - gesture.startClientX, e.clientY - gesture.startClientY);
+            const overInfo = findNodeUnder(e.clientX, e.clientY);
+            cleanup();
+            if (!wasActive) {
+                // Short tap on touch: set or clear focus.
+                if (e.pointerType !== "mouse" && isShortTap(elapsed, moved)) {
+                    if (sourceGEl) {
+                        focusedId = focusedIdFromG(sourceGEl, isPendingId);
+                    } else {
+                        focusedId = null;
+                    }
+                }
+                return;
+            }
+
+            if (source.kind === "person" && overInfo?.ref.kind === "family") {
+                attachPersonToFamily(source.id, overInfo.ref.id, "parent", startCenter);
+                return;
+            }
+            if (source.kind === "family" && overInfo?.ref.kind === "person") {
+                const tgtCenter = nodeCenter(overInfo.el) ?? undefined;
+                attachPersonToFamily(overInfo.ref.id, source.id, "child", tgtCenter);
+                return;
+            }
+            if (source.kind === "empty" && overInfo?.ref.kind === "family") {
+                const anchor = familyAnchor(overInfo.ref.id);
+                const title = anchor.via === "parents"
+                    ? $t("v2.createSpouseTitleOf", { name: joinNames(anchor.names) })
+                    : $t("v2.createParentTitleOf", { names: joinNames(anchor.names) });
+                createPersonInFamily(overInfo.ref.id, "parent", title, startCenter);
+                return;
+            }
+            if (source.kind === "family" && !overInfo) {
+                const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
+                const title = $t("v2.createChildTitleOf", { names: joinNames(familyParentNames(source.id)) });
+                createPersonInFamily(source.id, "child", title, releaseSvg);
+                return;
+            }
+            if (source.kind === "person" && !overInfo) {
+                const releaseSvg = clientToSvgPoint(svgEl, e.clientX, e.clientY);
+                createPendingFamilyForPerson(source.id, "parent", releaseSvg);
+                return;
+            }
+            if (source.kind === "empty" && overInfo?.ref.kind === "person") {
+                if (displayedStemmaIndex?.hasParentFamily(overInfo.ref.id)) return;
+                createPendingFamilyForPerson(overInfo.ref.id, "child", startCenter);
+                return;
+            }
+        };
+
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                cleanup();
+                focusedId = null;
+            }
+        };
+
+        const onCancel = () => cleanup();
+        // d3.drag attaches a pointerdown listener to each node g and restarts
+        // the force simulation on press, which would scramble pinned positions
+        // mid-gesture. Capturing pointerdown at the svg root and stopping
+        // propagation prevents the d3 handler from ever seeing it, and the
+        // same handler starts V3's linking gesture. Single path covers mouse,
+        // pen, and touch.
+        const onPointerDownCapture = (e: PointerEvent) => {
+            if (panActive) return;
+            if (e.pointerType === "mouse" && e.button !== 0) return;
+            e.stopImmediatePropagation();
+            onPointerStart(e);
+        };
+        // touchstart fires before pointerdown, so d3.zoom would start a pan in parallel
+        // with the link gesture; swallow single-finger touch, let pinch through.
+        const onTouchStartCapture = (e: TouchEvent) => {
+            if (panActive) return;
+            if (e.touches.length !== 1) return;
+            e.stopPropagation();
+        };
+        svgEl.addEventListener("pointerdown", onPointerDownCapture, true);
+        svgEl.addEventListener("touchstart", onTouchStartCapture, true);
+        window.addEventListener("pointermove", onPointerMove);
+        window.addEventListener("pointerup", onPointerEnd);
+        window.addEventListener("pointercancel", onCancel);
+        window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("contextmenu", onCancel);
+        window.addEventListener("blur", onCancel);
+        return () => {
+            svgEl.removeEventListener("pointerdown", onPointerDownCapture, true);
+            svgEl.removeEventListener("touchstart", onTouchStartCapture, true);
+            window.removeEventListener("pointermove", onPointerMove);
+            window.removeEventListener("pointerup", onPointerEnd);
+            window.removeEventListener("pointercancel", onCancel);
+            window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("contextmenu", onCancel);
+            window.removeEventListener("blur", onCancel);
+            cleanup();
+        };
+    });
+
+    function classifyForDrop(src: SourceRef, g: Element): "v3-drop-allowed" | "v3-drop-disallowed" | null {
+        const id = denormalizeId(g.id);
+        const kind: "person" | "family" = g.id.startsWith("person_") ? "person" : "family";
+        if (kind === "person" && isPendingPersonId(id)) return null;
+        if (src.kind === "person") {
+            if (kind !== "family") return null;
+            if (isPendingFamilyId(id)) {
+                const pending = findPendingFamily(id);
+                if (!pending) return null;
+                return pending.parents.includes(src.id) || pending.children.includes(src.id)
+                    ? "v3-drop-disallowed"
+                    : "v3-drop-allowed";
+            }
+            const c = displayedStemmaIndex?.canAddParent(id, src.id);
+            if (!c) return null;
+            return c.ok ? "v3-drop-allowed" : "v3-drop-disallowed";
+        }
+        if (src.kind === "family") {
+            if (kind !== "person") return null;
+            if (src.id === id) return null;
+            if (isPendingFamilyId(src.id)) {
+                const pending = findPendingFamily(src.id);
+                if (!pending) return null;
+                if (pending.parents.includes(id) || pending.children.includes(id)) return "v3-drop-disallowed";
+                if (displayedStemmaIndex?.hasParentFamily(id)) return "v3-drop-disallowed";
+                return "v3-drop-allowed";
+            }
+            const c = displayedStemmaIndex?.canAddChild(src.id, id);
+            if (!c) return null;
+            return c.ok ? "v3-drop-allowed" : "v3-drop-disallowed";
+        }
+        return null;
+    }
+
+    $effect(() => {
+        const src = activeGestureSource;
+        if (!src || src.kind === "empty") return;
+        void displayedStemmaIndex;
+        const svgEl = document.getElementById("chart");
+        if (!svgEl) return;
+        svgEl.querySelectorAll("g[id^='person_'], g[id^='family_']").forEach((g) => {
+            g.classList.remove("v3-drop-allowed", "v3-drop-disallowed");
+            const cls = classifyForDrop(src, g);
+            if (cls) g.classList.add(cls);
+        });
+        return () => {
+            svgEl.querySelectorAll("g.v3-drop-allowed, g.v3-drop-disallowed").forEach((g) => {
+                g.classList.remove("v3-drop-allowed", "v3-drop-disallowed");
+            });
+        };
+    });
+
+    $effect(() => {
+        if (editMode) return;
+        panMode = false;
+        spacePan = false;
+        untrack(() => {
+            const filtered = pendingFamilies.filter((p) => p.parents.length + p.children.length >= 2);
+            if (filtered.length !== pendingFamilies.length) pendingFamilies = filtered;
+        });
+    });
+
+    // Pan activation (edit mode Space/pan button) clears focus so ghosts are
+    // dismissed before the user starts dragging the canvas.
+    $effect(() => {
+        if (panActive) focusedId = null;
+    });
+
+    $effect(() => {
+        if (!editMode) return;
+        const isTypingTarget = (t: EventTarget | null): boolean => {
+            if (!(t instanceof HTMLElement)) return false;
+            const tag = t.tagName;
+            return tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable;
+        };
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                if (isTypingTarget(e.target)) return;
+                if (panMode && !activeGestureSource && !document.querySelector(".v3-modal-panel")) {
+                    panMode = false;
+                }
+                return;
+            }
+            if (e.code !== "Space" || e.repeat) return;
+            if (isTypingTarget(e.target)) return;
+            spacePan = true;
+            e.preventDefault();
+        };
+        const onKeyUp = (e: KeyboardEvent) => {
+            if (e.code !== "Space") return;
+            spacePan = false;
+        };
+        window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("keyup", onKeyUp);
+        return () => {
+            window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("keyup", onKeyUp);
+            spacePan = false;
+        };
+    });
+
+    $effect(() => {
+        if (!panActive) {
+            document.body.classList.remove("v3-pan-armed", "v3-pan-dragging");
+            return;
+        }
+        document.body.classList.add("v3-pan-armed");
+        const onDown = () => document.body.classList.add("v3-pan-dragging");
+        const onUp = () => document.body.classList.remove("v3-pan-dragging");
+        window.addEventListener("mousedown", onDown);
+        window.addEventListener("mouseup", onUp);
+        return () => {
+            window.removeEventListener("mousedown", onDown);
+            window.removeEventListener("mouseup", onUp);
+            document.body.classList.remove("v3-pan-armed", "v3-pan-dragging");
+        };
+    });
+
+    async function handleBulkAdd(names: string[]) {
+        for (const name of names) {
+            await withPendingAdd(name, () =>
+                controller.createOrphanPerson({ type: "CreateNewPerson", name }, { silent: true }),
+            );
+        }
+    }
+
+    function errorMessage(err: Error): string {
+        if (err instanceof LocalizedError) return $t(err.key, err.params);
+        return err.message;
+    }
+
+    function handlePersonSelected(person: PersonDescription) {
+        if (pendingRemovedPersonIds.has(person.id)) return;
+        if (isPendingId(person.id)) return;
+        personEditModal?.showPersonDetails({
+            description: person,
+            pin: pinnedPeople?.isPinned(person.id) ?? false,
+        });
+    }
+
+    function handleFamilySelected(family: FamilyDescription) {
+        if (pendingRemovedFamilyIds.has(family.id)) return;
+        selectedFamilyEl = document.getElementById(normalizeId("family", family.id));
+        selectedFamilyId = family.id;
+        familySheetOpen = true;
+    }
+
+    function closeFamilySheet() {
+        familySheetOpen = false;
+        selectedFamilyId = null;
+        selectedFamilyEl = null;
+    }
+
+    function setWith<T>(s: Set<T>, v: T): Set<T> {
+        return s.has(v) ? s : new Set([...s, v]);
+    }
+
+    function setWithout<T>(s: Set<T>, v: T): Set<T> {
+        if (!s.has(v)) return s;
+        const next = new Set(s);
+        next.delete(v);
+        return next;
+    }
+
+    function runRemovePerson(personId: string) {
+        pendingRemovedPersonIds = setWith(pendingRemovedPersonIds, personId);
+        controller
+            .removePerson(personId, { silent: true })
+            .finally(() => { pendingRemovedPersonIds = setWithout(pendingRemovedPersonIds, personId); });
+    }
+
+    function runRemoveFamily(familyId: string) {
+        pendingRemovedFamilyIds = setWith(pendingRemovedFamilyIds, familyId);
+        controller
+            .removeFamily(familyId, { silent: true })
+            .finally(() => { pendingRemovedFamilyIds = setWithout(pendingRemovedFamilyIds, familyId); });
+    }
+
+    let currentToken = $state<string | null>(null);
+    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+    let inflightRefresh: Promise<string> | null = null;
+    let e2eMode = false;
+
+    function scheduleRefresh(expiresAt: number) {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        if (e2eMode) return;
+        refreshTimer = setTimeout(() => {
+            void runRefresh();
+        }, msUntilRefresh(expiresAt));
+    }
+
+    function adoptToken(token: string) {
+        const saved = saveCredential(token);
+        currentToken = token;
+        if (saved) scheduleRefresh(saved.expiresAt);
+    }
+
+    function endSession() {
+        if (refreshTimer) clearTimeout(refreshTimer);
+        refreshTimer = null;
+        clearCredential();
+        currentToken = null;
+        signedIn = false;
+    }
+
+    function runRefresh(): Promise<string> {
+        if (e2eMode) return Promise.resolve(currentToken!);
+        if (inflightRefresh) return inflightRefresh;
+        inflightRefresh = refreshCredential()
+            .then((token) => {
+                adoptToken(token);
+                return token;
+            })
+            .catch((err) => {
+                endSession();
+                throw err;
+            })
+            .finally(() => {
+                inflightRefresh = null;
+            });
+        return inflightRefresh;
+    }
+
+    const tokenProvider: TokenProvider = {
+        getToken: () => currentToken,
+        refresh: () => runRefresh(),
+    };
+
+    function handleSignIn(user: User) {
+        adoptToken(user.id_token);
+        controller.authenticateAndListStemmas(tokenProvider);
+        signedIn = true;
+    }
+
+    function handleExportSvg() {
+        const filename = $t("nav.exportDefaultName");
+        stemmaChart?.exportSvg(filename);
+    }
+
+    function openAddStemma() {
+        promptModal?.prompt({
+            title: $t("stemma.addTitle"),
+            label: $t("stemma.nameLabel"),
+            confirmLabel: $t("common.add"),
+            placeholder: $t("stemma.defaultName"),
+            testid: "v3-add-stemma-modal",
+            onaccept: (value) => controller.addStemma(value),
+        });
+    }
+
+    function openRenameStemma(s: StemmaDescription) {
+        promptModal?.prompt({
+            title: $t("stemma.renameTitle"),
+            label: $t("stemma.nameLabel"),
+            confirmLabel: $t("stemma.rename"),
+            initial: s.name,
+            testid: "v3-rename-stemma-modal",
+            onaccept: (value) => controller.renameStemma(s.id, value),
+        });
+    }
+
+    function openCloneStemma(s: StemmaDescription) {
+        promptModal?.prompt({
+            title: $t("stemma.cloneTitle"),
+            label: $t("stemma.nameLabel"),
+            confirmLabel: $t("stemma.clone"),
+            initial: s.name,
+            testid: "v3-clone-stemma-modal",
+            onaccept: (value) => controller.cloneStemma(value, s.id),
+        });
+    }
+
+    function openAddPerson() {
+        personEditModal?.showCreatePerson({
+            title: $t("v2.addPerson"),
+            oncreate: ({ description, pin, photoUpload }) => {
+                void withPendingAdd(
+                    description.name,
+                    () => controller.createOrphanPerson(description, { silent: true }),
+                    undefined,
+                    (result) => {
+                        const newId = result.newPersonIds[0];
+                        if (newId && (photoUpload || pin)) {
+                            controller.savePerson(newId, description, pin, photoUpload, false);
+                        }
+                    },
+                );
+            },
+        });
+    }
+
+    function openRemoveStemma(s: StemmaDescription) {
+        confirmModal?.ask({
+            title: $t("removeStemma.title", { name: s.name }),
+            confirmLabel: $t("common.delete"),
+            danger: true,
+            testid: "v3-remove-stemma-modal",
+            onaccept: () => controller.removeStemma(s.id),
+        });
+    }
+
+    function handleFamilyRemoveRequested(familyId: string) {
+        confirmModal?.ask({
+            title: $t("v2.removeFamilyTitle"),
+            message: $t("v2.removeFamilyMessage"),
+            confirmLabel: $t("v2.dissolveFamilyConfirm"),
+            danger: true,
+            testid: "v3-remove-family-modal",
+            onaccept: () => runRemoveFamily(familyId),
+        });
+    }
+
+    function handlePersonRemoveRequested(payload: { id: string; name: string }) {
+        confirmModal?.ask({
+            title: $t("v2.removePersonTitle", { name: payload.name }),
+            message: $t("v2.removePersonMessage"),
+            confirmLabel: $t("common.delete"),
+            danger: true,
+            testid: "v3-remove-person-modal",
+            onaccept: () => {
+                runRemovePerson(payload.id);
+                personEditModal?.dismiss();
+            },
+        });
+    }
+
+    onMount(() => {
+        if (e2eAutoLoginEnabled) {
+            e2eMode = true;
+            const override = (window as unknown as { __STEMMA_E2E_USER__?: string }).__STEMMA_E2E_USER__;
+            handleSignIn({ id_token: override || "e2e-user@stemma.local" } as User);
+        } else {
+            initializeGoogleAuth(google_client_id).catch((err) => console.error("Google Identity init failed", err));
+
+            if (initialCached) {
+                handleSignIn({ id_token: initialCached.token });
+            } else {
+                fetch(`${stemma_backend_url}/warmup`).catch(() => {});
+            }
+        }
+
+        return () => {
+            for (const unsub of subscriptions) unsub();
+            if (refreshTimer) clearTimeout(refreshTimer);
+        };
+    });
+
+    const showCanvas = $derived(!isWorking && displayedStemma && displayedStemmaIndex && highlight && pinnedPeople);
+    const showEmpty = $derived(!isWorking && stemma && stemma.people.length === 0);
+</script>
+
+{#if signedIn}
+    <div class="v3-layout" class:v3-edit-mode={editMode}>
+        {#if editMode}
+            <svg class="v3-edit-watermark" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <pattern id="v3-edit-watermark-pattern" patternUnits="userSpaceOnUse" width="360" height="140" patternTransform="rotate(-25)">
+                        <text x="0" y="60" fill="#212529" font-size="42" font-weight="800" letter-spacing="6">{$t("v2.editModeBanner")}</text>
+                    </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#v3-edit-watermark-pattern)" />
+            </svg>
+        {/if}
+        <div class="v3-canvas-layer">
+            {#if showCanvas}
+                <FullStemma
+                    bind:this={stemmaChart}
+                    hidden={isWorking}
+                    stemma={displayedStemma!}
+                    currentStemmaId={currentStemmaId ?? ""}
+                    stemmaIndex={displayedStemmaIndex!}
+                    highlight={highlight!}
+                    pinnedPeople={pinnedPeople!}
+                    viewMode={ViewMode.ALL}
+                    simulationActive={!editMode}
+                    onpersonSelected={handlePersonSelected}
+                    onfamilySelected={handleFamilySelected}
+                    onhighlightChanged={() => highlightVersion++}
+                />
+            {/if}
+
+            {#if showEmpty}
+                <V3EmptyState {editMode} onaddPerson={openAddPerson} />
+            {/if}
+        </div>
+
+        <div class="v3-chrome" aria-hidden="false">
+            <div class="v3-top-left">
+                <V3Chip
+                    {ownedStemmas}
+                    {currentStemmaId}
+                    disabled={isWorking}
+                    onstemmaSelect={(id) => controller.selectStemma(id)}
+                    onstemmaAddNew={openAddStemma}
+                    onstemmaRename={openRenameStemma}
+                    onstemmaClone={openCloneStemma}
+                    onstemmaRemove={openRemoveStemma}
+                />
+            </div>
+
+            <div class="v3-top-center">
+                {#if stemma && stemma.people.length > 0}
+                    <V3Search
+                        people={stemma.people}
+                        disabled={isWorking}
+                        onselect={(id) => stemmaChart?.zoomToNode(id)}
+                    />
+                {/if}
+            </div>
+
+            <div class="v3-top-right">
+                <V3LangSwitcher />
+                <V3Menu
+                    showSignOut={!e2eAutoLoginEnabled}
+                    onabout={() => aboutModal?.show()}
+                    onsettings={() => settingsModal?.show()}
+                    onexport={handleExportSvg}
+                    onsignOut={endSession}
+                />
+            </div>
+
+            <div class="v3-bottom-right">
+                <V3Fab
+                    {editMode}
+                    {panMode}
+                    disabled={isWorking}
+                    oneditToggle={() => { editMode = !editMode; }}
+                    onpanToggle={() => { panMode = !panMode; }}
+                    onaddPerson={openAddPerson}
+                />
+            </div>
+
+            {#if !isWorking && stemma && stemmaIndex && highlight}
+                <div class="v3-bottom-left">
+                    <StatsCard {stemma} {stemmaIndex} {highlight} {highlightVersion} />
+                </div>
+            {/if}
+
+            {#if editMode && stemma}
+                <V3BulkAddTray
+                    orphans={orphanPeople}
+                    busy={isWorking}
+                    open={trayOpen}
+                    onbulkAdd={handleBulkAdd}
+                    ontoggle={() => { trayOpen = !trayOpen; }}
+                />
+            {/if}
+        </div>
+
+        {#if isWorking}
+            <div class="v3-loading">
+                <Circle2 />
+                <p class="mt-2">{$t("app.loading")}</p>
+            </div>
+        {/if}
+
+        {#if dragTip}
+            <div
+                class="v3-drag-tip"
+                style="left: {dragTip.x + 14}px; top: {dragTip.y + 14}px;"
+                data-testid="v3-drag-tip"
+            >
+                {dragTip.text}
+            </div>
+        {/if}
+
+        {#if error}
+            <div class="v3-error-bar">
+                <div class="alert alert-danger alert-dismissible fade show mb-0">
+                    <button
+                        type="button"
+                        class="btn-close"
+                        onclick={() => { error = null; }}
+                        aria-label={$t("common.close")}
+                    ></button>
+                    <strong>{$t("app.oops")}</strong> {errorMessage(error)}
+                </div>
+            </div>
+        {/if}
+    </div>
+
+    <V3Sheet
+        open={familySheetOpen}
+        anchorEl={selectedFamilyEl}
+        onclose={closeFamilySheet}
+        testid="v3-family-sheet"
+    >
+        {#snippet body()}
+            <V3FamilyCard
+                stemmaIndex={stemmaIndex}
+                {editMode}
+                familyId={selectedFamilyId}
+                onfamilyRemoveRequested={handleFamilyRemoveRequested}
+                onclose={closeFamilySheet}
+            />
+        {/snippet}
+    </V3Sheet>
+
+    <V3PersonDetailsModal
+        bind:this={personEditModal}
+        {editMode}
+        onpersonUpdated={(p) => controller.savePerson(p.id, p.description, p.pin, p.photoUpload, p.photoRemove)}
+        onpersonRemoveRequested={handlePersonRemoveRequested}
+        onshareAccessRequested={(p) => shareAccessModal?.show(p)}
+    />
+
+    <V3AboutModal bind:this={aboutModal} />
+    <V3SettingsModal bind:this={settingsModal} />
+    <V3ShareAccessModal
+        bind:this={shareAccessModal}
+        oncreate={(p) => controller.createInvitationToken(p.personId, p.email)}
+    />
+    <V3PromptModal bind:this={promptModal} />
+    <V3ConfirmModal bind:this={confirmModal} />
+{:else}
+    <div class="authenticate-bg vh-100">
+        <div class="authenticate-holder">
+            <Authenticate {google_client_id} onsignIn={(user) => handleSignIn(user)} />
+        </div>
+    </div>
+{/if}
+
+<style>
+    :global(:root) {
+        --v3-text-primary: #212529;
+        --v3-text-secondary: #495057;
+        --v3-text-muted: #6c757d;
+        --v3-bg-surface: #fff;
+        --v3-border-subtle: #f0f0f0;
+        --v3-radius-modal: 16px;
+        --v3-fs-title: 1rem;
+        --v3-fs-body: 0.9rem;
+        --v3-fs-label: 0.85rem;
+        --v3-fs-hint: 0.8rem;
+        --v3-fw-title: 700;
+        --v3-fw-section: 600;
+        --v3-fw-label: 500;
+    }
+
+    .v3-layout {
+        position: relative;
+        width: 100vw;
+        height: 100vh;
+        height: 100dvh;
+        overflow: hidden;
+        background: #f8f9fa;
+    }
+
+    .v3-canvas-layer {
+        position: absolute;
+        inset: 0;
+    }
+
+    :global(.v3-canvas-layer #chart) {
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding: 0 !important;
+        user-select: none;
+        -webkit-user-select: none;
+        -webkit-user-drag: none;
+    }
+
+    :global(.v3-edit-mode .v3-canvas-layer #chart) {
+        touch-action: none;
+    }
+
+    :global(.v3-canvas-layer #chart text) {
+        user-select: none;
+        -webkit-user-select: none;
+        -webkit-user-drag: none;
+    }
+
+    .v3-chrome {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+    }
+
+    .v3-top-left {
+        position: absolute;
+        top: 16px;
+        left: 16px;
+        pointer-events: auto;
+        z-index: 110;
+    }
+
+    .v3-top-center {
+        position: absolute;
+        top: 16px;
+        left: 50%;
+        transform: translateX(-50%);
+        pointer-events: auto;
+        z-index: 100;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+    }
+
+    @media (max-width: 767.98px) {
+        .v3-top-center {
+            top: 72px;
+        }
+    }
+
+    .v3-top-right {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        pointer-events: auto;
+        z-index: 100;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .v3-bottom-right {
+        position: absolute;
+        bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+        right: calc(20px + env(safe-area-inset-right, 0px));
+        pointer-events: auto;
+        z-index: 100;
+    }
+
+    .v3-bottom-left {
+        position: absolute;
+        bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+        left: calc(16px + env(safe-area-inset-left, 0px));
+        pointer-events: auto;
+        z-index: 100;
+    }
+
+    :global(.v3-bottom-left .stats-card) {
+        position: static;
+        bottom: auto;
+        right: auto;
+    }
+
+    .v3-loading {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        pointer-events: none;
+        z-index: 200;
+    }
+
+    .v3-error-bar {
+        position: absolute;
+        top: 72px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: min(480px, calc(100vw - 32px));
+        z-index: 300;
+        pointer-events: auto;
+    }
+
+    .authenticate-bg {
+        background-image: url("/assets/bg.webp");
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: cover;
+    }
+
+    .authenticate-holder {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+    }
+
+    :global(g.v3-ghost) {
+        opacity: 0.6;
+        cursor: default;
+        transition: opacity 200ms ease;
+    }
+
+    :global(g.v3-ghost > circle) {
+        fill: none;
+        stroke: #6c757d;
+        stroke-width: 1.5px;
+        stroke-dasharray: 5 3;
+        pointer-events: none;
+    }
+
+    :global(g.v3-ghost .v3-ghost-label) {
+        fill: #6c757d;
+        pointer-events: none;
+    }
+
+    :global(line.v3-ghost-edge) {
+        stroke: #6c757d;
+        stroke-width: 1px;
+        stroke-dasharray: 4 3;
+        opacity: 0.5;
+        pointer-events: none;
+        transition: opacity 200ms ease;
+    }
+
+    :global(g.v3-ghost-family) {
+        opacity: 0.5;
+        cursor: default;
+        transition: opacity 200ms ease;
+        pointer-events: none;
+    }
+
+    :global(g.v3-ghost-family > circle) {
+        fill: none;
+        stroke: #6c757d;
+        stroke-width: 1.5px;
+        stroke-dasharray: 5 3;
+        pointer-events: none;
+    }
+
+    :global(.v3-pending-remove) {
+        stroke-dasharray: 4 4;
+        stroke: #dc3545;
+        opacity: 0.45;
+        animation: v3-pending-pulse 1.2s ease-in-out infinite;
+    }
+
+    :global(.v3-pending-add) {
+        opacity: 0.45;
+        stroke-dasharray: 4 3;
+        stroke: #0d6efd;
+        animation: v3-pending-pulse 1.2s ease-in-out infinite;
+    }
+
+    @keyframes v3-pending-pulse {
+        0%, 100% { stroke-opacity: 1; }
+        50% { stroke-opacity: 0.35; }
+    }
+
+    :global(g.v3-drop-disallowed) {
+        opacity: 0.3;
+        filter: saturate(0.2);
+        pointer-events: none;
+    }
+
+    :global(g.v3-drop-allowed > circle) {
+        animation: v3-drop-allowed-pulse 1.8s ease-in-out infinite;
+    }
+
+    @keyframes v3-drop-allowed-pulse {
+        0%, 100% { stroke-opacity: 1; }
+        50% { stroke-opacity: 0.45; }
+    }
+
+    :global(g.v3-drop-target > circle) {
+        stroke: #0d6efd;
+        stroke-width: 3px;
+        stroke-dasharray: 4 2;
+        filter: drop-shadow(0 0 6px rgba(13, 110, 253, 0.55));
+    }
+
+    :global(g.v3-gesture-source > circle) {
+        stroke: #0d6efd;
+        stroke-width: 2.5px;
+        filter: drop-shadow(0 0 8px rgba(13, 110, 253, 0.65));
+    }
+
+    :global(.v3-empty-source-marker) {
+        fill: rgba(13, 110, 253, 0.08);
+        stroke: #0d6efd;
+        stroke-width: 1.5;
+        stroke-dasharray: 4 3;
+        opacity: 0.7;
+        pointer-events: none;
+    }
+
+    :global(.v3-endpoint-preview) {
+        fill: rgba(13, 110, 253, 0.08);
+        stroke: #0d6efd;
+        stroke-width: 1.5;
+        stroke-dasharray: 4 3;
+        opacity: 0.75;
+        pointer-events: none;
+    }
+
+    :global(.v3-link-line) {
+        stroke: #0d6efd;
+        stroke-width: 2px;
+        stroke-dasharray: 5 4;
+        pointer-events: none;
+        opacity: 0.7;
+    }
+
+    :global(body.v3-linking),
+    :global(body.v3-linking *) {
+        cursor: crosshair !important;
+        user-select: none !important;
+        -webkit-user-select: none !important;
+    }
+
+    :global(body.v3-pan-armed),
+    :global(body.v3-pan-armed *) {
+        cursor: grab !important;
+    }
+
+    :global(body.v3-pan-dragging),
+    :global(body.v3-pan-dragging *) {
+        cursor: grabbing !important;
+    }
+
+    .v3-drag-tip {
+        position: fixed;
+        pointer-events: none;
+        background: rgba(13, 110, 253, 0.95);
+        color: #fff;
+        padding: 4px 10px;
+        border-radius: 10px;
+        font-size: 0.82rem;
+        font-weight: 500;
+        max-width: min(320px, 80vw);
+        overflow-wrap: anywhere;
+        z-index: 400;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    }
+
+    .v3-edit-mode :global(g[id^='person_']),
+    .v3-edit-mode :global(g[id^='family_']) {
+        cursor: grab;
+    }
+
+    .v3-edit-mode {
+        box-shadow: inset 0 0 0 3px rgba(73, 80, 87, 0.55);
+        animation: v3-edit-mode-ring-pulse 2.4s ease-in-out infinite;
+    }
+
+    @keyframes v3-edit-mode-ring-pulse {
+        0%, 100% { box-shadow: inset 0 0 0 3px rgba(73, 80, 87, 0.55); }
+        50% { box-shadow: inset 0 0 0 3px rgba(73, 80, 87, 0.22); }
+    }
+
+    .v3-edit-watermark {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 0;
+        opacity: 0.04;
+    }
+
+    .v3-edit-mode::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        opacity: 0.08;
+        background-repeat: repeat;
+        background-size: 220px 220px;
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220' viewBox='0 0 220 220'><g fill='%23212529'><g transform='translate(30 40) rotate(20) scale(1.4)'><path d='M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325'/></g><g transform='translate(150 90) rotate(-35) scale(1.6)'><path d='M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325'/></g><g transform='translate(80 170) rotate(75) scale(1.3)'><path d='M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325'/></g></g></svg>");
+    }
+</style>

--- a/frontend/src/v3/components/V3AboutModal.svelte
+++ b/frontend/src/v3/components/V3AboutModal.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+    import * as d3 from "d3";
+    import { t } from "../../i18n";
+    import {
+        personR, familyR, defaultFamilyColor, relationsColor,
+        childRelationWidth, familyRelationWidth, labelFontSize,
+        personColor, addArrowMarkers
+    } from "../../graphStyles";
+    import V3Modal from "./V3Modal.svelte";
+
+    let open = $state(false);
+    let diagramEl = $state<HTMLDivElement | null>(null);
+
+    const width = 360;
+    const height = 220;
+
+    function renderDiagram(translate: (key: string) => string) {
+        if (!diagramEl) return;
+        diagramEl.innerHTML = "";
+
+        const svg = d3
+            .select(diagramEl)
+            .append("svg")
+            .attr("viewBox", `0 0 ${width} ${height}`)
+            .attr("width", "100%")
+            .attr("height", "100%");
+
+        const markers = addArrowMarkers(svg);
+
+        const parentsY = 40;
+        const familyY = 110;
+        const childY = 185;
+        const parentLeftX = 90;
+        const parentRightX = 270;
+        const familyX = 180;
+        const childX = 180;
+
+        svg.append("line").attr("x1", parentLeftX).attr("y1", parentsY)
+            .attr("x2", familyX).attr("y2", familyY)
+            .attr("stroke", relationsColor)
+            .attr("stroke-width", familyRelationWidth)
+            .attr("marker-end", markers.family);
+        svg.append("line").attr("x1", parentRightX).attr("y1", parentsY)
+            .attr("x2", familyX).attr("y2", familyY)
+            .attr("stroke", relationsColor)
+            .attr("stroke-width", familyRelationWidth)
+            .attr("marker-end", markers.family);
+        svg.append("line").attr("x1", familyX).attr("y1", familyY)
+            .attr("x2", childX).attr("y2", childY)
+            .attr("stroke", relationsColor)
+            .attr("stroke-width", childRelationWidth)
+            .attr("marker-end", markers.person);
+
+        svg.append("circle").attr("cx", parentLeftX).attr("cy", parentsY).attr("r", personR).attr("fill", personColor(0));
+        svg.append("circle").attr("cx", parentRightX).attr("cy", parentsY).attr("r", personR).attr("fill", personColor(0));
+        svg.append("circle").attr("cx", familyX).attr("cy", familyY).attr("r", familyR).attr("fill", defaultFamilyColor);
+        svg.append("circle").attr("cx", childX).attr("cy", childY).attr("r", personR).attr("fill", personColor(1));
+
+        const label = (text: string, x: number, y: number) => {
+            svg.append("text").text(text).attr("x", x).attr("y", y)
+                .attr("text-anchor", "middle").style("font-size", labelFontSize);
+        };
+
+        label(translate("about.diagram.parent1"), parentLeftX, parentsY - personR - 5);
+        label(translate("about.diagram.parent2"), parentRightX, parentsY - personR - 5);
+        label(translate("about.diagram.family"), familyX, familyY - familyR - 5);
+        label(translate("about.diagram.child"), childX, childY + personR + 18);
+    }
+
+    $effect(() => {
+        if (open && diagramEl && $t) {
+            renderDiagram($t);
+        }
+    });
+
+    export function show() {
+        open = true;
+    }
+
+    function close() {
+        open = false;
+    }
+</script>
+
+<V3Modal {open} title={$t("about.title")} size="lg" scroll onclose={close} testid="v3-about-modal">
+    {#snippet body()}
+        <img src="/assets/logo_color.webp" alt="" width="84" height="84" class="logo" />
+
+        <section>
+            <h6>{$t("about.heading")}</h6>
+            <p>{$t("about.intro")}</p>
+        </section>
+
+        <section>
+            <h6>{$t("about.familyRulesTitle")}</h6>
+            <p>{$t("about.familyRulesIntro")}</p>
+            <div class="about-diagram" bind:this={diagramEl}></div>
+            <p>{$t("about.familyRulesNote")}</p>
+            <ul>
+                <li>{$t("about.rule1")}</li>
+                <li>{$t("about.rule2")}</li>
+                <li>{$t("about.rule3")}</li>
+                <li>{$t("about.rule4")}</li>
+                <li>{$t("about.rule5")}</li>
+                <li>{$t("about.rule6")}</li>
+                <li>{$t("about.rule7")}</li>
+                <li>{$t("about.rule8")}</li>
+                <li>{$t("about.rule9")}</li>
+            </ul>
+        </section>
+
+        <section>
+            <h6>{$t("about.namesakesTitle")}</h6>
+            <p>{$t("about.namesakesText")}</p>
+        </section>
+
+        <section>
+            <h6>{$t("about.sharingTitle")}</h6>
+            <p>{$t("about.sharingText1")}</p>
+            <p>{$t("about.sharingText2")}</p>
+            <p>
+                <b>{$t("about.sharingWarning")}</b>{$t("about.sharingWarningText")} <i>@gmail.com</i>
+            </p>
+        </section>
+
+        <section>
+            <h6>{$t("about.problemsTitle")}</h6>
+            <p>
+                {$t("about.problemsText")}
+                <a href="mailto:danilasergeevich@gmail.com?subject=stemma">{$t("about.problemsEmail")}</a>.
+            </p>
+        </section>
+    {/snippet}
+
+    {#snippet footer()}
+        <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.ok")}</button>
+    {/snippet}
+</V3Modal>
+
+<style>
+    .logo {
+        display: block;
+        margin: 0 auto 12px;
+    }
+
+    section {
+        margin-top: 16px;
+    }
+
+    section:first-of-type {
+        margin-top: 0;
+    }
+
+    section h6 {
+        font-weight: var(--v3-fw-section);
+        margin-bottom: 6px;
+    }
+
+    section p {
+        margin-bottom: 8px;
+        font-size: var(--v3-fs-body);
+        color: var(--v3-text-secondary);
+    }
+
+    .about-diagram {
+        width: 100%;
+        max-width: 360px;
+        height: 220px;
+        margin: 8px auto;
+        display: block;
+    }
+
+    ul {
+        padding-left: 1.2rem;
+        font-size: var(--v3-fs-body);
+        color: var(--v3-text-secondary);
+    }
+
+    ul li {
+        margin-bottom: 4px;
+    }
+</style>

--- a/frontend/src/v3/components/V3BulkAddTray.svelte
+++ b/frontend/src/v3/components/V3BulkAddTray.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+    import type { PersonDescription } from "../../model";
+    import { t } from "../../i18n";
+
+    type Props = {
+        orphans: PersonDescription[];
+        busy: boolean;
+        open: boolean;
+        onbulkAdd: (names: string[]) => void;
+        ontoggle: () => void;
+    };
+
+    let { orphans, busy, open, onbulkAdd, ontoggle }: Props = $props();
+
+    let draft = $state("");
+
+    function submit() {
+        const names = draft
+            .split("\n")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (!names.length) return;
+        onbulkAdd(names);
+        draft = "";
+    }
+
+    function handleDragStart(event: DragEvent, personId: string) {
+        if (!event.dataTransfer) return;
+        event.dataTransfer.effectAllowed = "link";
+        event.dataTransfer.setData("application/x-stemma-person", personId);
+        event.dataTransfer.setData("text/plain", personId);
+    }
+</script>
+
+<aside
+    class="v3-tray"
+    class:open
+    data-testid="v3-bulk-add-tray"
+>
+    <button
+        type="button"
+        class="tray-toggle"
+        onclick={ontoggle}
+        aria-label={open ? $t("v2.tray.close") : $t("v2.tray.open")}
+        data-testid="v3-tray-toggle"
+    >
+        {open ? "›" : "‹"}
+    </button>
+    {#if open}
+        <div class="tray-body">
+            <div class="tray-title">{$t("v2.tray.title")}</div>
+            <textarea
+                class="form-control tray-textarea"
+                rows="4"
+                placeholder={$t("v2.tray.placeholder")}
+                bind:value={draft}
+                disabled={busy}
+                data-testid="v3-tray-textarea"
+            ></textarea>
+            <button
+                type="button"
+                class="btn btn-primary btn-sm tray-add"
+                onclick={submit}
+                disabled={busy || draft.trim().length === 0}
+                data-testid="v3-tray-add-all"
+            >
+                {$t("v2.tray.addAll")}
+            </button>
+            <div class="tray-chips" data-testid="v3-tray-chips">
+                {#each orphans as person (person.id)}
+                    <div
+                        class="tray-chip"
+                        role="button"
+                        tabindex="0"
+                        draggable="true"
+                        ondragstart={(e) => handleDragStart(e, person.id)}
+                        data-testid={`v3-tray-chip-${person.id}`}
+                        title={$t("v2.tray.dragHint")}
+                    >
+                        {person.name}
+                    </div>
+                {/each}
+                {#if orphans.length === 0}
+                    <div class="tray-empty">{$t("v2.tray.empty")}</div>
+                {/if}
+            </div>
+        </div>
+    {/if}
+</aside>
+
+<style>
+    .v3-tray {
+        position: absolute;
+        top: 72px;
+        right: 16px;
+        bottom: 90px;
+        width: 260px;
+        max-width: calc(100vw - 32px);
+        background: var(--v3-bg-surface);
+        border: 1px solid var(--v3-border-subtle);
+        border-radius: var(--v3-radius-modal);
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+        display: flex;
+        flex-direction: column;
+        pointer-events: auto;
+        z-index: 105;
+        transition: transform 0.18s ease;
+        transform: translateX(calc(100% + 24px));
+    }
+    .v3-tray.open {
+        transform: translateX(0);
+    }
+
+    .tray-toggle {
+        position: absolute;
+        top: 16px;
+        left: -36px;
+        width: 32px;
+        height: 32px;
+        border: 1px solid var(--v3-border-subtle);
+        background: var(--v3-bg-surface);
+        border-radius: 16px;
+        cursor: pointer;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+        font-size: 1.1rem;
+        line-height: 1;
+    }
+
+    .tray-body {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px 14px;
+        height: 100%;
+        overflow: hidden;
+    }
+
+    .tray-title {
+        font-weight: var(--v3-fw-section);
+        font-size: var(--v3-fs-body);
+    }
+
+    .tray-textarea {
+        resize: vertical;
+        font-size: var(--v3-fs-body);
+    }
+
+    .tray-add {
+        align-self: flex-end;
+    }
+
+    .tray-chips {
+        flex: 1;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding-top: 6px;
+        border-top: 1px solid var(--v3-border-subtle);
+    }
+
+    .tray-chip {
+        padding: 6px 10px;
+        border: 1px solid #d0d7de;
+        border-radius: 14px;
+        background: #f6f8fa;
+        cursor: grab;
+        user-select: none;
+        font-size: var(--v3-fs-body);
+    }
+    .tray-chip:active {
+        cursor: grabbing;
+    }
+
+    .tray-empty {
+        color: var(--v3-text-muted);
+        font-size: var(--v3-fs-hint);
+        text-align: center;
+        padding: 12px 0;
+    }
+</style>

--- a/frontend/src/v3/components/V3Chip.svelte
+++ b/frontend/src/v3/components/V3Chip.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+    import type { StemmaDescription } from "../../model";
+    import { t } from "../../i18n";
+
+    type Props = {
+        ownedStemmas: StemmaDescription[];
+        currentStemmaId: string | null;
+        disabled: boolean;
+        onstemmaSelect?: (id: string) => void;
+        onstemmaAddNew?: () => void;
+        onstemmaRename?: (s: StemmaDescription) => void;
+        onstemmaClone?: (s: StemmaDescription) => void;
+        onstemmaRemove?: (s: StemmaDescription) => void;
+    };
+
+    let {
+        ownedStemmas,
+        currentStemmaId,
+        disabled,
+        onstemmaSelect,
+        onstemmaAddNew,
+        onstemmaRename,
+        onstemmaClone,
+        onstemmaRemove,
+    }: Props = $props();
+
+    const currentStemma = $derived(ownedStemmas.find((s) => s.id === currentStemmaId));
+    let dropdownOpen = $state(false);
+
+    function toggleDropdown() {
+        if (!disabled) dropdownOpen = !dropdownOpen;
+    }
+
+    function selectStemma(id: string) {
+        dropdownOpen = false;
+        onstemmaSelect?.(id);
+    }
+
+    function trigger(action: ((s: StemmaDescription) => void) | undefined, s: StemmaDescription, e: MouseEvent) {
+        e.stopPropagation();
+        dropdownOpen = false;
+        action?.(s);
+    }
+
+    function addNew() {
+        dropdownOpen = false;
+        onstemmaAddNew?.();
+    }
+</script>
+
+<div class="v3-chip">
+    <button
+        type="button"
+        class="stemma-btn"
+        onclick={toggleDropdown}
+        disabled={disabled}
+        aria-expanded={dropdownOpen}
+        data-testid="v3-chip-stemma-btn"
+    >
+        <span class="stemma-name">{currentStemma?.name ?? ""}</span>
+        <i class="bi bi-chevron-down chevron" class:rotated={dropdownOpen}></i>
+    </button>
+    {#if dropdownOpen}
+        <div class="stemma-dropdown" data-testid="v3-chip-dropdown">
+            {#each ownedStemmas as s}
+                <div
+                    class="stemma-row"
+                    class:active={s.id === currentStemmaId}
+                    role="button"
+                    tabindex="0"
+                    onclick={() => selectStemma(s.id)}
+                    onkeydown={(e) => { if (e.key === "Enter") selectStemma(s.id); }}
+                >
+                    <span class="row-name">{s.name}</span>
+                    <div
+                        class="row-actions"
+                        onclick={(e) => e.stopPropagation()}
+                        onkeydown={(e) => e.stopPropagation()}
+                        role="toolbar"
+                        tabindex="-1"
+                    >
+                        <button
+                            type="button"
+                            class="row-btn"
+                            aria-label={$t("v2.renameStemma")}
+                            title={$t("v2.renameStemma")}
+                            onclick={(e) => trigger(onstemmaRename, s, e)}
+                            data-testid="v3-chip-rename"
+                        ><i class="bi bi-pencil"></i></button>
+                        <button
+                            type="button"
+                            class="row-btn"
+                            aria-label={$t("v2.cloneStemma")}
+                            title={$t("v2.cloneStemma")}
+                            onclick={(e) => trigger(onstemmaClone, s, e)}
+                            data-testid="v3-chip-clone"
+                        ><i class="bi bi-copy"></i></button>
+                        {#if s.removable}
+                            <button
+                                type="button"
+                                class="row-btn danger"
+                                aria-label={$t("v2.deleteStemma")}
+                                title={$t("v2.deleteStemma")}
+                                onclick={(e) => trigger(onstemmaRemove, s, e)}
+                                data-testid="v3-chip-remove"
+                            ><i class="bi bi-trash"></i></button>
+                        {:else}
+                            <span class="row-btn placeholder" aria-hidden="true"></span>
+                        {/if}
+                    </div>
+                </div>
+            {/each}
+            <div class="dropdown-divider"></div>
+            <button
+                type="button"
+                class="add-stemma"
+                onclick={addNew}
+                data-testid="v3-chip-add-stemma"
+            >
+                <i class="bi bi-plus-lg"></i> {$t("v2.newStemma")}
+            </button>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .v3-chip {
+        display: inline-flex;
+        align-items: center;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        padding: 6px 10px;
+        position: relative;
+    }
+
+    .stemma-btn {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: none;
+        border: none;
+        padding: 0 4px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        color: #212529;
+        white-space: nowrap;
+        max-width: 200px;
+    }
+
+    .stemma-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .stemma-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 180px;
+    }
+
+    .chevron {
+        font-size: 0.7rem;
+        transition: transform 0.15s ease;
+        flex-shrink: 0;
+    }
+
+    .chevron.rotated {
+        transform: rotate(180deg);
+    }
+
+    .stemma-dropdown {
+        position: absolute;
+        top: calc(100% + 8px);
+        left: 0;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        min-width: 240px;
+        z-index: 1000;
+        overflow: hidden;
+        padding: 4px 0;
+    }
+
+    .stemma-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 12px;
+        font-size: 0.875rem;
+        cursor: pointer;
+        color: #212529;
+    }
+
+    .stemma-row:hover {
+        background: #f8f9fa;
+    }
+
+    .stemma-row.active .row-name {
+        color: #0d6efd;
+        font-weight: 600;
+    }
+
+    .row-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .row-actions {
+        display: inline-flex;
+        gap: 2px;
+        flex-shrink: 0;
+    }
+
+    .row-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 26px;
+        border-radius: 50%;
+        background: transparent;
+        border: none;
+        color: #6c757d;
+        cursor: pointer;
+        transition: background-color 0.12s ease, color 0.12s ease;
+        font-size: 0.8rem;
+    }
+
+    .row-btn:hover {
+        background: #e9ecef;
+        color: #212529;
+    }
+
+    .row-btn.danger:hover {
+        background: #f8d7da;
+        color: #dc3545;
+    }
+
+    .row-btn.placeholder {
+        visibility: hidden;
+        pointer-events: none;
+        cursor: default;
+    }
+
+    .dropdown-divider {
+        height: 1px;
+        background: #e9ecef;
+        margin: 4px 0;
+    }
+
+    .add-stemma {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 8px 12px;
+        background: none;
+        border: none;
+        text-align: left;
+        font-size: 0.875rem;
+        cursor: pointer;
+        color: #0d6efd;
+        font-weight: 500;
+    }
+
+    .add-stemma:hover {
+        background: #f1f7ff;
+    }
+
+</style>

--- a/frontend/src/v3/components/V3ConfirmModal.svelte
+++ b/frontend/src/v3/components/V3ConfirmModal.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+    import V3Modal from "./V3Modal.svelte";
+
+    type Props = {
+        onconfirm?: () => void;
+    };
+
+    let { onconfirm }: Props = $props();
+
+    let open = $state(false);
+    let title = $state("");
+    let message = $state<string | null>(null);
+    let confirmLabel = $state("");
+    let danger = $state(false);
+    let testid = $state<string | undefined>(undefined);
+    let pendingConfirm: (() => void) | null = null;
+
+    export function ask(opts: {
+        title: string;
+        message?: string;
+        confirmLabel: string;
+        danger?: boolean;
+        testid?: string;
+        onaccept: () => void;
+    }) {
+        title = opts.title;
+        message = opts.message ?? null;
+        confirmLabel = opts.confirmLabel;
+        danger = opts.danger ?? false;
+        testid = opts.testid;
+        pendingConfirm = opts.onaccept;
+        open = true;
+    }
+
+    function close() {
+        open = false;
+        pendingConfirm = null;
+    }
+
+    function accept() {
+        const cb = pendingConfirm;
+        open = false;
+        pendingConfirm = null;
+        cb?.();
+        onconfirm?.();
+    }
+</script>
+
+<V3Modal {open} {title} size="sm" onclose={close} testid={testid}>
+    {#snippet body()}
+        {#if message}
+            <p class="confirm-msg">{message}</p>
+        {/if}
+    {/snippet}
+
+    {#snippet footer()}
+        <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.cancel")}</button>
+        <button
+            type="button"
+            class={danger ? "btn btn-danger" : "btn btn-primary"}
+            onclick={accept}
+            data-testid="v3-confirm-accept"
+        >
+            {confirmLabel}
+        </button>
+    {/snippet}
+</V3Modal>
+
+<style>
+    .confirm-msg {
+        margin: 0;
+        color: var(--v3-text-secondary);
+        font-size: var(--v3-fs-body);
+    }
+</style>

--- a/frontend/src/v3/components/V3EditPill.svelte
+++ b/frontend/src/v3/components/V3EditPill.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+</script>
+
+<div class="v3-edit-pill" aria-live="polite">
+    <span class="pulse-dot"></span>
+    {$t("v2.editMode")}
+</div>
+
+<style>
+    .v3-edit-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #ffc107;
+        color: #212529;
+        font-size: 0.78rem;
+        font-weight: 600;
+        padding: 4px 12px;
+        border-radius: 20px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        letter-spacing: 0.03em;
+        white-space: nowrap;
+    }
+
+    .pulse-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #664d03;
+        animation: pulse 1.6s ease-in-out infinite;
+        flex-shrink: 0;
+    }
+
+    @keyframes pulse {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50% { opacity: 0.5; transform: scale(0.8); }
+    }
+</style>

--- a/frontend/src/v3/components/V3EmptyState.svelte
+++ b/frontend/src/v3/components/V3EmptyState.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+
+    type Props = {
+        editMode: boolean;
+        onaddPerson?: () => void;
+    };
+
+    let { editMode, onaddPerson }: Props = $props();
+</script>
+
+<div class="v3-empty-state" data-testid="v3-empty-state">
+    <div class="empty-card">
+        <i class="bi bi-people empty-icon"></i>
+        <p class="empty-text">{$t("v2.emptyStemma")}</p>
+        {#if editMode}
+            <button type="button" class="btn btn-primary" onclick={() => onaddPerson?.()}>
+                {$t("v2.emptyStemmaCta")}
+            </button>
+        {/if}
+    </div>
+</div>
+
+<style>
+    .v3-empty-state {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+    }
+
+    .empty-card {
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+        padding: 40px 48px;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+        pointer-events: auto;
+    }
+
+    .empty-icon {
+        font-size: 3rem;
+        color: #adb5bd;
+    }
+
+    .empty-text {
+        margin: 0;
+        color: #6c757d;
+        font-size: 1rem;
+    }
+</style>

--- a/frontend/src/v3/components/V3Fab.svelte
+++ b/frontend/src/v3/components/V3Fab.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+
+    type Props = {
+        editMode: boolean;
+        panMode: boolean;
+        disabled: boolean;
+        oneditToggle?: () => void;
+        onpanToggle?: () => void;
+        onaddPerson?: () => void;
+    };
+
+    let { editMode, panMode, disabled, oneditToggle, onpanToggle, onaddPerson }: Props = $props();
+</script>
+
+<div class="v3-fab-cluster">
+    {#if editMode}
+        <button
+            type="button"
+            class="fab fab-secondary"
+            class:active={panMode}
+            aria-label={panMode ? $t("v2.panModeOff") : $t("v2.panModeOn")}
+            aria-pressed={panMode}
+            disabled={disabled}
+            onclick={() => onpanToggle?.()}
+            data-testid="v3-pan-fab"
+        >
+            <i class="bi bi-arrows-move"></i>
+        </button>
+        <button
+            type="button"
+            class="fab fab-secondary"
+            aria-label={$t("v2.addPersonFab")}
+            disabled={disabled}
+            onclick={() => onaddPerson?.()}
+            data-testid="v3-add-person-fab"
+        >
+            <i class="bi bi-person-plus"></i>
+        </button>
+    {/if}
+
+    <button
+        type="button"
+        class="fab fab-primary"
+        class:active={editMode}
+        aria-label={editMode ? $t("v2.exitEditMode") : $t("v2.enterEditMode")}
+        disabled={disabled}
+        onclick={() => oneditToggle?.()}
+        data-testid="v3-edit-fab"
+    >
+        {#if editMode}
+            <i class="bi bi-x-lg"></i>
+        {:else}
+            <i class="bi bi-pencil"></i>
+        {/if}
+    </button>
+</div>
+
+<style>
+    .v3-fab-cluster {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .fab {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: 50%;
+        cursor: pointer;
+        font-size: 1.25rem;
+        transition: box-shadow 0.15s ease, transform 0.1s ease;
+    }
+
+    .fab:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .fab:not(:disabled):hover {
+        transform: translateY(-2px);
+    }
+
+    .fab-primary {
+        width: 56px;
+        height: 56px;
+        background: #0d6efd;
+        color: #fff;
+        box-shadow: 0 4px 12px rgba(13, 110, 253, 0.4);
+    }
+
+    .fab-primary.active {
+        background: #495057;
+        box-shadow: 0 4px 12px rgba(73, 80, 87, 0.4);
+    }
+
+    .fab-primary:not(:disabled):hover {
+        box-shadow: 0 6px 18px rgba(13, 110, 253, 0.5);
+    }
+
+    .fab-secondary {
+        width: 48px;
+        height: 48px;
+        background: #fff;
+        color: #0d6efd;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    }
+
+    .fab-secondary:not(:disabled):hover {
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+    }
+
+    .fab-secondary.active {
+        background: #495057;
+        color: #fff;
+        box-shadow: 0 4px 12px rgba(73, 80, 87, 0.4);
+    }
+
+    .fab-secondary.active:not(:disabled):hover {
+        box-shadow: 0 6px 18px rgba(73, 80, 87, 0.5);
+    }
+
+    @media (max-width: 767.98px) {
+        .fab-primary {
+            width: 48px;
+            height: 48px;
+            font-size: 1.1rem;
+        }
+
+        .fab-secondary {
+            width: 40px;
+            height: 40px;
+            font-size: 1rem;
+        }
+    }
+</style>

--- a/frontend/src/v3/components/V3FamilyCard.svelte
+++ b/frontend/src/v3/components/V3FamilyCard.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+    import type { FamilyDescription, PersonDescription } from "../../model";
+    import type { StemmaIndex } from "../../stemmaIndex";
+    import { t } from "../../i18n";
+    import { personDisplayName } from "../../personDisplayName";
+
+    type Props = {
+        stemmaIndex: StemmaIndex | null;
+        editMode: boolean;
+        familyId: string | null;
+        onfamilyRemoveRequested?: (familyId: string) => void;
+        onclose?: () => void;
+    };
+
+    let {
+        stemmaIndex,
+        editMode,
+        familyId,
+        onfamilyRemoveRequested,
+        onclose,
+    }: Props = $props();
+
+    const family = $derived.by<FamilyDescription | null>(() => {
+        if (!familyId || !stemmaIndex) return null;
+        return stemmaIndex.family(familyId) ?? null;
+    });
+
+    const canRemoveFamily = $derived(family != null && !family.readOnly);
+
+    const familyTitle = $derived.by<string>(() => {
+        if (!family || !stemmaIndex) return $t("family.compositionTitle");
+        const idx = stemmaIndex;
+        const parentNames = family.parents
+            .map((id) => idx.person(id))
+            .filter((p): p is PersonDescription => p != null)
+            .map((p) => personDisplayName(p.name, $t));
+        if (parentNames.length === 0) return $t("family.compositionTitle");
+        return parentNames.join(" & ");
+    });
+
+    function requestRemove() {
+        if (!familyId) return;
+        const id = familyId;
+        onclose?.();
+        onfamilyRemoveRequested?.(id);
+    }
+
+    function personName(id: string): string {
+        const p = stemmaIndex?.person(id);
+        return p ? personDisplayName(p.name, $t) : id;
+    }
+</script>
+
+<div>
+    <div class="family-title">
+        <span class="title-text">{familyTitle}</span>
+    </div>
+
+    {#if family && family.parents.length > 0}
+        <p class="section-label">{$t("family.parents")}</p>
+        <ul class="member-list">
+            {#each family.parents as pid}
+                <li>{personName(pid)}</li>
+            {/each}
+        </ul>
+    {/if}
+    {#if family && family.children.length > 0}
+        <p class="section-label">{$t("family.children")}</p>
+        <ul class="member-list">
+            {#each family.children as cid}
+                <li>{personName(cid)}</li>
+            {/each}
+        </ul>
+    {/if}
+    {#if !family || (family.parents.length === 0 && family.children.length === 0)}
+        <p class="no-info">{$t("family.noInfo")}</p>
+    {/if}
+
+    {#if editMode && canRemoveFamily}
+        <div class="card-actions justify-end">
+            <button
+                type="button"
+                class="btn btn-sm btn-secondary"
+                onclick={() => onclose?.()}
+            >
+                {$t("common.cancel")}
+            </button>
+            <button
+                type="button"
+                class="btn btn-sm btn-danger"
+                onclick={requestRemove}
+                data-testid="v3-remove-family-action"
+            >
+                {$t("v2.dissolveFamily")}
+            </button>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .family-title {
+        margin-bottom: 14px;
+        line-height: 1.35;
+    }
+
+    .title-text {
+        font-weight: 700;
+        font-size: 0.95rem;
+    }
+
+    .section-label {
+        font-size: 0.72rem;
+        color: #6c757d;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin: 12px 0 6px;
+        font-weight: 600;
+    }
+
+    .member-list {
+        list-style: none;
+        padding: 0;
+        margin: 0 0 4px;
+        font-size: 0.92rem;
+        line-height: 1.5;
+    }
+
+    .member-list li + li {
+        margin-top: 4px;
+    }
+
+    .no-info {
+        color: #6c757d;
+        font-style: italic;
+        font-size: 0.9rem;
+        margin: 8px 0;
+    }
+
+    .card-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
+        padding-top: 16px;
+        margin-top: 4px;
+        border-top: 1px solid #f1f3f5;
+    }
+
+    .card-actions.justify-end {
+        justify-content: flex-end;
+    }
+</style>

--- a/frontend/src/v3/components/V3FamilyGhost.svelte
+++ b/frontend/src/v3/components/V3FamilyGhost.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+    import type { GhostFamilyAction } from "../ghostHelpers";
+
+    type Props = {
+        action: GhostFamilyAction;
+        onconfirm?: (name: string) => void;
+        oncancel?: () => void;
+    };
+
+    let { action, onconfirm, oncancel }: Props = $props();
+
+    let name = $state("");
+
+    const title = $derived(action === "addChild" ? $t("v2.familyGhostAddChild") : $t("v2.familyGhostAddSpouse"));
+
+    function confirm() {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        onconfirm?.(trimmed);
+    }
+</script>
+
+<div class="family-ghost-body" data-testid="v3-family-ghost-popover">
+    <div class="ghost-title">{title}</div>
+    <input
+        type="text"
+        class="form-control form-control-sm"
+        placeholder={$t("v2.namePlaceholder")}
+        bind:value={name}
+        data-testid="v3-family-ghost-name"
+        onkeydown={(e) => { if (e.key === "Enter") confirm(); }}
+    />
+    <div class="ghost-actions">
+        <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            onclick={() => oncancel?.()}
+            data-testid="v3-ghost-cancel"
+        >
+            {$t("common.cancel")}
+        </button>
+        <button
+            type="button"
+            class="btn btn-primary btn-sm ms-auto"
+            disabled={!name.trim()}
+            onclick={confirm}
+            data-testid="v3-ghost-confirm"
+        >
+            {$t("common.ok")}
+        </button>
+    </div>
+</div>
+
+<style>
+    .family-ghost-body {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+    .ghost-title {
+        font-weight: 700;
+        font-size: 0.95rem;
+    }
+    .ghost-actions {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding-top: 8px;
+        border-top: 1px solid #f1f3f5;
+    }
+</style>

--- a/frontend/src/v3/components/V3LangSwitcher.svelte
+++ b/frontend/src/v3/components/V3LangSwitcher.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import { locale, t } from "../../i18n";
+</script>
+
+<button
+    type="button"
+    class="v3-lang-switcher"
+    aria-label={$t("nav.language")}
+    onclick={() => locale.set($locale === "en" ? "ru" : "en")}
+    data-testid="v3-lang-switcher"
+>
+    {$locale === "en" ? "RU" : "EN"}
+</button>
+
+<style>
+    .v3-lang-switcher {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        background: #fff;
+        border: none;
+        padding: 0;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        cursor: pointer;
+        color: #495057;
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        transition: box-shadow 0.15s ease, transform 0.1s ease, color 0.12s ease;
+    }
+
+    .v3-lang-switcher:hover {
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+        transform: translateY(-1px);
+        color: #212529;
+    }
+</style>

--- a/frontend/src/v3/components/V3LinkRolePicker.svelte
+++ b/frontend/src/v3/components/V3LinkRolePicker.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+
+    type Role = "parent" | "child";
+
+    type Props = {
+        onpick?: (role: Role) => void;
+        oncancel?: () => void;
+    };
+
+    let { onpick, oncancel }: Props = $props();
+</script>
+
+<div class="link-role-menu" data-testid="v3-link-role-menu">
+    <div class="role-title">{$t("v2.linkRoleTitle")}</div>
+    <button
+        type="button"
+        class="btn btn-outline-primary btn-sm role-btn"
+        onclick={() => onpick?.("parent")}
+        data-testid="v3-link-role-parent"
+    >
+        {$t("v2.linkRoleParent")}
+    </button>
+    <button
+        type="button"
+        class="btn btn-outline-primary btn-sm role-btn"
+        onclick={() => onpick?.("child")}
+        data-testid="v3-link-role-child"
+    >
+        {$t("v2.linkRoleChild")}
+    </button>
+    <button
+        type="button"
+        class="btn btn-link btn-sm cancel-btn"
+        onclick={() => oncancel?.()}
+    >
+        {$t("common.cancel")}
+    </button>
+</div>
+
+<style>
+    .link-role-menu {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 4px 0;
+    }
+    .role-title {
+        font-weight: var(--v3-fw-section);
+        font-size: var(--v3-fs-body);
+        margin-bottom: 4px;
+    }
+    .role-btn {
+        text-align: left;
+    }
+    .cancel-btn {
+        align-self: flex-end;
+        padding: 4px 8px;
+    }
+</style>

--- a/frontend/src/v3/components/V3Menu.svelte
+++ b/frontend/src/v3/components/V3Menu.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+
+    type Props = {
+        showSignOut: boolean;
+        onabout?: () => void;
+        onsettings?: () => void;
+        onexport?: () => void;
+        onsignOut?: () => void;
+    };
+
+    let { showSignOut, onabout, onsettings, onexport, onsignOut }: Props = $props();
+
+    let open = $state(false);
+
+    function toggle() {
+        open = !open;
+    }
+
+    function closeAndCall(fn?: () => void) {
+        open = false;
+        fn?.();
+    }
+</script>
+
+<div class="v3-menu">
+    <button
+        type="button"
+        class="menu-btn"
+        onclick={toggle}
+        aria-label="Menu"
+        aria-expanded={open}
+    >
+        <img src="/assets/logo_color.webp" alt="Stemma" width="32" height="32" />
+    </button>
+
+    {#if open}
+        <div class="menu-dropdown">
+            <button type="button" class="menu-item" onclick={() => closeAndCall(onabout)} data-testid="v3-menu-about">
+                <i class="bi bi-info-circle me-2"></i>{$t("v2.about")}
+            </button>
+            <button type="button" class="menu-item" onclick={() => closeAndCall(onsettings)} data-testid="v3-menu-settings">
+                <i class="bi bi-gear me-2"></i>{$t("v2.settings")}
+            </button>
+            <button type="button" class="menu-item" onclick={() => closeAndCall(onexport)} data-testid="v3-menu-export">
+                <i class="bi bi-download me-2"></i>{$t("v2.exportSvg")}
+            </button>
+            {#if showSignOut}
+                <div class="menu-divider"></div>
+                <button type="button" class="menu-item sign-out" onclick={() => closeAndCall(onsignOut)}>
+                    <i class="bi bi-box-arrow-right me-2"></i>{$t("v2.signOut")}
+                </button>
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .v3-menu {
+        position: relative;
+    }
+
+    .menu-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        background: #fff;
+        border: none;
+        padding: 0;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        cursor: pointer;
+        transition: box-shadow 0.15s ease, transform 0.1s ease;
+        overflow: hidden;
+    }
+
+    .menu-btn img {
+        display: block;
+    }
+
+    .menu-btn:hover {
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+        transform: translateY(-1px);
+    }
+
+    .menu-dropdown {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        min-width: 180px;
+        z-index: 1000;
+        overflow: hidden;
+        padding: 4px 0;
+    }
+
+    .menu-item {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        padding: 10px 16px;
+        background: none;
+        border: none;
+        text-align: left;
+        font-size: 0.875rem;
+        cursor: pointer;
+        color: #212529;
+    }
+
+    .menu-item:hover {
+        background: #f8f9fa;
+    }
+
+    .menu-item.sign-out {
+        color: #dc3545;
+    }
+
+    .menu-divider {
+        height: 1px;
+        background: #dee2e6;
+        margin: 4px 0;
+    }
+</style>

--- a/frontend/src/v3/components/V3Modal.svelte
+++ b/frontend/src/v3/components/V3Modal.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+    import type { Snippet } from "svelte";
+    import { t } from "../../i18n";
+
+    type Size = "sm" | "md" | "lg";
+
+    type Props = {
+        open: boolean;
+        title?: string;
+        size?: Size;
+        scroll?: boolean;
+        dismissOnBackdrop?: boolean;
+        onclose?: () => void;
+        body: Snippet;
+        footer?: Snippet;
+        testid?: string;
+    };
+
+    let {
+        open,
+        title,
+        size = "md",
+        scroll = false,
+        dismissOnBackdrop = true,
+        onclose,
+        body,
+        footer,
+        testid,
+    }: Props = $props();
+
+    function close() {
+        onclose?.();
+    }
+
+    function handleBackdrop() {
+        if (dismissOnBackdrop) close();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (!open) return;
+        if (e.key === "Escape") close();
+    }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+    <div class="v3-modal-backdrop" onclick={handleBackdrop} aria-hidden="true"></div>
+    <div
+        class="v3-modal-panel size-{size}"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        data-testid={testid}
+    >
+        {#if title}
+            <div class="v3-modal-header">
+                <h6 class="v3-modal-title">{title}</h6>
+                <button
+                    type="button"
+                    class="v3-modal-close"
+                    aria-label={$t("common.close")}
+                    onclick={close}
+                >
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            </div>
+        {/if}
+
+        <div class="v3-modal-body" class:scroll>
+            {@render body()}
+        </div>
+
+        {#if footer}
+            <div class="v3-modal-footer">
+                {@render footer()}
+            </div>
+        {/if}
+    </div>
+{/if}
+
+<style>
+    .v3-modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        z-index: 1060;
+        animation: fade-in 0.12s ease-out;
+    }
+
+    @keyframes fade-in {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .v3-modal-panel {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: var(--v3-bg-surface);
+        border-radius: var(--v3-radius-modal);
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+        z-index: 1070;
+        display: flex;
+        flex-direction: column;
+        max-height: calc(100vh - 32px);
+        animation: pop-in 0.15s ease-out;
+        overflow: hidden;
+    }
+
+    .size-sm { width: min(380px, calc(100vw - 32px)); }
+    .size-md { width: min(480px, calc(100vw - 32px)); }
+    .size-lg { width: min(720px, calc(100vw - 32px)); }
+
+    @keyframes pop-in {
+        from { opacity: 0; transform: translate(-50%, -48%) scale(0.96); }
+        to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+    }
+
+    .v3-modal-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 18px 22px 12px;
+        gap: 12px;
+    }
+
+    .v3-modal-title {
+        margin: 0;
+        font-weight: var(--v3-fw-title);
+        font-size: var(--v3-fs-title);
+        color: var(--v3-text-primary);
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .v3-modal-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: transparent;
+        border: none;
+        color: var(--v3-text-muted);
+        cursor: pointer;
+        font-size: var(--v3-fs-label);
+        transition: background-color 0.12s ease, color 0.12s ease;
+        flex-shrink: 0;
+    }
+
+    .v3-modal-close:hover {
+        background: #f1f3f5;
+        color: var(--v3-text-primary);
+    }
+
+    .v3-modal-body {
+        padding: 4px 22px 16px;
+        flex: 1;
+        min-height: 0;
+    }
+
+    .v3-modal-body.scroll {
+        overflow-y: auto;
+    }
+
+    .v3-modal-footer {
+        padding: 12px 22px 18px;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 8px;
+        border-top: 1px solid var(--v3-border-subtle);
+    }
+
+    @keyframes slide-up {
+        from { transform: translateY(100%); }
+        to { transform: translateY(0); }
+    }
+
+    @media (max-width: 767px) {
+        .v3-modal-panel,
+        .v3-modal-panel.size-sm,
+        .v3-modal-panel.size-md,
+        .v3-modal-panel.size-lg {
+            top: auto;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            width: 100%;
+            max-width: 100%;
+            transform: none;
+            max-height: 85vh;
+            border-radius: 20px 20px 0 0;
+            box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+            animation: slide-up 0.22s ease-out;
+        }
+
+        .v3-modal-body {
+            overflow-y: auto;
+        }
+    }
+</style>

--- a/frontend/src/v3/components/V3PersonDetailsModal.svelte
+++ b/frontend/src/v3/components/V3PersonDetailsModal.svelte
@@ -1,0 +1,929 @@
+<script module lang="ts">
+    export type {
+        ShowPerson,
+        UpdatePerson,
+    } from "../../components/person_details_modal/PersonDetailsModal.svelte";
+
+    const CROP_OUTPUT_SIZE = 512;
+    const CROP_MAX_ZOOM = 4;
+    const CROP_OUTPUT_MIME = "image/jpeg";
+    const CROP_OUTPUT_QUALITY = 0.9;
+    const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+    const ALLOWED_PHOTO_TYPES = ["image/jpeg", "image/png", "image/webp"];
+</script>
+
+<script lang="ts">
+    import { imask } from "@imask/svelte";
+    import { t } from "../../i18n";
+    import { renderBioMarkdown } from "../../bioMarkdown";
+    import { isUnknownPerson } from "../../personDisplayName";
+    import {
+        clampCropOffset,
+        coverBaseScale,
+    } from "../../components/person_details_modal/PersonDetailsModal.svelte";
+    import type {
+        ShowPerson,
+        UpdatePerson,
+    } from "../../components/person_details_modal/PersonDetailsModal.svelte";
+    import type { CreateNewPerson } from "../../model";
+    import V3Modal from "./V3Modal.svelte";
+
+    export type CreatePersonPayload = {
+        description: CreateNewPerson;
+        pin: boolean;
+        photoUpload: Blob | null;
+    };
+
+    type Props = {
+        editMode?: boolean;
+        onpersonUpdated?: (payload: UpdatePerson) => void;
+        onpersonRemoveRequested?: (payload: { id: string; name: string }) => void;
+        onshareAccessRequested?: (payload: { personId: string; name: string }) => void;
+    };
+
+    let {
+        editMode = false,
+        onpersonUpdated,
+        onpersonRemoveRequested,
+        onshareAccessRequested,
+    }: Props = $props();
+
+    let open = $state(false);
+    let mode = $state<"view" | "create">("view");
+    let createTitle = $state<string | null>(null);
+    let activeCreateCallback: ((payload: CreatePersonPayload) => void) | null = null;
+    const isCreate = $derived(mode === "create");
+    let birthInputEl = $state<HTMLInputElement | null>(null);
+    let deathInputEl = $state<HTMLInputElement | null>(null);
+    let photoFileInputEl = $state<HTMLInputElement | null>(null);
+
+    let pinned = $state(false);
+    let unknown = $state(false);
+    let name = $state("");
+    let birthDate = $state<Date | null>(null);
+    let deathDate = $state<Date | null>(null);
+    let bio = $state("");
+    let id = $state("");
+    let personReadOnly = $state(false);
+    const editingAllowed = $derived(isCreate || (editMode && !personReadOnly));
+    const readOnly = $derived(!editingAllowed);
+    let photoUrl = $state<string | null>(null);
+    let photoErrString = $state<string | null>(null);
+    let originalPhotoUrl: string | null = null;
+    let pendingPhotoBlob = $state<Blob | null>(null);
+    let pendingPhotoPreviewUrl = $state<string | null>(null);
+    let pendingPhotoRemove = $state(false);
+
+    let cropImageEl = $state<HTMLImageElement | null>(null);
+    let cropContainerEl = $state<HTMLElement | null>(null);
+    let cropping = $state(false);
+    let cropImageUrl = $state<string | null>(null);
+    let cropBaseScale = $state(1);
+    let cropScale = $state(1);
+    let cropDx = $state(0);
+    let cropDy = $state(0);
+    let cropNaturalW = $state(0);
+    let cropNaturalH = $state(0);
+    let cropImageReady = $state(false);
+    let dragOrigin: { x: number; y: number; dx: number; dy: number } | null = null;
+
+    let birthDateErrString = $state<string | null>(null);
+    let deathDateErrString = $state<string | null>(null);
+
+    let bioTab = $state<"edit" | "preview">("preview");
+    const bioHtml = $derived(renderBioMarkdown(bio));
+    const displayName = $derived(unknown ? $t("person.unknown") : name);
+
+    const saveDisabled = $derived(birthDateErrString != null || deathDateErrString != null);
+
+    function dateToIsoLocalTime(d: Date | null) {
+        if (!d) return null;
+        const date = d.getDate();
+        const month = d.getMonth() + 1;
+        const year = d.getFullYear();
+        const dateStr = date < 10 ? "0" + date : date.toString();
+        const monthStr = month < 10 ? "0" + month : month.toString();
+        return `${year}-${monthStr}-${dateStr}`;
+    }
+
+    function parseMaskedDateStr(str: string) {
+        const [day, month, year] = str.split(".");
+        return new Date(Number(year), Number(month) - 1, Number(day));
+    }
+
+    function dateToMaskedDateStr(date: Date | null) {
+        if (!date) return null;
+        const day = date.getDate();
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+        const dayStr = day < 10 ? "0" + day : day.toString();
+        const monthStr = month < 10 ? "0" + month : month.toString();
+        return [dayStr, monthStr, year.toString()].join(".");
+    }
+
+    const dateMaskingOpts = {
+        mask: Date,
+        lazy: true,
+        max: new Date(),
+        format: dateToMaskedDateStr,
+        parse: parseMaskedDateStr,
+    };
+
+    function attachMaskedDateListeners(
+        el: HTMLInputElement,
+        setErr: (err: string | null) => void,
+        setDate: (d: Date) => void,
+    ) {
+        function onAccept(e: Event) {
+            const maskRef = (e as CustomEvent).detail;
+            setErr(maskRef.unmaskedValue ? $t("person.incompleteDate") : null);
+        }
+        function onComplete(e: Event) {
+            const maskRef = (e as CustomEvent).detail;
+            setErr(null);
+            setDate(parseMaskedDateStr(maskRef.value));
+            validateLifetimeRange();
+        }
+        el.addEventListener("accept", onAccept);
+        el.addEventListener("complete", onComplete);
+        return () => {
+            el.removeEventListener("accept", onAccept);
+            el.removeEventListener("complete", onComplete);
+        };
+    }
+
+    $effect(() => {
+        if (!birthInputEl) return;
+        return attachMaskedDateListeners(
+            birthInputEl,
+            (err) => (birthDateErrString = err),
+            (d) => (birthDate = d),
+        );
+    });
+
+    $effect(() => {
+        if (!deathInputEl) return;
+        return attachMaskedDateListeners(
+            deathInputEl,
+            (err) => (deathDateErrString = err),
+            (d) => (deathDate = d),
+        );
+    });
+
+    function validateLifetimeRange() {
+        if (!birthDate || !deathDate) return;
+        if (deathDate < birthDate) {
+            birthDateErrString = $t("person.invalidDateRange");
+            deathDateErrString = $t("person.invalidDateRange");
+        } else {
+            birthDateErrString = null;
+            deathDateErrString = null;
+        }
+    }
+
+    function resetFormState(p: ShowPerson | null) {
+        id = p?.description.id ?? "";
+        name = p?.description.name ?? "";
+        unknown = p ? isUnknownPerson(p.description.name) : false;
+        birthDate = p?.description.birthDate ? new Date(p.description.birthDate) : null;
+        deathDate = p?.description.deathDate ? new Date(p.description.deathDate) : null;
+        bio = p?.description.bio ?? "";
+        pinned = p?.pin ?? false;
+        personReadOnly = p?.description.readOnly ?? false;
+        bioTab = p ? "preview" : "edit";
+        originalPhotoUrl = p?.description.photoUrl ?? null;
+        photoUrl = originalPhotoUrl;
+        photoErrString = null;
+        if (photoFileInputEl) photoFileInputEl.value = "";
+        resetCropState();
+        resetPendingPhoto();
+        birthDateErrString = null;
+        deathDateErrString = null;
+        queueMicrotask(() => {
+            if (birthInputEl) birthInputEl.value = dateToMaskedDateStr(birthDate) ?? "";
+            if (deathInputEl) deathInputEl.value = dateToMaskedDateStr(deathDate) ?? "";
+        });
+    }
+
+    export function showPersonDetails(p: ShowPerson) {
+        mode = "view";
+        createTitle = null;
+        resetFormState(p);
+        open = true;
+    }
+
+    export function showCreatePerson(opts: { title?: string; oncreate: (payload: CreatePersonPayload) => void }) {
+        mode = "create";
+        createTitle = opts.title ?? null;
+        activeCreateCallback = opts.oncreate;
+        resetFormState(null);
+        open = true;
+    }
+
+    function close() {
+        open = false;
+        activeCreateCallback = null;
+        resetPendingPhoto();
+    }
+
+    export function dismiss() {
+        close();
+    }
+
+    function save() {
+        if (saveDisabled) return;
+        const description = {
+            type: "CreateNewPerson" as const,
+            name: unknown ? "" : name,
+            birthDate: dateToIsoLocalTime(birthDate),
+            deathDate: dateToIsoLocalTime(deathDate),
+            bio,
+        };
+        if (mode === "create") {
+            const cb = activeCreateCallback;
+            activeCreateCallback = null;
+            cb?.({
+                description,
+                pin: pinned,
+                photoUpload: pendingPhotoBlob,
+            });
+        } else {
+            onpersonUpdated?.({
+                id,
+                description,
+                pin: pinned,
+                photoUpload: pendingPhotoBlob,
+                photoRemove: pendingPhotoRemove,
+            });
+        }
+        close();
+    }
+
+    function remove() {
+        onpersonRemoveRequested?.({ id, name: displayName });
+    }
+
+    function requestShareAccess() {
+        if (!id) return;
+        const personId = id;
+        const personName = displayName;
+        close();
+        onshareAccessRequested?.({ personId, name: personName });
+    }
+
+    function resetPendingPhoto() {
+        if (pendingPhotoPreviewUrl) URL.revokeObjectURL(pendingPhotoPreviewUrl);
+        pendingPhotoPreviewUrl = null;
+        pendingPhotoBlob = null;
+        pendingPhotoRemove = false;
+    }
+
+    function resetCropState() {
+        if (cropImageUrl) URL.revokeObjectURL(cropImageUrl);
+        cropImageUrl = null;
+        cropping = false;
+        cropImageReady = false;
+        cropScale = 1;
+        cropBaseScale = 1;
+        cropDx = 0;
+        cropDy = 0;
+        cropNaturalW = 0;
+        cropNaturalH = 0;
+        dragOrigin = null;
+    }
+
+    function pickPhoto() {
+        photoErrString = null;
+        photoFileInputEl?.click();
+    }
+
+    function onPhotoFileChange(event: Event) {
+        const input = event.currentTarget as HTMLInputElement;
+        const file = input.files && input.files[0];
+        if (!file) return;
+        if (!ALLOWED_PHOTO_TYPES.includes(file.type)) {
+            photoErrString = $t("person.photoUnsupportedType");
+            input.value = "";
+            return;
+        }
+        if (file.size > MAX_PHOTO_BYTES) {
+            photoErrString = $t("person.photoTooLarge");
+            input.value = "";
+            return;
+        }
+        photoErrString = null;
+        if (cropImageUrl) URL.revokeObjectURL(cropImageUrl);
+        cropImageUrl = URL.createObjectURL(file);
+        cropImageReady = false;
+        cropping = true;
+        input.value = "";
+    }
+
+    function onCropImageLoaded() {
+        if (!cropImageEl || !cropContainerEl) return;
+        cropNaturalW = cropImageEl.naturalWidth;
+        cropNaturalH = cropImageEl.naturalHeight;
+        const containerSize = cropContainerEl.clientWidth;
+        cropBaseScale = coverBaseScale(cropNaturalW, cropNaturalH, containerSize);
+        cropScale = 1;
+        const imgW = cropNaturalW * cropBaseScale;
+        const imgH = cropNaturalH * cropBaseScale;
+        cropDx = (containerSize - imgW) / 2;
+        cropDy = (containerSize - imgH) / 2;
+        cropImageReady = true;
+    }
+
+    function reclampCropOffset() {
+        if (!cropContainerEl) return;
+        const containerSize = cropContainerEl.clientWidth;
+        const total = cropBaseScale * cropScale;
+        const imgW = cropNaturalW * total;
+        const imgH = cropNaturalH * total;
+        const clamped = clampCropOffset(cropDx, cropDy, imgW, imgH, containerSize);
+        cropDx = clamped.dx;
+        cropDy = clamped.dy;
+    }
+
+    function onCropScaleChange() {
+        reclampCropOffset();
+    }
+
+    function onCropPointerDown(event: PointerEvent) {
+        if (!cropImageReady) return;
+        const target = event.currentTarget as HTMLElement;
+        target.setPointerCapture(event.pointerId);
+        dragOrigin = { x: event.clientX, y: event.clientY, dx: cropDx, dy: cropDy };
+        event.preventDefault();
+    }
+
+    function onCropPointerMove(event: PointerEvent) {
+        if (!dragOrigin) return;
+        const nextDx = dragOrigin.dx + (event.clientX - dragOrigin.x);
+        const nextDy = dragOrigin.dy + (event.clientY - dragOrigin.y);
+        const containerSize = cropContainerEl?.clientWidth ?? 0;
+        const total = cropBaseScale * cropScale;
+        const imgW = cropNaturalW * total;
+        const imgH = cropNaturalH * total;
+        const clamped = clampCropOffset(nextDx, nextDy, imgW, imgH, containerSize);
+        cropDx = clamped.dx;
+        cropDy = clamped.dy;
+    }
+
+    function onCropPointerUp(event: PointerEvent) {
+        if (!dragOrigin) return;
+        const target = event.currentTarget as HTMLElement;
+        if (target.hasPointerCapture(event.pointerId)) target.releasePointerCapture(event.pointerId);
+        dragOrigin = null;
+    }
+
+    function onCropWheel(event: WheelEvent) {
+        if (!cropImageReady) return;
+        event.preventDefault();
+        const delta = -event.deltaY * 0.002;
+        const nextScale = Math.min(CROP_MAX_ZOOM, Math.max(1, cropScale + delta));
+        if (nextScale === cropScale) return;
+        cropScale = nextScale;
+        reclampCropOffset();
+    }
+
+    function cancelCrop() {
+        resetCropState();
+    }
+
+    function confirmCrop() {
+        if (!cropImageEl || !cropContainerEl || !cropImageReady) return;
+        const containerSize = cropContainerEl.clientWidth;
+        const total = cropBaseScale * cropScale;
+        const sx = -cropDx / total;
+        const sy = -cropDy / total;
+        const ss = containerSize / total;
+        const canvas = document.createElement("canvas");
+        canvas.width = CROP_OUTPUT_SIZE;
+        canvas.height = CROP_OUTPUT_SIZE;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        ctx.drawImage(cropImageEl, sx, sy, ss, ss, 0, 0, CROP_OUTPUT_SIZE, CROP_OUTPUT_SIZE);
+        canvas.toBlob(
+            (blob) => {
+                if (!blob) {
+                    photoErrString = $t("person.photoUploadFailed");
+                    return;
+                }
+                if (pendingPhotoPreviewUrl) URL.revokeObjectURL(pendingPhotoPreviewUrl);
+                pendingPhotoBlob = blob;
+                pendingPhotoPreviewUrl = URL.createObjectURL(blob);
+                pendingPhotoRemove = false;
+                photoUrl = pendingPhotoPreviewUrl;
+                resetCropState();
+            },
+            CROP_OUTPUT_MIME,
+            CROP_OUTPUT_QUALITY,
+        );
+    }
+
+    function removePhoto() {
+        photoErrString = null;
+        if (pendingPhotoBlob) {
+            if (pendingPhotoPreviewUrl) URL.revokeObjectURL(pendingPhotoPreviewUrl);
+            pendingPhotoPreviewUrl = null;
+            pendingPhotoBlob = null;
+            photoUrl = originalPhotoUrl;
+            return;
+        }
+        if (originalPhotoUrl) {
+            pendingPhotoRemove = true;
+            photoUrl = null;
+        }
+    }
+</script>
+
+<V3Modal
+    {open}
+    title={cropping ? $t("person.photoAdjustTitle") : isCreate ? (createTitle ?? $t("v2.addPerson")) : $t("person.title")}
+    size="lg"
+    scroll
+    dismissOnBackdrop={!cropping}
+    onclose={close}
+    testid="v3-person-details-modal"
+>
+    {#snippet body()}
+        {#if cropping}
+            <div class="crop-wrap">
+                <div
+                    bind:this={cropContainerEl}
+                    class="crop-area"
+                    role="application"
+                    aria-label={$t("person.photoAdjustHint")}
+                    onpointerdown={onCropPointerDown}
+                    onpointermove={onCropPointerMove}
+                    onpointerup={onCropPointerUp}
+                    onpointercancel={onCropPointerUp}
+                    onwheel={onCropWheel}
+                >
+                    {#if cropImageUrl}
+                        <img
+                            bind:this={cropImageEl}
+                            src={cropImageUrl}
+                            alt=""
+                            class="crop-image"
+                            style="transform: translate({cropDx}px, {cropDy}px) scale({cropBaseScale * cropScale}); visibility: {cropImageReady ? 'visible' : 'hidden'};"
+                            onload={onCropImageLoaded}
+                            draggable="false"
+                        />
+                    {/if}
+                    <div class="crop-overlay"></div>
+                </div>
+                <input
+                    type="range"
+                    class="form-range"
+                    min="1"
+                    max={CROP_MAX_ZOOM}
+                    step="0.01"
+                    bind:value={cropScale}
+                    oninput={onCropScaleChange}
+                    disabled={!cropImageReady}
+                    aria-label={$t("person.photoAdjustHint")}
+                />
+                <p class="hint">{$t("person.photoAdjustHint")}</p>
+            </div>
+        {:else}
+            <div class="grid">
+                <div class="col-photo">
+                    <div class="photo-frame">
+                        {#if photoUrl}
+                            <img src={photoUrl} alt={name} class="photo-image" />
+                        {:else}
+                            <div class="photo-empty">{$t("person.photo")}</div>
+                        {/if}
+                        {#if !readOnly}
+                            <button
+                                type="button"
+                                class="photo-upload-btn"
+                                onclick={pickPhoto}
+                                aria-label={photoUrl ? $t("person.photoReplace") : $t("person.photoUpload")}
+                                data-testid="v3-person-photo-upload"
+                            >
+                                <span class="photo-upload-label">
+                                    {photoUrl ? $t("person.photoReplace") : $t("person.photoUpload")}
+                                </span>
+                            </button>
+                            <input
+                                bind:this={photoFileInputEl}
+                                type="file"
+                                accept="image/jpeg,image/png,image/webp"
+                                class="d-none"
+                                onchange={onPhotoFileChange}
+                            />
+                        {/if}
+                    </div>
+                    {#if !readOnly && photoUrl}
+                        <button type="button" class="btn btn-outline-danger btn-sm w-100 mt-2" onclick={removePhoto}>
+                            {$t("person.photoRemove")}
+                        </button>
+                    {/if}
+                    {#if photoErrString}
+                        <div class="text-danger mt-2 small">{photoErrString}</div>
+                    {/if}
+                </div>
+
+                <div class="col-fields">
+                    <div class="field-row">
+                        <label for="v3-person-name" class="field-label">{$t("person.name")}</label>
+                        <input
+                            id="v3-person-name"
+                            class="form-control"
+                            bind:value={name}
+                            readonly={readOnly}
+                            disabled={unknown}
+                            data-testid="v3-person-name-input"
+                        />
+                        {#if !readOnly}
+                            <div class="form-check form-switch mt-2">
+                                <input
+                                    class="form-check-input"
+                                    type="checkbox"
+                                    id="v3-person-unknown"
+                                    bind:checked={unknown}
+                                    onchange={() => { if (unknown) name = ""; }}
+                                />
+                                <label class="form-check-label" for="v3-person-unknown">
+                                    {$t("person.unknownToggle")}
+                                </label>
+                            </div>
+                        {/if}
+                    </div>
+
+                    <div class="field-row">
+                        <span class="field-label">{$t("person.lifeYears")}</span>
+                        <div class="dates-row">
+                            <div class="date-cell">
+                                <input
+                                    bind:this={birthInputEl}
+                                    value={dateToMaskedDateStr(birthDate)}
+                                    use:imask={dateMaskingOpts}
+                                    class="form-control {birthDateErrString ? 'is-invalid' : ''}"
+                                    readonly={readOnly}
+                                    placeholder={$t("person.datePlaceholder")}
+                                    data-testid="v3-person-birth"
+                                />
+                                {#if birthDateErrString}
+                                    <div class="invalid-feedback">{birthDateErrString}</div>
+                                {/if}
+                            </div>
+                            <div class="date-cell">
+                                <input
+                                    bind:this={deathInputEl}
+                                    value={dateToMaskedDateStr(deathDate)}
+                                    use:imask={dateMaskingOpts}
+                                    class="form-control {deathDateErrString ? 'is-invalid' : ''}"
+                                    readonly={readOnly}
+                                    placeholder={$t("person.datePlaceholder")}
+                                    data-testid="v3-person-death"
+                                />
+                                {#if deathDateErrString}
+                                    <div class="invalid-feedback">{deathDateErrString}</div>
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-bio">
+                    <div class="bio-header">
+                        <span class="field-label">{$t("person.bio")}</span>
+                        {#if !readOnly}
+                            <div class="bio-tabs">
+                                <button
+                                    type="button"
+                                    class="bio-tab {bioTab === 'edit' ? 'active' : ''}"
+                                    onclick={() => (bioTab = "edit")}
+                                >{$t("person.bioEdit")}</button>
+                                <button
+                                    type="button"
+                                    class="bio-tab {bioTab === 'preview' ? 'active' : ''}"
+                                    onclick={() => (bioTab = "preview")}
+                                >{$t("person.bioPreview")}</button>
+                            </div>
+                        {/if}
+                    </div>
+                    {#if !readOnly && bioTab === "edit"}
+                        <textarea
+                            class="form-control bio-textarea"
+                            rows="6"
+                            bind:value={bio}
+                            data-testid="v3-person-bio"
+                        ></textarea>
+                        <div class="form-text">{$t("person.bioMarkdownHint")}</div>
+                    {:else if bioHtml}
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        <div class="bio-preview">{@html bioHtml}</div>
+                    {:else}
+                        <div class="bio-preview text-muted fst-italic">{$t("person.bioEmpty")}</div>
+                    {/if}
+                </div>
+
+                {#if editingAllowed}
+                    <div class="col-pin">
+                        <div class="form-check form-switch">
+                            <input
+                                class="form-check-input"
+                                type="checkbox"
+                                id="v3-person-pin"
+                                bind:checked={pinned}
+                            />
+                            <label class="form-check-label" for="v3-person-pin">{$t("person.pin")}</label>
+                        </div>
+                    </div>
+                {/if}
+            </div>
+        {/if}
+    {/snippet}
+
+    {#snippet footer()}
+        {#if cropping}
+            <button type="button" class="btn btn-secondary" onclick={cancelCrop}>{$t("common.cancel")}</button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                disabled={!cropImageReady}
+                onclick={confirmCrop}
+                data-testid="v3-person-crop-save"
+            >{$t("common.save")}</button>
+        {:else if isCreate}
+            <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.cancel")}</button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                disabled={saveDisabled}
+                onclick={save}
+                data-testid="v3-person-create"
+            >{$t("common.create")}</button>
+        {:else if editingAllowed}
+            <button
+                type="button"
+                class="btn btn-danger me-auto"
+                onclick={remove}
+                data-testid="v3-person-delete"
+            >{$t("common.delete")}</button>
+            {#if !personReadOnly}
+                <button
+                    type="button"
+                    class="btn btn-outline-primary"
+                    onclick={requestShareAccess}
+                    data-testid="v3-share-access-btn"
+                >{$t("v2.shareAccess")}</button>
+            {/if}
+            <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.cancel")}</button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                disabled={saveDisabled}
+                onclick={save}
+                data-testid="v3-person-save"
+            >{$t("common.save")}</button>
+        {:else}
+            {#if !personReadOnly}
+                <button
+                    type="button"
+                    class="btn btn-outline-primary me-auto"
+                    onclick={requestShareAccess}
+                    data-testid="v3-share-access-btn"
+                >{$t("v2.shareAccess")}</button>
+            {/if}
+            <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.close")}</button>
+        {/if}
+    {/snippet}
+</V3Modal>
+
+<style>
+    .grid {
+        display: grid;
+        grid-template-columns: 200px 1fr;
+        gap: 16px;
+    }
+
+    .col-photo { grid-column: 1; grid-row: 1; }
+    .col-fields { grid-column: 2; grid-row: 1; }
+    .col-bio { grid-column: 1 / -1; }
+    .col-pin { grid-column: 1 / -1; }
+
+    @media (max-width: 560px) {
+        .grid {
+            grid-template-columns: 1fr;
+        }
+        .col-photo, .col-fields { grid-column: 1; grid-row: auto; }
+    }
+
+    .field-row + .field-row {
+        margin-top: 12px;
+    }
+
+    .field-label {
+        display: block;
+        margin: 4px 0 6px;
+        font-size: var(--v3-fs-label);
+        color: var(--v3-text-secondary);
+        font-weight: var(--v3-fw-label);
+    }
+
+    .dates-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+    }
+
+    .date-cell {
+        position: relative;
+    }
+
+    .photo-frame {
+        position: relative;
+        width: 100%;
+        aspect-ratio: 1 / 1;
+        border-radius: 12px;
+        overflow: hidden;
+        border: 1px solid #e9ecef;
+        background-color: #f8f9fa;
+    }
+
+    .photo-image {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+    }
+
+    .photo-empty {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--v3-text-muted);
+        font-size: var(--v3-fs-label);
+    }
+
+    .photo-upload-btn {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
+        transition: background-color 0.15s ease;
+    }
+
+    .photo-upload-btn:hover,
+    .photo-upload-btn:focus-visible {
+        background-color: rgba(0, 0, 0, 0.35);
+    }
+
+    .photo-upload-label {
+        width: 100%;
+        padding: 0.5rem;
+        background-color: rgba(0, 0, 0, 0.55);
+        color: #fff;
+        font-size: var(--v3-fs-label);
+        text-align: center;
+        opacity: 0;
+        transition: opacity 0.15s ease;
+    }
+
+    .photo-frame:has(.photo-empty) .photo-upload-label,
+    .photo-upload-btn:hover .photo-upload-label,
+    .photo-upload-btn:focus-visible .photo-upload-label {
+        opacity: 1;
+    }
+
+    .bio-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 4px;
+    }
+
+    .bio-tabs {
+        display: inline-flex;
+        background: #f1f3f5;
+        border-radius: 8px;
+        padding: 2px;
+    }
+
+    .bio-tab {
+        padding: 4px 10px;
+        background: none;
+        border: none;
+        font-size: var(--v3-fs-hint);
+        color: var(--v3-text-muted);
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: var(--v3-fw-label);
+    }
+
+    .bio-tab.active {
+        background: var(--v3-bg-surface);
+        color: var(--v3-text-primary);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    }
+
+    .bio-textarea {
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        font-size: var(--v3-fs-body);
+    }
+
+    .bio-preview {
+        min-height: 6rem;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #e9ecef;
+        border-radius: 10px;
+        background-color: #fff;
+        line-height: 1.5;
+        font-size: 0.95rem;
+        overflow-wrap: anywhere;
+    }
+
+    .bio-preview :global(p) { margin: 0 0 0.75rem; }
+    .bio-preview :global(p:last-child) { margin-bottom: 0; }
+    .bio-preview :global(h1),
+    .bio-preview :global(h2),
+    .bio-preview :global(h3),
+    .bio-preview :global(h4),
+    .bio-preview :global(h5),
+    .bio-preview :global(h6) {
+        margin: 1rem 0 0.5rem;
+        font-weight: 600;
+    }
+    .bio-preview :global(h1) { font-size: 1.4rem; }
+    .bio-preview :global(h2) { font-size: 1.25rem; }
+    .bio-preview :global(h3) { font-size: 1.1rem; }
+    .bio-preview :global(ul),
+    .bio-preview :global(ol) {
+        padding-left: 1.25rem;
+        margin-bottom: 0.75rem;
+    }
+    .bio-preview :global(a) { color: #0d6efd; word-break: break-word; }
+    .bio-preview :global(blockquote) {
+        margin: 0 0 0.75rem;
+        padding: 0.25rem 0.75rem;
+        border-left: 3px solid #e9ecef;
+        color: var(--v3-text-muted);
+    }
+    .bio-preview :global(code) {
+        padding: 0.1em 0.3em;
+        font-size: 0.875em;
+        background-color: rgba(0, 0, 0, 0.06);
+        border-radius: 0.25rem;
+    }
+
+    .crop-wrap {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .crop-area {
+        position: relative;
+        width: 100%;
+        max-width: 400px;
+        aspect-ratio: 1 / 1;
+        margin: 0 auto;
+        border-radius: 12px;
+        overflow: hidden;
+        background-color: #000;
+        cursor: grab;
+        touch-action: none;
+        user-select: none;
+    }
+
+    .crop-area:active { cursor: grabbing; }
+
+    .crop-image {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform-origin: 0 0;
+        pointer-events: none;
+        max-width: none;
+    }
+
+    .crop-overlay {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+    }
+
+    .hint {
+        margin: 0;
+        color: var(--v3-text-muted);
+        font-size: var(--v3-fs-hint);
+        text-align: center;
+    }
+
+</style>

--- a/frontend/src/v3/components/V3PersonGhost.svelte
+++ b/frontend/src/v3/components/V3PersonGhost.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+
+    export type PersonGhostAction = "addChild" | "addSpouse";
+
+    type Props = {
+        onsubmit?: (payload: { action: PersonGhostAction; name: string }) => void;
+        oncancel?: () => void;
+    };
+
+    let { onsubmit, oncancel }: Props = $props();
+
+    let stage = $state<"pick" | "name">("pick");
+    let action = $state<PersonGhostAction>("addChild");
+    let name = $state("");
+
+    function pick(a: PersonGhostAction) {
+        action = a;
+        stage = "name";
+    }
+
+    function confirm() {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        onsubmit?.({ action, name: trimmed });
+    }
+</script>
+
+<div class="ghost-menu" data-testid="v3-person-ghost-menu">
+    {#if stage === "pick"}
+        <button
+            type="button"
+            class="btn btn-outline-primary btn-sm role-btn"
+            onclick={() => pick("addChild")}
+            data-testid="v3-person-ghost-add-child"
+        >
+            {$t("v2.familyGhostAddChild")}
+        </button>
+        <button
+            type="button"
+            class="btn btn-outline-primary btn-sm role-btn"
+            onclick={() => pick("addSpouse")}
+            data-testid="v3-person-ghost-add-spouse"
+        >
+            {$t("v2.familyGhostAddSpouse")}
+        </button>
+        <button
+            type="button"
+            class="btn btn-link btn-sm cancel-btn"
+            onclick={() => oncancel?.()}
+        >
+            {$t("common.cancel")}
+        </button>
+    {:else}
+        <input
+            type="text"
+            class="form-control form-control-sm"
+            placeholder={$t("v2.namePlaceholder")}
+            bind:value={name}
+            data-testid="v3-person-ghost-name"
+            onkeydown={(e) => { if (e.key === "Enter") confirm(); }}
+        />
+        <div class="actions">
+            <button
+                type="button"
+                class="btn btn-link btn-sm cancel-btn"
+                onclick={() => oncancel?.()}
+            >
+                {$t("common.cancel")}
+            </button>
+            <button
+                type="button"
+                class="btn btn-primary btn-sm ms-auto"
+                disabled={!name.trim()}
+                onclick={confirm}
+                data-testid="v3-person-ghost-confirm"
+            >
+                {$t("common.add")}
+            </button>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .ghost-menu {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 4px 0;
+    }
+    .role-btn {
+        text-align: left;
+    }
+    .cancel-btn {
+        padding: 4px 8px;
+    }
+    .actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+</style>

--- a/frontend/src/v3/components/V3PromptModal.svelte
+++ b/frontend/src/v3/components/V3PromptModal.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+    import V3Modal from "./V3Modal.svelte";
+
+    let open = $state(false);
+    let inputEl = $state<HTMLInputElement | null>(null);
+    let value = $state("");
+
+    let title = $state("");
+    let label = $state("");
+    let confirmLabel = $state("");
+    let placeholder = $state("");
+    let testid = $state<string | undefined>(undefined);
+    let inputTestid = $state<string>("v3-prompt-input");
+    let confirmTestid = $state<string>("v3-prompt-confirm");
+    let pendingAccept: ((value: string) => void) | null = null;
+
+    export function prompt(opts: {
+        title: string;
+        label: string;
+        confirmLabel: string;
+        initial?: string;
+        placeholder?: string;
+        testid?: string;
+        inputTestid?: string;
+        confirmTestid?: string;
+        onaccept: (value: string) => void;
+    }) {
+        title = opts.title;
+        label = opts.label;
+        confirmLabel = opts.confirmLabel;
+        placeholder = opts.placeholder ?? "";
+        testid = opts.testid;
+        inputTestid = opts.inputTestid ?? "v3-prompt-input";
+        confirmTestid = opts.confirmTestid ?? "v3-prompt-confirm";
+        value = opts.initial ?? "";
+        pendingAccept = opts.onaccept;
+        open = true;
+        setTimeout(() => {
+            inputEl?.focus();
+            inputEl?.select();
+        }, 60);
+    }
+
+    function close() {
+        open = false;
+        pendingAccept = null;
+    }
+
+    function commit() {
+        const v = value.trim();
+        if (!v) return;
+        const cb = pendingAccept;
+        open = false;
+        pendingAccept = null;
+        cb?.(v);
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+        }
+    }
+</script>
+
+<V3Modal {open} {title} size="sm" onclose={close} testid={testid}>
+    {#snippet body()}
+        <label for="v3-prompt-input" class="prompt-label">{label}</label>
+        <input
+            id="v3-prompt-input"
+            class="form-control"
+            bind:this={inputEl}
+            bind:value
+            onkeydown={handleKeydown}
+            placeholder={placeholder}
+            data-testid={inputTestid}
+        />
+    {/snippet}
+
+    {#snippet footer()}
+        <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.cancel")}</button>
+        <button
+            type="button"
+            class="btn btn-primary"
+            onclick={commit}
+            disabled={!value.trim()}
+            data-testid={confirmTestid}
+        >
+            {confirmLabel}
+        </button>
+    {/snippet}
+</V3Modal>
+
+<style>
+    .prompt-label {
+        display: block;
+        margin: 4px 0 6px;
+        font-size: var(--v3-fs-label);
+        font-weight: var(--v3-fw-label);
+        color: var(--v3-text-secondary);
+    }
+</style>

--- a/frontend/src/v3/components/V3Search.svelte
+++ b/frontend/src/v3/components/V3Search.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+    import type { PersonDescription } from "../../model";
+    import { t } from "../../i18n";
+    import { highlightMatches, searchPeople } from "../../personSearch";
+
+    type Props = {
+        people: PersonDescription[];
+        disabled?: boolean;
+        onselect?: (id: string) => void;
+    };
+
+    let { people, disabled = false, onselect }: Props = $props();
+
+    let query = $state("");
+    let activeIndex = $state(-1);
+    let focused = $state(false);
+    let inputEl = $state<HTMLInputElement | null>(null);
+    let blurTimeout: ReturnType<typeof setTimeout>;
+
+    const results = $derived(searchPeople(query, people));
+    const hasQuery = $derived(query.trim().length >= 2);
+    const showDropdown = $derived(focused && hasQuery);
+    const showNoResults = $derived(showDropdown && results.length === 0);
+
+    $effect(() => {
+        results;
+        activeIndex = -1;
+    });
+
+    function lifespan(p: PersonDescription): string {
+        const parts = [p.birthDate || "?", p.deathDate].filter(Boolean);
+        return parts.length ? parts.join(" – ") : "";
+    }
+
+    function selectPerson(id: string) {
+        onselect?.(id);
+        query = "";
+        focused = false;
+        inputEl?.blur();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") {
+            query = "";
+            focused = false;
+            inputEl?.blur();
+            return;
+        }
+        if (!showDropdown || results.length === 0) return;
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            activeIndex = (activeIndex + 1) % results.length;
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            activeIndex = (activeIndex - 1 + results.length) % results.length;
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            const idx = activeIndex >= 0 ? activeIndex : 0;
+            selectPerson(results[idx].item.id);
+        }
+    }
+
+    function handleBlur() {
+        blurTimeout = setTimeout(() => {
+            focused = false;
+        }, 150);
+    }
+
+    function handleFocus() {
+        clearTimeout(blurTimeout);
+        focused = true;
+    }
+
+    function clearQuery() {
+        query = "";
+        inputEl?.focus();
+    }
+</script>
+
+<div class="v3-search" data-testid="v3-search">
+    <i class="bi bi-search search-icon" aria-hidden="true"></i>
+    <input
+        bind:this={inputEl}
+        type="search"
+        class="search-input"
+        placeholder={$t("search.placeholder")}
+        bind:value={query}
+        {disabled}
+        onkeydown={handleKeydown}
+        onblur={handleBlur}
+        onfocus={handleFocus}
+        aria-label={$t("search.placeholder")}
+        data-testid="v3-search-input"
+    />
+    {#if query.length > 0}
+        <button
+            type="button"
+            class="clear-btn"
+            onclick={clearQuery}
+            aria-label={$t("common.close")}
+            data-testid="v3-search-clear"
+        >
+            <i class="bi bi-x"></i>
+        </button>
+    {/if}
+
+    {#if showDropdown}
+        <div class="search-dropdown" data-testid="v3-search-dropdown">
+            {#if showNoResults}
+                <div class="no-results" data-testid="v3-search-no-results">
+                    {$t("v2.searchNoResults")}
+                </div>
+            {:else}
+                {#each results as result, i}
+                    <button
+                        type="button"
+                        class="search-row"
+                        class:active={i === activeIndex}
+                        onmousedown={(e) => { e.preventDefault(); selectPerson(result.item.id); }}
+                        data-testid="v3-search-result"
+                    >
+                        <span class="row-name">{@html highlightMatches(result.item.name, result.matchedIndices)}</span>
+                        {#if lifespan(result.item)}
+                            <span class="row-meta">{lifespan(result.item)}</span>
+                        {/if}
+                    </button>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .v3-search {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        padding: 6px 10px;
+        position: relative;
+        width: min(320px, calc(100vw - 200px));
+        min-width: 200px;
+    }
+
+    .search-icon {
+        color: #6c757d;
+        font-size: 0.95rem;
+        flex-shrink: 0;
+    }
+
+    .search-input {
+        flex: 1 1 auto;
+        min-width: 0;
+        border: none;
+        outline: none;
+        background: transparent;
+        font-size: 0.875rem;
+        color: #212529;
+        padding: 2px 0;
+    }
+
+    .search-input::placeholder {
+        color: #adb5bd;
+    }
+
+    .search-input::-webkit-search-cancel-button {
+        display: none;
+    }
+
+    .clear-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background: transparent;
+        border: none;
+        color: #6c757d;
+        cursor: pointer;
+        flex-shrink: 0;
+        font-size: 0.95rem;
+    }
+
+    .clear-btn:hover {
+        background: #e9ecef;
+        color: #212529;
+    }
+
+    .search-dropdown {
+        position: absolute;
+        top: calc(100% + 8px);
+        left: 0;
+        right: 0;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        max-height: 320px;
+        overflow-y: auto;
+        z-index: 1000;
+        padding: 4px 0;
+    }
+
+    .search-row {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        width: 100%;
+        padding: 8px 12px;
+        background: none;
+        border: none;
+        text-align: left;
+        font-size: 0.875rem;
+        color: #212529;
+        cursor: pointer;
+    }
+
+    .search-row:hover,
+    .search-row.active {
+        background: #f1f7ff;
+    }
+
+    .row-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .row-name :global(b) {
+        font-weight: 700;
+        color: #0d6efd;
+    }
+
+    .row-meta {
+        color: #6c757d;
+        font-size: 0.8rem;
+        flex-shrink: 0;
+    }
+
+    .no-results {
+        padding: 10px 12px;
+        color: #6c757d;
+        font-size: 0.85rem;
+        text-align: center;
+    }
+</style>

--- a/frontend/src/v3/components/V3SettingsModal.svelte
+++ b/frontend/src/v3/components/V3SettingsModal.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+    import type { Settings } from "../../model";
+    import { DEFAULT_SETTINGS, ViewMode } from "../../model";
+    import V3Modal from "./V3Modal.svelte";
+
+    type Props = {
+        onsettingsChanged?: (settings: Settings) => void;
+    };
+
+    let { onsettingsChanged }: Props = $props();
+
+    let open = $state(false);
+    let viewMode = $state<ViewMode>(DEFAULT_SETTINGS.viewMode);
+
+    export function show() {
+        open = true;
+    }
+
+    function close() {
+        open = false;
+    }
+
+    function save() {
+        onsettingsChanged?.({ viewMode });
+        close();
+    }
+</script>
+
+<V3Modal {open} title={$t("settings.title")} size="sm" onclose={close} testid="v3-settings-modal">
+    {#snippet body()}
+        <div class="option" role="radio" tabindex="0" aria-checked={viewMode === ViewMode.ALL} onclick={() => (viewMode = ViewMode.ALL)} onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); viewMode = ViewMode.ALL; } }}>
+            <span class="dot" class:active={viewMode === ViewMode.ALL}></span>
+            <span class="label">{$t("settings.showAll")}</span>
+        </div>
+        <div class="option" role="radio" tabindex="0" aria-checked={viewMode === ViewMode.EDITABLE_ONLY} onclick={() => (viewMode = ViewMode.EDITABLE_ONLY)} onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); viewMode = ViewMode.EDITABLE_ONLY; } }}>
+            <span class="dot" class:active={viewMode === ViewMode.EDITABLE_ONLY}></span>
+            <span class="label">{$t("settings.showEditableOnly")}</span>
+        </div>
+    {/snippet}
+
+    {#snippet footer()}
+        <button type="button" class="btn btn-secondary" onclick={close}>{$t("common.cancel")}</button>
+        <button type="button" class="btn btn-primary" onclick={save} data-testid="v3-settings-save">{$t("common.save")}</button>
+    {/snippet}
+</V3Modal>
+
+<style>
+    .option {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 8px;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: background-color 0.12s ease;
+    }
+
+    .option:hover {
+        background: #f8f9fa;
+    }
+
+    .option + .option {
+        margin-top: 2px;
+    }
+
+    .dot {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid #adb5bd;
+        flex-shrink: 0;
+        transition: border-color 0.12s ease;
+        position: relative;
+    }
+
+    .dot.active {
+        border-color: #0d6efd;
+    }
+
+    .dot.active::after {
+        content: "";
+        position: absolute;
+        inset: 2px;
+        border-radius: 50%;
+        background: #0d6efd;
+    }
+
+    .label {
+        font-size: var(--v3-fs-body);
+        color: var(--v3-text-primary);
+    }
+</style>

--- a/frontend/src/v3/components/V3ShareAccessModal.svelte
+++ b/frontend/src/v3/components/V3ShareAccessModal.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+    import { t } from "../../i18n";
+    import V3Modal from "./V3Modal.svelte";
+
+    type Props = {
+        oncreate?: (payload: { personId: string; email: string }) => void;
+    };
+
+    let { oncreate }: Props = $props();
+
+    let open = $state(false);
+    let personId = $state("");
+    let personName = $state("");
+    let email = $state("");
+
+    const submitDisabled = $derived(!email.trim());
+
+    export function show(args: { personId: string; name: string }) {
+        personId = args.personId;
+        personName = args.name;
+        email = "";
+        open = true;
+    }
+
+    export function close() {
+        open = false;
+    }
+
+    export function dismiss() {
+        close();
+    }
+
+    function handleCreate() {
+        const value = email.trim();
+        if (!value || !personId) return;
+        oncreate?.({ personId, email: value });
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            handleCreate();
+        }
+    }
+</script>
+
+<V3Modal
+    {open}
+    title={$t("v2.shareTitle", { name: personName })}
+    size="md"
+    onclose={close}
+    testid="v3-share-access-modal"
+>
+    {#snippet body()}
+        <label for="v3-share-access-email" class="field-label">{$t("v2.shareEmailLabel")}</label>
+        <input
+            id="v3-share-access-email"
+            type="email"
+            class="form-control"
+            placeholder="name@gmail.com"
+            bind:value={email}
+            onkeydown={handleKeydown}
+            data-testid="v3-share-access-email"
+        />
+        <p class="hint">{$t("v2.shareEmailHint")}</p>
+    {/snippet}
+
+    {#snippet footer()}
+        <button
+            type="button"
+            class="btn btn-secondary"
+            onclick={close}
+            data-testid="v3-share-access-cancel"
+        >{$t("common.cancel")}</button>
+        <button
+            type="button"
+            class="btn btn-primary"
+            disabled={submitDisabled}
+            onclick={handleCreate}
+            data-testid="v3-share-access-create"
+        >{$t("v2.shareCreateLink")}</button>
+    {/snippet}
+</V3Modal>
+
+<style>
+    .field-label {
+        display: block;
+        margin: 0 0 6px;
+        font-size: var(--v3-fs-label);
+        color: var(--v3-text-secondary);
+        font-weight: var(--v3-fw-label);
+    }
+
+    .hint {
+        margin: 8px 0 0;
+        font-size: var(--v3-fs-hint);
+        color: var(--v3-text-muted);
+    }
+</style>

--- a/frontend/src/v3/components/V3Sheet.svelte
+++ b/frontend/src/v3/components/V3Sheet.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+    import type { Snippet } from "svelte";
+    import { onMount } from "svelte";
+
+    type Props = {
+        open: boolean;
+        anchorEl?: Element | null;
+        onclose?: () => void;
+        body: Snippet;
+        footer?: Snippet;
+        testid?: string;
+    };
+
+    let { open, anchorEl = null, onclose, body, footer, testid }: Props = $props();
+
+    let isMobile = $state(typeof window !== "undefined" && !window.matchMedia("(min-width: 768px)").matches);
+
+    onMount(() => {
+        const mql = window.matchMedia("(min-width: 768px)");
+        const onChange = (e: MediaQueryListEvent) => { isMobile = !e.matches; };
+        mql.addEventListener("change", onChange);
+        return () => mql.removeEventListener("change", onChange);
+    });
+
+    type PopoverPos = { top: number; left: number; maxH: number; placement: "right" | "left" | "below" };
+
+    const popoverPos = $derived.by<PopoverPos>(() => {
+        if (!open || isMobile || !anchorEl) return { top: 0, left: 0, maxH: 0, placement: "right" };
+        const rect = anchorEl.getBoundingClientRect();
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const popW = 320;
+        const margin = 12;
+        const popH = Math.min(600, vh - 16);
+
+        const anchorInView = rect.right > 0 && rect.left < vw && rect.bottom > 0 && rect.top < vh;
+
+        if (!anchorInView) {
+            return {
+                left: Math.max(8, (vw - popW) / 2),
+                top: Math.max(8, (vh - popH) / 2),
+                maxH: popH,
+                placement: "below",
+            };
+        }
+
+        let left: number;
+        let placement: "right" | "left" | "below";
+        if (vw - rect.right >= popW + margin) {
+            left = rect.right + margin;
+            placement = "right";
+        } else if (rect.left >= popW + margin) {
+            left = rect.left - popW - margin;
+            placement = "left";
+        } else {
+            left = Math.max(8, (vw - popW) / 2);
+            placement = "below";
+        }
+
+        const centeredTop = rect.top + rect.height / 2 - popH / 2;
+        const top = Math.max(8, Math.min(centeredTop, vh - popH - 8));
+        return { top, left, maxH: popH, placement };
+    });
+
+    function handleBackdropClick() {
+        onclose?.();
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") onclose?.();
+    }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+    {#if isMobile}
+        <div class="sheet-backdrop" onclick={handleBackdropClick} aria-hidden="true"></div>
+        <div class="bottom-sheet" data-testid={testid} role="dialog" aria-modal="true">
+            <div class="sheet-handle"></div>
+            <div class="sheet-body">
+                {@render body()}
+            </div>
+            {#if footer}
+                <div class="sheet-footer">
+                    {@render footer()}
+                </div>
+            {/if}
+        </div>
+    {:else if anchorEl}
+        <div class="popover-backdrop" onclick={handleBackdropClick} aria-hidden="true"></div>
+        <div
+            class="popover-panel"
+            style="top: {popoverPos.top}px; left: {popoverPos.left}px; max-height: {popoverPos.maxH}px;"
+            data-testid={testid}
+            role="dialog"
+            aria-modal="true"
+        >
+            <div class="popover-body">
+                {@render body()}
+            </div>
+            {#if footer}
+                <div class="popover-footer">
+                    {@render footer()}
+                </div>
+            {/if}
+        </div>
+    {:else}
+        <div class="sheet-backdrop" onclick={handleBackdropClick} aria-hidden="true"></div>
+        <div class="centered-panel" data-testid={testid} role="dialog" aria-modal="true">
+            <div class="sheet-body">
+                {@render body()}
+            </div>
+            {#if footer}
+                <div class="sheet-footer">
+                    {@render footer()}
+                </div>
+            {/if}
+        </div>
+    {/if}
+{/if}
+
+<style>
+    .sheet-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        z-index: 1040;
+        animation: fade-in 0.12s ease-out;
+    }
+
+    .popover-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.35);
+        z-index: 1040;
+        animation: fade-in 0.12s ease-out;
+    }
+
+    @keyframes fade-in {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .bottom-sheet {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: var(--v3-bg-surface);
+        border-radius: 20px 20px 0 0;
+        box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+        z-index: 1050;
+        max-height: 80vh;
+        display: flex;
+        flex-direction: column;
+        animation: slide-up 0.22s ease-out;
+    }
+
+    @keyframes slide-up {
+        from { transform: translateY(100%); }
+        to { transform: translateY(0); }
+    }
+
+    .sheet-handle {
+        width: 40px;
+        height: 4px;
+        background: #dee2e6;
+        border-radius: 2px;
+        margin: 12px auto 8px;
+        flex-shrink: 0;
+    }
+
+    .sheet-body {
+        flex: 1;
+        overflow-y: auto;
+        padding: 8px 20px 4px;
+    }
+
+    .sheet-footer {
+        padding: 12px 20px 20px;
+        border-top: 1px solid var(--v3-border-subtle);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .popover-panel {
+        position: fixed;
+        width: 320px;
+        display: flex;
+        flex-direction: column;
+        background: var(--v3-bg-surface);
+        border-radius: var(--v3-radius-modal);
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+        z-index: 1050;
+        animation: pop-in 0.15s ease-out;
+    }
+
+    @keyframes pop-in {
+        from { opacity: 0; transform: scale(0.95); }
+        to { opacity: 1; transform: scale(1); }
+    }
+
+    .popover-body {
+        flex: 1;
+        overflow-y: auto;
+        padding: 16px 18px 8px;
+    }
+
+    .popover-footer {
+        padding: 8px 18px 16px;
+        border-top: 1px solid var(--v3-border-subtle);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .centered-panel {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: min(480px, calc(100vw - 32px));
+        max-height: calc(100vh - 48px);
+        background: var(--v3-bg-surface);
+        border-radius: var(--v3-radius-modal);
+        box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+        z-index: 1050;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+</style>

--- a/frontend/src/v3/focusGesture.test.ts
+++ b/frontend/src/v3/focusGesture.test.ts
@@ -1,0 +1,93 @@
+import { isShortTap, isLongPress, focusedIdFromG, closestNodeG, TAP_MAX_MS, TAP_MAX_MOVE_PX } from "./focusGesture";
+
+describe("isShortTap", () => {
+    it("returns true when elapsed < TAP_MAX_MS and moved <= TAP_MAX_MOVE_PX", () => {
+        expect(isShortTap(TAP_MAX_MS - 1, 0)).toBe(true);
+        expect(isShortTap(100, TAP_MAX_MOVE_PX)).toBe(true);
+    });
+
+    it("returns false when elapsed >= TAP_MAX_MS", () => {
+        expect(isShortTap(TAP_MAX_MS, 0)).toBe(false);
+        expect(isShortTap(TAP_MAX_MS + 1, 0)).toBe(false);
+    });
+
+    it("returns false when moved > TAP_MAX_MOVE_PX", () => {
+        expect(isShortTap(100, TAP_MAX_MOVE_PX + 1)).toBe(false);
+    });
+
+    it("returns false when both thresholds exceeded", () => {
+        expect(isShortTap(TAP_MAX_MS + 100, TAP_MAX_MOVE_PX + 5)).toBe(false);
+    });
+});
+
+describe("isLongPress", () => {
+    it("returns true when elapsed >= TAP_MAX_MS and moved <= TAP_MAX_MOVE_PX", () => {
+        expect(isLongPress(TAP_MAX_MS, 0)).toBe(true);
+        expect(isLongPress(TAP_MAX_MS + 1, 0)).toBe(true);
+        expect(isLongPress(TAP_MAX_MS, TAP_MAX_MOVE_PX)).toBe(true);
+    });
+
+    it("returns false when elapsed < TAP_MAX_MS", () => {
+        expect(isLongPress(TAP_MAX_MS - 1, 0)).toBe(false);
+        expect(isLongPress(0, 0)).toBe(false);
+    });
+
+    it("returns false when moved > TAP_MAX_MOVE_PX", () => {
+        expect(isLongPress(TAP_MAX_MS, TAP_MAX_MOVE_PX + 1)).toBe(false);
+    });
+
+    it("returns false when both thresholds violated", () => {
+        expect(isLongPress(TAP_MAX_MS - 1, TAP_MAX_MOVE_PX + 1)).toBe(false);
+    });
+});
+
+describe("focusedIdFromG", () => {
+    const noPending = (_id: string) => false;
+    const allPending = (_id: string) => true;
+
+    function makeG(domId: string): SVGGElement {
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.setAttribute("id", domId);
+        return g;
+    }
+
+    it("extracts person kind and id from person_ prefix", () => {
+        const g = makeG("person_abc123");
+        expect(focusedIdFromG(g, noPending)).toEqual({ kind: "person", id: "abc123" });
+    });
+
+    it("extracts family kind and id from family_ prefix", () => {
+        const g = makeG("family_xyz789");
+        expect(focusedIdFromG(g, noPending)).toEqual({ kind: "family", id: "xyz789" });
+    });
+
+    it("returns null for pending ids", () => {
+        const g = makeG("person_pending-abc");
+        expect(focusedIdFromG(g, allPending)).toBeNull();
+    });
+});
+
+describe("closestNodeG", () => {
+    it("returns null for null target", () => {
+        expect(closestNodeG(null)).toBeNull();
+    });
+
+    it("returns the element itself when it matches", () => {
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.setAttribute("id", "person_abc");
+        expect(closestNodeG(g)).toBe(g);
+    });
+
+    it("walks up to find a matching ancestor", () => {
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.setAttribute("id", "family_def");
+        const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+        g.appendChild(circle);
+        expect(closestNodeG(circle)).toBe(g);
+    });
+
+    it("returns null when no ancestor matches", () => {
+        const div = document.createElement("div");
+        expect(closestNodeG(div)).toBeNull();
+    });
+});

--- a/frontend/src/v3/focusGesture.ts
+++ b/frontend/src/v3/focusGesture.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure helpers for the v3 focus state machine.
+ *
+ * Desktop: mousemove with distance-based hit detection (150 px radius in SVG
+ * user-space) -> focus; mouseleave from SVG -> debounced clear (150 ms).
+ * Mobile: pointerdown starts a tap timer; pointerup within TAP_MAX_MS and
+ * TAP_MAX_MOVE_PX -> short-tap -> focus. Movement or timeout = drag, no focus.
+ */
+
+export type NodeKind = "person" | "family";
+
+export type FocusedId = { kind: NodeKind; id: string };
+
+export const MOUSE_LEAVE_DEBOUNCE_MS = 150;
+export const TAP_MAX_MS = 500;
+export const TAP_MAX_MOVE_PX = 10;
+export const FOCUS_RADIUS_SVG = 150;
+
+/**
+ * Returns true when a pointerup event qualifies as a short tap (no drag, no
+ * long press). All inputs are the raw numbers so this function is pure and
+ * trivially testable.
+ */
+export function isShortTap(
+    elapsedMs: number,
+    movedPx: number,
+): boolean {
+    return elapsedMs < TAP_MAX_MS && movedPx <= TAP_MAX_MOVE_PX;
+}
+
+/**
+ * Returns true when a timer-fired event qualifies as a long press (pointer
+ * held down for at least TAP_MAX_MS with minimal movement). All inputs are the
+ * raw numbers so this function is pure and trivially testable.
+ */
+export function isLongPress(
+    elapsedMs: number,
+    movedPx: number,
+): boolean {
+    return elapsedMs >= TAP_MAX_MS && movedPx <= TAP_MAX_MOVE_PX;
+}
+
+/**
+ * Finds the nearest ancestor `<g>` element whose id starts with "person_" or
+ * "family_", starting from `target`. Returns null when no such ancestor exists.
+ */
+export function closestNodeG(target: EventTarget | null): SVGGElement | null {
+    const el = target as Element | null;
+    return (el?.closest?.("g[id^='person_'], g[id^='family_']") as SVGGElement | null) ?? null;
+}
+
+/**
+ * Derives a FocusedId from a DOM `<g>` element produced by the chart, or
+ * returns null if the element is a pending node (which should not receive focus).
+ */
+export function focusedIdFromG(
+    g: SVGGElement,
+    isPendingId: (id: string) => boolean,
+): FocusedId | null {
+    const kind: NodeKind = g.id.startsWith("person_") ? "person" : "family";
+    const id = g.id.split("_")[1];
+    if (isPendingId(id)) return null;
+    return { kind, id };
+}
+
+/**
+ * Finds the nearest real (non-pending) person or family node whose center is
+ * within `radiusSvg` SVG user-space units of `(cursorSvgX, cursorSvgY)`.
+ *
+ * Each candidate <g> element must carry a d3 datum with `x` and `y` fields
+ * (the same format d3-force populates).  Real node <g> elements have ids
+ * starting with "person_" or "family_".
+ *
+ * Returns null when no node is within range.
+ */
+export function nearestNodeWithinRadius(
+    mainG: SVGGElement,
+    cursorSvgX: number,
+    cursorSvgY: number,
+    radiusSvg: number,
+    isPendingId: (id: string) => boolean,
+): FocusedId | null {
+    let best: FocusedId | null = null;
+    let bestDist = radiusSvg;
+
+    const candidates = mainG.querySelectorAll<SVGGElement>("g[id^='person_'], g[id^='family_']");
+    for (const g of candidates) {
+        const datum = (g as SVGGElement & { __data__?: { x?: number; y?: number } }).__data__;
+        if (!datum || datum.x == null || datum.y == null) continue;
+        const dist = Math.hypot(datum.x - cursorSvgX, datum.y - cursorSvgY);
+        if (dist <= bestDist) {
+            const focused = focusedIdFromG(g, isPendingId);
+            if (focused) {
+                bestDist = dist;
+                best = focused;
+            }
+        }
+    }
+
+    return best;
+}

--- a/frontend/src/v3/ghostHelpers.test.ts
+++ b/frontend/src/v3/ghostHelpers.test.ts
@@ -1,0 +1,331 @@
+import { deriveGhosts, deriveGhostBranches, immediateNeighborIds } from "./ghostHelpers";
+import type { Stemma } from "../model";
+import { StemmaIndex } from "../stemmaIndex";
+
+function makeStemma(overrides: Partial<Stemma> = {}): Stemma {
+    return {
+        type: "Stemma",
+        people: [
+            { type: "PersonDescription", id: "p1", name: "Alice", readOnly: false },
+            { type: "PersonDescription", id: "p2", name: "Bob", readOnly: false },
+            { type: "PersonDescription", id: "p3", name: "Carol", readOnly: false },
+        ],
+        families: [
+            { type: "FamilyDescription", id: "f1", parents: ["p1", "p2"], children: ["p3"], readOnly: false },
+        ],
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// deriveGhosts (legacy API — kept for backward compat)
+// ---------------------------------------------------------------------------
+
+describe("deriveGhosts — no focus", () => {
+    it("returns empty list when focusedId is null", () => {
+        const index = new StemmaIndex(makeStemma());
+        expect(deriveGhosts(null, index)).toHaveLength(0);
+    });
+});
+
+describe("deriveGhosts — focused person with parent family", () => {
+    it("returns only a spouse ghost when person already has a parent family", () => {
+        const index = new StemmaIndex(makeStemma());
+        // p3 is a child in f1, so it already has a parent family
+        const ghosts = deriveGhosts({ kind: "person", id: "p3" }, index);
+        expect(ghosts).toHaveLength(1);
+        expect(ghosts[0].kind).toBe("spouse");
+        expect(ghosts[0].id).toBe("ghost-spouse");
+        expect(ghosts[0].labelKey).toBe("v3.addAnotherSpouse");
+    });
+});
+
+describe("deriveGhosts — focused person without parent family", () => {
+    it("returns spouse and parent ghosts when person has no parent family", () => {
+        const index = new StemmaIndex(makeStemma());
+        // p1 is a parent in f1, not a child of any family
+        const ghosts = deriveGhosts({ kind: "person", id: "p1" }, index);
+        expect(ghosts).toHaveLength(2);
+        const kinds = ghosts.map((g) => g.kind);
+        expect(kinds).toContain("spouse");
+        expect(kinds).toContain("parent");
+    });
+
+    it("assigns correct label keys", () => {
+        const index = new StemmaIndex(makeStemma());
+        const ghosts = deriveGhosts({ kind: "person", id: "p1" }, index);
+        const byKind = Object.fromEntries(ghosts.map((g) => [g.kind, g]));
+        expect(byKind["spouse"].labelKey).toBe("v3.addAnotherSpouse");
+        expect(byKind["parent"].labelKey).toBe("v3.addParent");
+    });
+
+    it("assigns stable dom ids", () => {
+        const index = new StemmaIndex(makeStemma());
+        const ghosts = deriveGhosts({ kind: "person", id: "p1" }, index);
+        const ids = ghosts.map((g) => g.id);
+        expect(ids).toContain("ghost-spouse");
+        expect(ids).toContain("ghost-parent");
+    });
+
+    it("applies non-zero seed offsets for parent (upward)", () => {
+        const index = new StemmaIndex(makeStemma());
+        const ghosts = deriveGhosts({ kind: "person", id: "p1" }, index);
+        const parent = ghosts.find((g) => g.kind === "parent")!;
+        expect(parent.dy).toBeLessThan(0);
+    });
+
+    it("applies non-zero seed offset for spouse (rightward)", () => {
+        const index = new StemmaIndex(makeStemma());
+        const ghosts = deriveGhosts({ kind: "person", id: "p1" }, index);
+        const spouse = ghosts.find((g) => g.kind === "spouse")!;
+        expect(spouse.dx).toBeGreaterThan(0);
+    });
+});
+
+describe("deriveGhosts — focused family", () => {
+    it("returns only a child ghost for a focused family", () => {
+        const index = new StemmaIndex(makeStemma());
+        const ghosts = deriveGhosts({ kind: "family", id: "f1" }, index);
+        expect(ghosts).toHaveLength(1);
+        expect(ghosts[0].kind).toBe("child");
+        expect(ghosts[0].id).toBe("ghost-child");
+        expect(ghosts[0].labelKey).toBe("v3.addChild");
+    });
+
+    it("applies non-zero seed offset for child (downward)", () => {
+        const index = new StemmaIndex(makeStemma());
+        const ghosts = deriveGhosts({ kind: "family", id: "f1" }, index);
+        expect(ghosts[0].dy).toBeGreaterThan(0);
+    });
+});
+
+describe("deriveGhosts — isolated person (no families)", () => {
+    it("returns spouse and parent ghosts for person with no family connections", () => {
+        const isolatedStemma: Stemma = {
+            type: "Stemma",
+            people: [{ type: "PersonDescription", id: "lone", name: "Lone", readOnly: false }],
+            families: [],
+        };
+        const index = new StemmaIndex(isolatedStemma);
+        const ghosts = deriveGhosts({ kind: "person", id: "lone" }, index);
+        expect(ghosts).toHaveLength(2);
+        expect(ghosts.map((g) => g.kind)).toContain("spouse");
+        expect(ghosts.map((g) => g.kind)).toContain("parent");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deriveGhostBranches — new branch-based API
+// ---------------------------------------------------------------------------
+
+describe("deriveGhostBranches — no focus", () => {
+    it("returns empty list when focusedId is null", () => {
+        const index = new StemmaIndex(makeStemma());
+        expect(deriveGhostBranches(null, index)).toHaveLength(0);
+    });
+});
+
+describe("deriveGhostBranches — focused person without parent family", () => {
+    it("returns 3 branches: spouse, parent, child", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        expect(branches).toHaveLength(3);
+        const kinds = branches.map((b) => b.kind);
+        expect(kinds).toContain("spouse");
+        expect(kinds).toContain("parent");
+        expect(kinds).toContain("child");
+    });
+
+    it("each branch has a ghost family id", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        for (const branch of branches) {
+            expect(branch.familyId).not.toBeNull();
+        }
+    });
+
+    it("spouse branch offsets are rightward", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        const spouse = branches.find((b) => b.kind === "spouse")!;
+        expect(spouse.familyDx).toBeGreaterThan(0);
+        expect(spouse.personDx).toBeGreaterThan(0);
+        expect(spouse.personDx).toBeGreaterThan(spouse.familyDx);
+    });
+
+    it("parent branch offsets are upward", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        const parent = branches.find((b) => b.kind === "parent")!;
+        expect(parent.familyDy).toBeLessThan(0);
+        expect(parent.personDy).toBeLessThan(0);
+        expect(parent.personDy).toBeLessThan(parent.familyDy);
+    });
+
+    it("child branch offsets are downward", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        const child = branches.find((b) => b.kind === "child")!;
+        expect(child.familyDy).toBeGreaterThan(0);
+        expect(child.personDy).toBeGreaterThan(0);
+        expect(child.personDy).toBeGreaterThan(child.familyDy);
+    });
+
+    it("assigns distinct stable DOM ids", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        const allIds = branches.flatMap((b) => [b.familyId, b.personId]).filter(Boolean);
+        const unique = new Set(allIds);
+        expect(unique.size).toBe(allIds.length);
+    });
+
+    it("assigns correct label keys", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        const byKind = Object.fromEntries(branches.map((b) => [b.kind, b]));
+        expect(byKind["spouse"].labelKey).toBe("v3.addAnotherSpouse");
+        expect(byKind["parent"].labelKey).toBe("v3.addParent");
+        expect(byKind["child"].labelKey).toBe("v3.addChild");
+    });
+});
+
+describe("deriveGhostBranches — focused person with parent family", () => {
+    it("returns 2 branches: spouse and child (no parent branch)", () => {
+        const index = new StemmaIndex(makeStemma());
+        // p3 is a child in f1
+        const branches = deriveGhostBranches({ kind: "person", id: "p3" }, index);
+        expect(branches).toHaveLength(2);
+        const kinds = branches.map((b) => b.kind);
+        expect(kinds).toContain("spouse");
+        expect(kinds).toContain("child");
+        expect(kinds).not.toContain("parent");
+    });
+});
+
+describe("deriveGhostBranches — focused family", () => {
+    it("returns 1 branch: child with no ghost family (familyId is null)", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "family", id: "f1" }, index);
+        expect(branches).toHaveLength(1);
+        expect(branches[0].kind).toBe("child");
+        expect(branches[0].familyId).toBeNull();
+    });
+
+    it("child branch for family-focused uses downward person offset", () => {
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "family", id: "f1" }, index);
+        expect(branches[0].personDy).toBeGreaterThan(0);
+    });
+});
+
+describe("deriveGhostBranches — isolated person", () => {
+    it("returns 3 branches for a person with no family connections", () => {
+        const isolatedStemma: Stemma = {
+            type: "Stemma",
+            people: [{ type: "PersonDescription", id: "lone", name: "Lone", readOnly: false }],
+            families: [],
+        };
+        const index = new StemmaIndex(isolatedStemma);
+        const branches = deriveGhostBranches({ kind: "person", id: "lone" }, index);
+        expect(branches).toHaveLength(3);
+        const kinds = branches.map((b) => b.kind);
+        expect(kinds).toContain("spouse");
+        expect(kinds).toContain("parent");
+        expect(kinds).toContain("child");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// immediateNeighborIds
+// ---------------------------------------------------------------------------
+
+describe("immediateNeighborIds — focused person", () => {
+    it("returns the containing family and all co-members, excluding the focused person", () => {
+        const index = new StemmaIndex(makeStemma());
+        // p1 is in f1 with p2 as co-parent and p3 as child
+        const refs = immediateNeighborIds({ kind: "person", id: "p1" }, index);
+        const ids = refs.map((r) => r.id);
+        expect(ids).toContain("f1");
+        expect(ids).toContain("p2");
+        expect(ids).toContain("p3");
+        expect(ids).not.toContain("p1");
+    });
+
+    it("tags families as kind=family and people as kind=person", () => {
+        const index = new StemmaIndex(makeStemma());
+        const refs = immediateNeighborIds({ kind: "person", id: "p1" }, index);
+        const byId = Object.fromEntries(refs.map((r) => [r.id, r.kind]));
+        expect(byId["f1"]).toBe("family");
+        expect(byId["p2"]).toBe("person");
+        expect(byId["p3"]).toBe("person");
+    });
+
+    it("returns empty list for an isolated person (no families)", () => {
+        const isolatedStemma: Stemma = {
+            type: "Stemma",
+            people: [{ type: "PersonDescription", id: "lone", name: "Lone", readOnly: false }],
+            families: [],
+        };
+        const index = new StemmaIndex(isolatedStemma);
+        const refs = immediateNeighborIds({ kind: "person", id: "lone" }, index);
+        expect(refs).toHaveLength(0);
+    });
+
+    it("does not include duplicates when a person shares multiple families", () => {
+        const multiStemma: Stemma = {
+            type: "Stemma",
+            people: [
+                { type: "PersonDescription", id: "a", name: "A", readOnly: false },
+                { type: "PersonDescription", id: "b", name: "B", readOnly: false },
+                { type: "PersonDescription", id: "c", name: "C", readOnly: false },
+            ],
+            families: [
+                { type: "FamilyDescription", id: "fA", parents: ["a", "b"], children: [], readOnly: false },
+                { type: "FamilyDescription", id: "fB", parents: ["a", "c"], children: [], readOnly: false },
+            ],
+        };
+        const index = new StemmaIndex(multiStemma);
+        const refs = immediateNeighborIds({ kind: "person", id: "a" }, index);
+        const ids = refs.map((r) => r.id);
+        // 'a' itself must not appear; b, c, fA, fB must each appear exactly once
+        expect(ids.filter((id) => id === "a")).toHaveLength(0);
+        expect(ids.filter((id) => id === "b")).toHaveLength(1);
+        expect(ids.filter((id) => id === "c")).toHaveLength(1);
+        expect(ids.filter((id) => id === "fA")).toHaveLength(1);
+        expect(ids.filter((id) => id === "fB")).toHaveLength(1);
+    });
+});
+
+describe("immediateNeighborIds — focused family", () => {
+    it("returns all parents and children, excluding the focused family id", () => {
+        const index = new StemmaIndex(makeStemma());
+        // f1 has parents [p1, p2] and children [p3]
+        const refs = immediateNeighborIds({ kind: "family", id: "f1" }, index);
+        const ids = refs.map((r) => r.id);
+        expect(ids).toContain("p1");
+        expect(ids).toContain("p2");
+        expect(ids).toContain("p3");
+        expect(ids).not.toContain("f1");
+    });
+
+    it("all refs for focused family are kind=person", () => {
+        const index = new StemmaIndex(makeStemma());
+        const refs = immediateNeighborIds({ kind: "family", id: "f1" }, index);
+        for (const ref of refs) {
+            expect(ref.kind).toBe("person");
+        }
+    });
+
+    it("returns empty list for a family with no members", () => {
+        const emptyStemma: Stemma = {
+            type: "Stemma",
+            people: [],
+            families: [
+                { type: "FamilyDescription", id: "empty-fam", parents: [], children: [], readOnly: false },
+            ],
+        };
+        const index = new StemmaIndex(emptyStemma);
+        const refs = immediateNeighborIds({ kind: "family", id: "empty-fam" }, index);
+        expect(refs).toHaveLength(0);
+    });
+});

--- a/frontend/src/v3/ghostHelpers.ts
+++ b/frontend/src/v3/ghostHelpers.ts
@@ -1,0 +1,232 @@
+/**
+ * Pure helpers for the v3 ghost-node affordances.
+ *
+ * Ghosts are dashed placeholder nodes rendered around the focused entity to
+ * invite the user to add a spouse, parent, or child without needing drag
+ * gestures.  All logic here is pure so it can be unit-tested without a DOM.
+ */
+
+import type { FocusedId } from "./focusGesture";
+import type { StemmaIndex } from "../stemmaIndex";
+
+export type GhostKind = "spouse" | "parent" | "child";
+
+/** Legacy action type used by V3FamilyGhost popover component. */
+export type GhostFamilyAction = "addChild" | "addParent";
+
+export type GhostDescriptor = {
+    /** Stable DOM id assigned to the ghost <g> element. */
+    id: string;
+    kind: GhostKind;
+    /** i18n key for the ghost label. */
+    labelKey: string;
+    /** Offset from the focused node's (x, y) in SVG user-space. */
+    dx: number;
+    dy: number;
+};
+
+/**
+ * A ghost branch consists of an intermediate ghost family node and an endpoint
+ * ghost person node, both positioned relative to the focused real node.
+ *
+ * When the focused entity is a family, there is no intermediate ghost family —
+ * only a ghost person (child).  In that case `family` is null.
+ */
+export type GhostBranch = {
+    kind: GhostKind;
+    /** Stable DOM ids for the ghost family <g> and ghost person <g>. */
+    familyId: string | null;
+    personId: string;
+    /** i18n key for the ghost person label. */
+    labelKey: string;
+    /**
+     * Seed offsets (SVG user-space) from the focused node's center.
+     * family* offsets are the intermediate node; person* offsets are the endpoint.
+     */
+    familyDx: number;
+    familyDy: number;
+    personDx: number;
+    personDy: number;
+};
+
+const GHOST_OFFSETS: Record<GhostKind, { dx: number; dy: number }> = {
+    spouse: { dx: 100, dy: 0 },
+    parent: { dx: 0, dy: -100 },
+    child: { dx: 0, dy: 100 },
+};
+
+const GHOST_LABEL_KEYS: Record<GhostKind, string> = {
+    spouse: "v3.addAnotherSpouse",
+    parent: "v3.addParent",
+    child: "v3.addChild",
+};
+
+/**
+ * Derives the list of ghost descriptors for the currently focused entity.
+ *
+ * Rules (per CLAUDE.md):
+ * - Focused person → spouse-ghost (always) + parent-ghost (only if person
+ *   has no parent family).
+ * - Focused family → child-ghost (always).
+ * - No focus → empty list.
+ *
+ * @deprecated Use deriveGhostBranches for the new branch-based rendering.
+ */
+export function deriveGhosts(
+    focusedId: FocusedId | null,
+    stemmaIndex: StemmaIndex,
+): readonly GhostDescriptor[] {
+    if (!focusedId) return [];
+
+    if (focusedId.kind === "person") {
+        const ghosts: GhostDescriptor[] = [ghostDescriptor("spouse")];
+        if (!stemmaIndex.hasParentFamily(focusedId.id)) {
+            ghosts.push(ghostDescriptor("parent"));
+        }
+        return ghosts;
+    }
+
+    if (focusedId.kind === "family") {
+        return [ghostDescriptor("child")];
+    }
+
+    return [];
+}
+
+function ghostDescriptor(kind: GhostKind): GhostDescriptor {
+    const { dx, dy } = GHOST_OFFSETS[kind];
+    return {
+        id: `ghost-${kind}`,
+        kind,
+        labelKey: GHOST_LABEL_KEYS[kind],
+        dx,
+        dy,
+    };
+}
+
+export type NeighborRef = { kind: "person" | "family"; id: string };
+
+/**
+ * Returns the immediate (1-hop) neighbors of the focused entity in the family
+ * graph as tagged refs.  These nodes are unfrozen during ghost physics so the
+ * ghost branch can push them aside if needed.
+ *
+ * For a focused person P:
+ *   every family F that contains P  +  every person Q that shares a family with P.
+ * For a focused family F:
+ *   every person in F's parents and children.
+ * The focused node itself is NOT included (it is frozen separately).
+ */
+export function immediateNeighborIds(focusedId: FocusedId, stemmaIndex: StemmaIndex): readonly NeighborRef[] {
+    const seen = new Set<string>();
+    const refs: NeighborRef[] = [];
+
+    const addPerson = (id: string) => {
+        if (!seen.has(id) && id !== focusedId.id) {
+            seen.add(id);
+            refs.push({ kind: "person", id });
+        }
+    };
+    const addFamily = (id: string) => {
+        if (!seen.has(id) && id !== focusedId.id) {
+            seen.add(id);
+            refs.push({ kind: "family", id });
+        }
+    };
+
+    if (focusedId.kind === "person") {
+        const families = stemmaIndex.relatedFamilies(focusedId.id);
+        for (const f of families) {
+            addFamily(f.id);
+            for (const pid of f.parents) addPerson(pid);
+            for (const pid of f.children) addPerson(pid);
+        }
+        return refs;
+    }
+
+    if (focusedId.kind === "family") {
+        const f = stemmaIndex.family(focusedId.id);
+        if (f) {
+            for (const pid of f.parents) addPerson(pid);
+            for (const pid of f.children) addPerson(pid);
+        }
+        return refs;
+    }
+
+    return refs;
+}
+
+/**
+ * Derives ghost branches for the currently focused entity.
+ *
+ * Each branch for a focused person contains an intermediate ghost family node
+ * and an endpoint ghost person node.  For a focused family the branch has no
+ * intermediate ghost family (the family already exists) — only a ghost person.
+ *
+ * Seed offsets (SVG user-space, relative to focused node center):
+ * - spouse:  ghost family at (+80, 0), ghost person at (+160, 0)
+ * - parent:  ghost family at (0, -80), ghost person at (0, -160)
+ * - child (person-focused): ghost family at (0, +80), ghost person at (0, +160)
+ * - child (family-focused): ghost person at (0, +100) — no ghost family
+ */
+export function deriveGhostBranches(
+    focusedId: FocusedId | null,
+    stemmaIndex: StemmaIndex,
+): readonly GhostBranch[] {
+    if (!focusedId) return [];
+
+    if (focusedId.kind === "person") {
+        const branches: GhostBranch[] = [
+            {
+                kind: "spouse",
+                familyId: "ghost-family-spouse",
+                personId: "ghost-person-spouse",
+                labelKey: GHOST_LABEL_KEYS["spouse"],
+                familyDx: 80,
+                familyDy: 0,
+                personDx: 160,
+                personDy: 0,
+            },
+        ];
+        if (!stemmaIndex.hasParentFamily(focusedId.id)) {
+            branches.push({
+                kind: "parent",
+                familyId: "ghost-family-parent",
+                personId: "ghost-person-parent",
+                labelKey: GHOST_LABEL_KEYS["parent"],
+                familyDx: 0,
+                familyDy: -80,
+                personDx: 0,
+                personDy: -160,
+            });
+        }
+        branches.push({
+            kind: "child",
+            familyId: "ghost-family-child",
+            personId: "ghost-person-child",
+            labelKey: GHOST_LABEL_KEYS["child"],
+            familyDx: 0,
+            familyDy: 80,
+            personDx: 0,
+            personDy: 160,
+        });
+        return branches;
+    }
+
+    if (focusedId.kind === "family") {
+        return [
+            {
+                kind: "child",
+                familyId: null,
+                personId: "ghost-person-child",
+                labelKey: GHOST_LABEL_KEYS["child"],
+                familyDx: 0,
+                familyDy: 0,
+                personDx: GHOST_OFFSETS["child"].dx,
+                personDy: GHOST_OFFSETS["child"].dy,
+            },
+        ];
+    }
+
+    return [];
+}


### PR DESCRIPTION
## Summary
- New \`/v3\` route forks v2 and layers explicit ghost-node affordances for adding spouses, parents, and children. Drag gestures from v2 remain unchanged.
- Implements the v3 epic tickets #193–#200 plus rework #201: focused-person ghosts render as branches through an intermediate ghost family (only the endpoint ghost person is clickable). Ghosts appear only in edit mode. 150 px distance-based focus radius. Physics freezes the tree except for the focused node's immediate neighbours, with snap-back on blur.
- Three v3.* i18n keys added in both \`en\` and \`ru\`.
- Pure helpers (\`focusGesture.ts\`, \`ghostHelpers.ts\`) with unit coverage; e2e smoke for the /v3 chrome and edit-mode-only ghost rendering.

## Follow-ups
- #202 — ghost visuals + reachability of the click hit-zone
- #203 — split \`V3App.svelte\` (~2.3k LoC) into focused components

## Test plan
- [ ] \`cd frontend && npm run check\` passes (0 errors)
- [ ] \`cd frontend && npm test\` passes (195+ tests including new focusGesture / ghostHelpers suites)
- [ ] \`cd frontend && npm run build\` succeeds
- [ ] \`cd e2e && npx playwright test\` — v3 smoke + v2 regression
- [ ] Manual: visit \`/v3\`, enter edit mode, hover a person → ghost branches appear; \`/v2\` still renders v2 verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)