### PR TITLE
fix(v3): tighten ghost focus zone to node radius, extract cursorNearGhost

### DIFF
--- a/frontend/src/v3/components/V3FocusController.svelte
+++ b/frontend/src/v3/components/V3FocusController.svelte
@@ -3,10 +3,12 @@
         FOCUS_RADIUS_SVG,
         MOUSE_LEAVE_DEBOUNCE_MS,
         nearestNodeWithinRadius,
+        cursorNearGhost,
         type FocusedId,
     } from "../focusGesture";
     import { isPendingId } from "../pendingState";
     import { clientToSvgPoint } from "../v3DomGeometry";
+    import { personR } from "../../graphStyles";
 
 
     type Props = {
@@ -43,10 +45,7 @@
             const svgPt = clientToSvgPoint(svgEl as unknown as SVGSVGElement, e.clientX, e.clientY);
             const next = nearestNodeWithinRadius(mainG, svgPt.x, svgPt.y, FOCUS_RADIUS_SVG, isPendingId);
             if (!next) {
-                const nearGhost = ghostSimPositions.some(
-                    (p) => Math.hypot(p.x - svgPt.x, p.y - svgPt.y) <= FOCUS_RADIUS_SVG,
-                );
-                if (nearGhost) {
+                if (cursorNearGhost(ghostSimPositions, svgPt.x, svgPt.y, personR)) {
                     cancelLeave();
                     return;
                 }

--- a/frontend/src/v3/focusGesture.test.ts
+++ b/frontend/src/v3/focusGesture.test.ts
@@ -1,4 +1,4 @@
-import { isShortTap, isLongPress, focusedIdFromG, closestNodeG, TAP_MAX_MS, TAP_MAX_MOVE_PX } from "./focusGesture";
+import { isShortTap, isLongPress, focusedIdFromG, closestNodeG, cursorNearGhost, TAP_MAX_MS, TAP_MAX_MOVE_PX, FOCUS_RADIUS_SVG } from "./focusGesture";
 
 describe("isShortTap", () => {
     it("returns true when elapsed < TAP_MAX_MS and moved <= TAP_MAX_MOVE_PX", () => {
@@ -89,5 +89,66 @@ describe("closestNodeG", () => {
     it("returns null when no ancestor matches", () => {
         const div = document.createElement("div");
         expect(closestNodeG(div)).toBeNull();
+    });
+});
+
+describe("cursorNearGhost", () => {
+    it("returns false when positions list is empty", () => {
+        expect(cursorNearGhost([], 0, 0, FOCUS_RADIUS_SVG)).toBe(false);
+    });
+
+    it("returns true when cursor is exactly on a ghost center", () => {
+        expect(cursorNearGhost([{ x: 100, y: 200 }], 100, 200, FOCUS_RADIUS_SVG)).toBe(true);
+    });
+
+    it("returns true when cursor is within hitRadius of a ghost center", () => {
+        // ghost at (160, 0), cursor at (12, 0) — distance = 148, within FOCUS_RADIUS_SVG=150
+        expect(cursorNearGhost([{ x: 160, y: 0 }], 12, 0, FOCUS_RADIUS_SVG)).toBe(true);
+    });
+
+    it("returns false when cursor is just outside hitRadius of all ghosts", () => {
+        // ghost at (160, 0), cursor at (9, 0) — distance = 151, outside FOCUS_RADIUS_SVG=150
+        expect(cursorNearGhost([{ x: 160, y: 0 }], 9, 0, FOCUS_RADIUS_SVG)).toBe(false);
+    });
+
+    it("returns true when cursor is within the rendered node radius of a ghost center (personR extension)", () => {
+        // Ghost person center at (160, 0). Cursor at (152, 0): distance to ghost = 8px.
+        // Without personR extension, this is well within range. This test verifies
+        // that at the edge of the gap (cursor between real-node radius and ghost),
+        // focus is preserved once ghost positions are known.
+        const ghostPersonR = 15;
+        // cursor is exactly personR pixels past the real-node focus radius, and
+        // personR pixels before the ghost center — should still keep focus
+        const cursorX = FOCUS_RADIUS_SVG + 1; // just outside real-node radius
+        const ghostX = FOCUS_RADIUS_SVG + 1 + ghostPersonR - 1; // ghost center is personR-1 away
+        expect(cursorNearGhost([{ x: ghostX, y: 0 }], cursorX, 0, ghostPersonR)).toBe(true);
+    });
+
+    it("returns true for any ghost when multiple positions provided", () => {
+        const positions = [
+            { x: 500, y: 500 },
+            { x: 160, y: 0 },
+        ];
+        // cursor near second ghost
+        expect(cursorNearGhost(positions, 15, 0, FOCUS_RADIUS_SVG)).toBe(true);
+    });
+
+    it("covers the traversal gap between real-node radius and ghost seed position", () => {
+        // Simulates cursor moving from real node (0,0) toward a ghost person at (160,0).
+        // Ghost person rendered radius is personR=15.
+        // Real node focus radius is FOCUS_RADIUS_SVG=150.
+        // At cursor position (155,0): distance to real node = 155 > 150, so real node doesn't help.
+        // Distance to ghost center = 5 < personR=15, so ghost hit radius keeps focus.
+        const ghostPersonR = 15;
+        expect(cursorNearGhost([{ x: 160, y: 0 }], 155, 0, ghostPersonR)).toBe(true);
+    });
+
+    it("does NOT keep focus when cursor is in the true gap (beyond real radius, beyond ghost radius)", () => {
+        // ghost at (160,0), personR=15. Cursor at (145,0): distance to ghost=15 which equals personR.
+        // At ghost hit radius boundary: distance=personR should be included (<=), so this is true.
+        const ghostPersonR = 15;
+        expect(cursorNearGhost([{ x: 160, y: 0 }], 145, 0, ghostPersonR)).toBe(true);
+        // cursor at (144,0): distance to ghost=16 > personR=15, so NOT near ghost
+        expect(cursorNearGhost([{ x: 160, y: 0 }], 144, 0, ghostPersonR)).toBe(false);
     });
 });

--- a/frontend/src/v3/focusGesture.ts
+++ b/frontend/src/v3/focusGesture.ts
@@ -17,6 +17,23 @@ export const TAP_MAX_MOVE_PX = 10;
 export const FOCUS_RADIUS_SVG = 150;
 
 /**
+ * Returns true when the cursor position is within `hitRadius` SVG user-space
+ * units of any ghost position.
+ *
+ * Using the ghost's rendered node radius as `hitRadius` ensures the focus zone
+ * exactly covers the ghost's visual circle and closes the traversal gap between
+ * the real-node focus radius and the ghost seed distance.
+ */
+export function cursorNearGhost(
+    positions: ReadonlyArray<{ x: number; y: number }>,
+    cursorSvgX: number,
+    cursorSvgY: number,
+    hitRadius: number,
+): boolean {
+    return positions.some((p) => Math.hypot(p.x - cursorSvgX, p.y - cursorSvgY) <= hitRadius);
+}
+
+/**
  * Returns true when a pointerup event qualifies as a short tap (no drag, no
  * long press). All inputs are the raw numbers so this function is pure and
  * trivially testable.


### PR DESCRIPTION
## Summary

- Extracts `cursorNearGhost` pure helper from `focusGesture.ts` (previously an inline `Array.some` in the component) so it can be unit-tested.
- Changes the ghost proximity check in `V3FocusController` from `FOCUS_RADIUS_SVG` (150 px) to `personR` (15 px), matching the ghost node's rendered radius.
- The real-node zone [0, 150 px] and ghost zone [160 ± 15 = 145–175 px] overlap at 145–150 px, guaranteeing gap-free cursor traversal from a focused node to any of its ghost persons.
- Ghost family nodes (`pointer-events: none`) are already excluded from the sim positions passed to the check.
- 8 new unit tests in `focusGesture.test.ts` covering all `cursorNearGhost` branch cases and the traversal-gap scenario.

## Test plan

- [x] `npm test` — 203 tests, all pass (8 new)
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Manual: hover a real node in edit mode, move cursor toward ghost → ghost stays visible and is clickable
- [ ] v2 view unaffected (no v2 files touched)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)