### PR TITLE
feat(v3): ghost edges terminate at circle boundary with arrow markers and correct widths

### DIFF
--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
     import * as d3 from "d3";
     import { normalizeId } from "../../graphTools";
-    import { personR, familyR, labelFontSize } from "../../graphStyles";
+    import { personR, familyR, labelFontSize, familyRelationWidth, childRelationWidth, arrowPath } from "../../graphStyles";
     import { t } from "../../i18n";
     import type { StemmaIndex } from "../../stemmaIndex";
     import type { FocusedId } from "../focusGesture";
     import { deriveGhostBranches, immediateNeighborIds, type GhostKind } from "../ghostHelpers";
     import { nodeCenter } from "../v3DomGeometry";
+    import { trimToCircle } from "../ghostEdgeGeometry";
 
     type Props = {
         focusedId: FocusedId | null;
@@ -19,6 +20,37 @@
     let { focusedId, stemmaIndex, stemmaChartReady, onghostClick, onpositionsChange }: Props = $props();
 
     const SVG_NS = "http://www.w3.org/2000/svg";
+    const GHOST_COLOR = "#6c757d";
+    const GHOST_ARROW_TO_FAMILY_ID = "v3-ghost-arrow-to-family";
+    const GHOST_ARROW_TO_PERSON_ID = "v3-ghost-arrow-to-person";
+
+    function ensureGhostMarkers(svgEl: SVGSVGElement): void {
+        if (svgEl.querySelector(`#${GHOST_ARROW_TO_FAMILY_ID}`)) return;
+        let defs = svgEl.querySelector("defs");
+        if (!defs) {
+            defs = document.createElementNS(SVG_NS, "defs") as SVGDefsElement;
+            svgEl.insertBefore(defs, svgEl.firstChild);
+        }
+        for (const { id, refX } of [
+            { id: GHOST_ARROW_TO_FAMILY_ID, refX: 10 },
+            { id: GHOST_ARROW_TO_PERSON_ID, refX: 10 },
+        ]) {
+            const marker = document.createElementNS(SVG_NS, "marker") as SVGMarkerElement;
+            marker.setAttribute("id", id);
+            marker.setAttribute("viewBox", "0 0 10 6");
+            marker.setAttribute("refX", String(refX));
+            marker.setAttribute("refY", "3");
+            marker.setAttribute("markerWidth", "10");
+            marker.setAttribute("markerHeight", "6");
+            marker.setAttribute("markerUnits", "userSpaceOnUse");
+            marker.setAttribute("orient", "auto");
+            const path = document.createElementNS(SVG_NS, "path") as SVGPathElement;
+            path.setAttribute("d", arrowPath);
+            path.style.fill = GHOST_COLOR;
+            marker.appendChild(path);
+            defs.appendChild(marker);
+        }
+    }
 
     // Tracks ghost DOM elements that are currently fading out so they can be
     // removed after the CSS transition completes even when a new focus takes
@@ -50,6 +82,7 @@
         const svgEl = document.getElementById("chart") as unknown as SVGSVGElement | null;
         const mainG = svgEl?.querySelector("g.main") as SVGGElement | null;
         if (!svgEl || !mainG) return;
+        ensureGhostMarkers(svgEl);
 
         // Snapshot every real node position before any freeze decision.
         type Snapshot = { x: number; y: number };
@@ -128,6 +161,8 @@
 
         const allGhostEls: Element[] = [];
 
+        type EdgeKind = "focusToFamily" | "familyToPerson" | "focusToPerson";
+
         type BranchSimEntry = {
             familySimNode: SimNode | null;
             personSimNode: SimNode;
@@ -139,13 +174,20 @@
         };
         const branchEntries: BranchSimEntry[] = [];
 
-        const makeLine = (x1: number, y1: number, x2: number, y2: number): SVGLineElement => {
+        const makeLine = (x1: number, y1: number, x2: number, y2: number, edgeKind: EdgeKind): SVGLineElement => {
             const line = document.createElementNS(SVG_NS, "line") as SVGLineElement;
             line.setAttribute("class", "v3-ghost-edge");
             line.setAttribute("x1", String(x1));
             line.setAttribute("y1", String(y1));
             line.setAttribute("x2", String(x2));
             line.setAttribute("y2", String(y2));
+            if (edgeKind === "focusToFamily") {
+                line.setAttribute("stroke-width", familyRelationWidth);
+                line.setAttribute("marker-end", `url(#${GHOST_ARROW_TO_FAMILY_ID})`);
+            } else {
+                line.setAttribute("stroke-width", childRelationWidth);
+                line.setAttribute("marker-end", `url(#${GHOST_ARROW_TO_PERSON_ID})`);
+            }
             line.style.opacity = "0";
             mainG.appendChild(line);
             allGhostEls.push(line);
@@ -205,9 +247,9 @@
                 const familySeedY = origin ? origin.y + branch.familyDy : branch.familyDy;
 
                 const edgeFocusToFamily = origin
-                    ? makeLine(origin.x, origin.y, familySeedX, familySeedY)
+                    ? makeLine(origin.x, origin.y, familySeedX, familySeedY, "focusToFamily")
                     : null;
-                const edgeFamilyToPerson = makeLine(familySeedX, familySeedY, personSeedX, personSeedY);
+                const edgeFamilyToPerson = makeLine(familySeedX, familySeedY, personSeedX, personSeedY, "familyToPerson");
 
                 const familyEl = makeGhostFamilyEl(branch.familyId, familySeedX, familySeedY);
                 const personEl = makeGhostPersonEl(branch.personId, personSeedX, personSeedY, branch.labelKey);
@@ -246,7 +288,7 @@
                 });
             } else {
                 const edgeFocusToPerson = origin
-                    ? makeLine(origin.x, origin.y, personSeedX, personSeedY)
+                    ? makeLine(origin.x, origin.y, personSeedX, personSeedY, "focusToPerson")
                     : null;
                 const personEl = makeGhostPersonEl(branch.personId, personSeedX, personSeedY, branch.labelKey);
 
@@ -345,18 +387,22 @@
                     familyEl.setAttribute("transform", `translate(${familySimNode.x},${familySimNode.y})`);
                     nextPositions.push({ x: familySimNode.x, y: familySimNode.y });
                     if (edgeFocusToFamily && origin) {
-                        edgeFocusToFamily.setAttribute("x2", String(familySimNode.x));
-                        edgeFocusToFamily.setAttribute("y2", String(familySimNode.y));
+                        const trimmed = trimToCircle(origin.x, origin.y, familySimNode.x, familySimNode.y, familyR);
+                        edgeFocusToFamily.setAttribute("x2", String(trimmed.x));
+                        edgeFocusToFamily.setAttribute("y2", String(trimmed.y));
                     }
                     if (edgeFamilyToPerson) {
-                        edgeFamilyToPerson.setAttribute("x1", String(familySimNode.x));
-                        edgeFamilyToPerson.setAttribute("y1", String(familySimNode.y));
-                        edgeFamilyToPerson.setAttribute("x2", String(personSimNode.x));
-                        edgeFamilyToPerson.setAttribute("y2", String(personSimNode.y));
+                        const trimmedStart = trimToCircle(personSimNode.x, personSimNode.y, familySimNode.x, familySimNode.y, familyR);
+                        const trimmedEnd = trimToCircle(familySimNode.x, familySimNode.y, personSimNode.x, personSimNode.y, personR);
+                        edgeFamilyToPerson.setAttribute("x1", String(trimmedStart.x));
+                        edgeFamilyToPerson.setAttribute("y1", String(trimmedStart.y));
+                        edgeFamilyToPerson.setAttribute("x2", String(trimmedEnd.x));
+                        edgeFamilyToPerson.setAttribute("y2", String(trimmedEnd.y));
                     }
                 } else if (edgeFocusToFamily && origin) {
-                    edgeFocusToFamily.setAttribute("x2", String(personSimNode.x));
-                    edgeFocusToFamily.setAttribute("y2", String(personSimNode.y));
+                    const trimmed = trimToCircle(origin.x, origin.y, personSimNode.x, personSimNode.y, personR);
+                    edgeFocusToFamily.setAttribute("x2", String(trimmed.x));
+                    edgeFocusToFamily.setAttribute("y2", String(trimmed.y));
                 }
             }
             if (!positionsEqual(nextPositions, lastPositions)) {
@@ -423,7 +469,6 @@
 
     :global(line.v3-ghost-edge) {
         stroke: #6c757d;
-        stroke-width: 1px;
         stroke-dasharray: 4 3;
         opacity: 0.5;
         pointer-events: none;

--- a/frontend/src/v3/ghostEdgeGeometry.test.ts
+++ b/frontend/src/v3/ghostEdgeGeometry.test.ts
@@ -1,0 +1,32 @@
+import { trimToCircle } from "./ghostEdgeGeometry";
+
+describe("trimToCircle", () => {
+    it("returns a point on the circle boundary along the given direction", () => {
+        const result = trimToCircle(0, 0, 100, 0, 15);
+        expect(result.x).toBeCloseTo(85, 5);
+        expect(result.y).toBeCloseTo(0, 5);
+    });
+
+    it("works for diagonal lines", () => {
+        const result = trimToCircle(0, 0, 30, 40, 5);
+        // dist = 50, scale = 45/50 = 0.9
+        expect(result.x).toBeCloseTo(27, 5);
+        expect(result.y).toBeCloseTo(36, 5);
+    });
+
+    it("returns the target center when line length is less than radius", () => {
+        const result = trimToCircle(0, 0, 3, 4, 10);
+        expect(result).toEqual({ x: 3, y: 4 });
+    });
+
+    it("returns the target center when line length equals radius exactly", () => {
+        const result = trimToCircle(0, 0, 5, 0, 5);
+        expect(result).toEqual({ x: 5, y: 0 });
+    });
+
+    it("handles vertical lines", () => {
+        const result = trimToCircle(0, 0, 0, 100, 20);
+        expect(result.x).toBeCloseTo(0, 5);
+        expect(result.y).toBeCloseTo(80, 5);
+    });
+});

--- a/frontend/src/v3/ghostEdgeGeometry.ts
+++ b/frontend/src/v3/ghostEdgeGeometry.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure geometry helpers for positioning ghost edges.
+ */
+
+/**
+ * Returns the point along the line from (x1,y1) to (x2,y2) that lies on the
+ * circumference of a circle of radius `r` centered at (x2,y2).
+ *
+ * When the line is shorter than the radius the target center is returned
+ * unchanged (degenerate case — avoids division by zero and sign flips).
+ */
+export function trimToCircle(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    r: number,
+): { x: number; y: number } {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= r) return { x: x2, y: y2 };
+    const scale = (dist - r) / dist;
+    return { x: x1 + dx * scale, y: y1 + dy * scale };
+}


### PR DESCRIPTION
## Summary

- Ghost edges now render with the same arrow markers and per-edge stroke widths as real edges (dashed + gray).
- Two ghost SVG markers are injected into `<defs>` on first render: `v3-ghost-arrow-to-family` and `v3-ghost-arrow-to-person`, gray (`#6c757d`), `refX=10` so the tip sits exactly at the trimmed line endpoint.
- `focusToFamily` edges use `familyRelationWidth` (2.5 px); `familyToPerson` and `focusToPerson` edges use `childRelationWidth` (0.5 px).
- Each ghost line endpoint is trimmed in the simulation tick callback so the line terminates at the target circle's circumference (`personR` or `familyR`) rather than its center — no visible segment inside hollow ghost circles.
- `trimToCircle` pure geometry helper extracted to `ghostEdgeGeometry.ts` with full unit test coverage.

## Test plan

- [x] `npm test` — 200 tests pass (includes new `ghostEdgeGeometry.test.ts`)
- [x] `npm run check` — svelte-check 0 errors, 0 warnings
- [ ] `cd e2e && npm test -- --grep v3` — requires Docker for DynamoDB Local; not run locally but will execute in CI

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)