### PR TITLE
fix(v3): make ghost circle clickable + hover highlight (#207)

### DIFF
--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -404,21 +404,32 @@
 <style>
     :global(g.v3-ghost) {
         opacity: 0.6;
-        cursor: default;
+        cursor: pointer;
+        pointer-events: all;
         transition: opacity 200ms ease;
     }
 
+    :global(g.v3-ghost:hover) {
+        opacity: 0.9;
+    }
+
     :global(g.v3-ghost > circle) {
-        fill: none;
+        fill: transparent;
         stroke: #6c757d;
         stroke-width: 1.5px;
         stroke-dasharray: 5 3;
-        pointer-events: none;
+    }
+
+    :global(g.v3-ghost:hover > circle) {
+        stroke: #0d6efd;
     }
 
     :global(g.v3-ghost .v3-ghost-label) {
         fill: #6c757d;
-        pointer-events: none;
+    }
+
+    :global(g.v3-ghost:hover .v3-ghost-label) {
+        fill: #0d6efd;
     }
 
     :global(line.v3-ghost-edge) {


### PR DESCRIPTION
## Summary

- Drop `pointer-events: none` from `g.v3-ghost > circle` and `g.v3-ghost .v3-ghost-label` so the elements no longer swallow hits.
- Set `pointer-events: all` and `cursor: pointer` on `g.v3-ghost` so the entire ghost node (including the hollow interior) is a valid hit target.
- Change `fill: none` → `fill: transparent` on the circle — SVG `fill:none` means the interior is geometrically invisible to pointer events; `transparent` preserves the visual while making the disk fully clickable.
- `g.v3-ghost-family` keeps `pointer-events: none` per #202 — unchanged.
- Add `:hover` rules on `g.v3-ghost`: opacity 0.6 → 0.9; stroke + label fill tinted to `#0d6efd` (Bootstrap primary blue, already used in `V3DragGestures.svelte` — no new palette tokens).

Closes #207.

## Test plan

- [ ] `npm test` — 195 tests pass.
- [ ] `npm run check` — 0 svelte-check errors/warnings.
- [ ] Manual: hover a ghost node in the browser — cursor changes to pointer, opacity lifts, stroke and label turn blue.
- [ ] Manual: click inside the hollow circle — create-person modal opens (not just clicks on the dashed stroke).
- [ ] E2E `cd e2e && npm test -- --grep v3` smoke (note: requires Docker for DynamoDB Local + full stack — skipped in this PR but runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)