### PR TITLE
feat(v3): inject ghost-child into existing spouse-families with real-sim physics

### DIFF
--- a/frontend/src/stemmaIndex.ts
+++ b/frontend/src/stemmaIndex.ts
@@ -115,6 +115,12 @@ export class StemmaIndex {
         return this._childToParents.has(personId)
     }
 
+    spouseFamilyIds(personId: string): string[] {
+        const entries = this._parentToChildren.get(personId)
+        if (!entries) return []
+        return entries.map(e => e.familyId)
+    }
+
     private computeLineage(personId: string, relation: Map<string, DirectedFamilyDescription[]>) {
         var foundRelatieves: string[] = []
         var foundFamilies: string[] = []

--- a/frontend/src/v3/V3App.svelte
+++ b/frontend/src/v3/V3App.svelte
@@ -268,7 +268,7 @@
             {focusedId}
             stemmaIndex={displayedStemmaIndex}
             stemmaChartReady={!!stemmaChart}
-            onghostClick={(kind, focused, pos) => actions.onGhostClick(kind, focused, pos)}
+            onghostClick={(kind, focused, pos, existingFamilyId) => actions.onGhostClick(kind, focused, pos, existingFamilyId)}
             onpositionsChange={(p) => (ghostSimPositions = p)}
         />
         <V3DragGestures

--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -12,7 +12,7 @@
         focusedId: FocusedId | null;
         stemmaIndex: StemmaIndex | null;
         stemmaChartReady: boolean;
-        onghostClick: (kind: GhostKind, focused: FocusedId, ghostPos: { x: number; y: number }) => void;
+        onghostClick: (kind: GhostKind, focused: FocusedId, ghostPos: { x: number; y: number }, existingFamilyId?: string) => void;
         onpositionsChange: (positions: Array<{ x: number; y: number }>) => void;
     };
 
@@ -136,6 +136,8 @@
             edgeFocusToFamily: SVGLineElement | null;
             edgeFamilyToPerson: SVGLineElement | null;
             kind: GhostKind;
+            /** Real family sim node for existingFamilyId branches — used to update the edge source in tick. */
+            realFamilySimNode: SimNode | null;
         };
         const branchEntries: BranchSimEntry[] = [];
 
@@ -193,14 +195,23 @@
             return gEl;
         };
 
+        // simNodeById allows building forceLink references to both real and ghost nodes.
+        const simNodeById = new Map<string, SimNode>();
+        for (const n of realSimNodes) simNodeById.set(n.id, n);
+
+        type SimLink = { source: SimNode; target: SimNode };
+        const simLinks: SimLink[] = [];
+
         for (const branch of branches) {
             const personSeedX = origin ? origin.x + branch.personDx : branch.personDx;
             const personSeedY = origin ? origin.y + branch.personDy : branch.personDy;
 
             const capturedFocusedId = focusedId;
             const capturedKind = branch.kind;
+            const capturedExistingFamilyId = branch.existingFamilyId;
 
             if (branch.familyId !== null) {
+                // Ghost family intermediate node exists.
                 const familySeedX = origin ? origin.x + branch.familyDx : branch.familyDx;
                 const familySeedY = origin ? origin.y + branch.familyDy : branch.familyDy;
 
@@ -228,6 +239,13 @@
                     seedY: personSeedY,
                     isGhost: true,
                 };
+                simNodeById.set(familySimNode.id, familySimNode);
+                simNodeById.set(personSimNode.id, personSimNode);
+
+                // Link: focus → ghost family → ghost person.
+                const focusSimNode = focusDomId ? simNodeById.get(focusDomId) : null;
+                if (focusSimNode) simLinks.push({ source: focusSimNode, target: familySimNode });
+                simLinks.push({ source: familySimNode, target: personSimNode });
 
                 branchEntries.push({
                     familySimNode,
@@ -237,14 +255,59 @@
                     edgeFocusToFamily,
                     edgeFamilyToPerson,
                     kind: capturedKind,
+                    realFamilySimNode: null,
                 });
 
                 personEl.addEventListener("pointerup", (e: PointerEvent) => {
                     e.stopPropagation();
                     const ghostPos = { x: personSimNode.x, y: personSimNode.y };
-                    onghostClick(capturedKind, capturedFocusedId, ghostPos);
+                    onghostClick(capturedKind, capturedFocusedId, ghostPos, capturedExistingFamilyId);
+                });
+            } else if (branch.existingFamilyId) {
+                // Child branch attached to an existing real family (issue #206).
+                // The ghost person becomes a sibling — link the real family node to it.
+                const realFamilyDomId = normalizeId("family", branch.existingFamilyId);
+                const realFamilySimNode = simNodeById.get(realFamilyDomId);
+                const realFamilyCenter = realFamilySimNode
+                    ? { x: realFamilySimNode.x, y: realFamilySimNode.y }
+                    : origin;
+
+                const edgeRealFamilyToPerson = realFamilyCenter
+                    ? makeLine(realFamilyCenter.x, realFamilyCenter.y, personSeedX, personSeedY)
+                    : null;
+                const personEl = makeGhostPersonEl(branch.personId, personSeedX, personSeedY, branch.labelKey);
+
+                const personSimNode: SimNode = {
+                    id: branch.personId,
+                    x: personSeedX,
+                    y: personSeedY,
+                    seedX: personSeedX,
+                    seedY: personSeedY,
+                    isGhost: true,
+                };
+                simNodeById.set(personSimNode.id, personSimNode);
+
+                // Link the existing real family to the ghost-child so siblings shift.
+                if (realFamilySimNode) simLinks.push({ source: realFamilySimNode, target: personSimNode });
+
+                branchEntries.push({
+                    familySimNode: null,
+                    personSimNode,
+                    familyEl: null,
+                    personEl,
+                    edgeFocusToFamily: edgeRealFamilyToPerson,
+                    edgeFamilyToPerson: null,
+                    kind: capturedKind,
+                    realFamilySimNode: realFamilySimNode ?? null,
+                });
+
+                personEl.addEventListener("pointerup", (e: PointerEvent) => {
+                    e.stopPropagation();
+                    const ghostPos = { x: personSimNode.x, y: personSimNode.y };
+                    onghostClick(capturedKind, capturedFocusedId, ghostPos, capturedExistingFamilyId);
                 });
             } else {
+                // Family-focused child branch (no ghost family, no existing family).
                 const edgeFocusToPerson = origin
                     ? makeLine(origin.x, origin.y, personSeedX, personSeedY)
                     : null;
@@ -258,6 +321,11 @@
                     seedY: personSeedY,
                     isGhost: true,
                 };
+                simNodeById.set(personSimNode.id, personSimNode);
+
+                // Link: focus → ghost person.
+                const focusSimNode = focusDomId ? simNodeById.get(focusDomId) : null;
+                if (focusSimNode) simLinks.push({ source: focusSimNode, target: personSimNode });
 
                 branchEntries.push({
                     familySimNode: null,
@@ -267,12 +335,13 @@
                     edgeFocusToFamily: edgeFocusToPerson,
                     edgeFamilyToPerson: null,
                     kind: capturedKind,
+                    realFamilySimNode: null,
                 });
 
                 personEl.addEventListener("pointerup", (e: PointerEvent) => {
                     e.stopPropagation();
                     const ghostPos = { x: personSimNode.x, y: personSimNode.y };
-                    onghostClick(capturedKind, capturedFocusedId, ghostPos);
+                    onghostClick(capturedKind, capturedFocusedId, ghostPos, capturedExistingFamilyId);
                 });
             }
         }
@@ -289,6 +358,7 @@
         });
 
         const GHOST_RADIUS = 32;
+        const LINK_DISTANCE = 85;
         const ghostSimNodes = branchEntries.flatMap((e) =>
             e.familySimNode ? [e.familySimNode, e.personSimNode] : [e.personSimNode],
         );
@@ -299,6 +369,13 @@
             .force("collide", d3.forceCollide<SimNode>().radius(GHOST_RADIUS).strength(0.8))
             .force("seedX", d3.forceX<SimNode>((n) => n.seedX).strength((n) => (n.isGhost ? 0.15 : 0)))
             .force("seedY", d3.forceY<SimNode>((n) => n.seedY).strength((n) => (n.isGhost ? 0.15 : 0)))
+            .force(
+                "link",
+                d3
+                    .forceLink<SimNode, SimLink>(simLinks)
+                    .distance(LINK_DISTANCE)
+                    .strength(0.5),
+            )
             .alphaDecay(0.02)
             .velocityDecay(0.6);
 
@@ -336,7 +413,7 @@
 
             const nextPositions: Array<{ x: number; y: number }> = [];
             for (const entry of branchEntries) {
-                const { familySimNode, personSimNode, familyEl, personEl, edgeFocusToFamily, edgeFamilyToPerson } = entry;
+                const { familySimNode, personSimNode, familyEl, personEl, edgeFocusToFamily, edgeFamilyToPerson, realFamilySimNode } = entry;
 
                 personEl.setAttribute("transform", `translate(${personSimNode.x},${personSimNode.y})`);
                 nextPositions.push({ x: personSimNode.x, y: personSimNode.y });
@@ -354,6 +431,12 @@
                         edgeFamilyToPerson.setAttribute("x2", String(personSimNode.x));
                         edgeFamilyToPerson.setAttribute("y2", String(personSimNode.y));
                     }
+                } else if (realFamilySimNode && edgeFocusToFamily) {
+                    // Edge from existing real family (may move) to ghost person.
+                    edgeFocusToFamily.setAttribute("x1", String(realFamilySimNode.x));
+                    edgeFocusToFamily.setAttribute("y1", String(realFamilySimNode.y));
+                    edgeFocusToFamily.setAttribute("x2", String(personSimNode.x));
+                    edgeFocusToFamily.setAttribute("y2", String(personSimNode.y));
                 } else if (edgeFocusToFamily && origin) {
                     edgeFocusToFamily.setAttribute("x2", String(personSimNode.x));
                     edgeFocusToFamily.setAttribute("y2", String(personSimNode.y));

--- a/frontend/src/v3/ghostHelpers.test.ts
+++ b/frontend/src/v3/ghostHelpers.test.ts
@@ -136,12 +136,16 @@ describe("deriveGhostBranches — focused person without parent family", () => {
         expect(kinds).toContain("child");
     });
 
-    it("each branch has a ghost family id", () => {
+    it("spouse and parent branches have a ghost family id; child branch uses existingFamilyId (no ghost family)", () => {
         const index = new StemmaIndex(makeStemma());
+        // p1 is a parent in f1, so child branch uses existingFamilyId=f1
         const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
-        for (const branch of branches) {
-            expect(branch.familyId).not.toBeNull();
-        }
+        const byKind = Object.fromEntries(branches.map((b) => [b.kind, b]));
+        expect(byKind["spouse"].familyId).not.toBeNull();
+        expect(byKind["parent"].familyId).not.toBeNull();
+        // child branch attaches to existing family f1
+        expect(byKind["child"].familyId).toBeNull();
+        expect(byKind["child"].existingFamilyId).toBe("f1");
     });
 
     it("spouse branch offsets are rightward", () => {
@@ -162,19 +166,18 @@ describe("deriveGhostBranches — focused person without parent family", () => {
         expect(parent.personDy).toBeLessThan(parent.familyDy);
     });
 
-    it("child branch offsets are downward", () => {
+    it("child branch person offset is downward", () => {
         const index = new StemmaIndex(makeStemma());
         const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
         const child = branches.find((b) => b.kind === "child")!;
-        expect(child.familyDy).toBeGreaterThan(0);
+        // child branch uses existingFamilyId so familyId is null; only personDy matters
         expect(child.personDy).toBeGreaterThan(0);
-        expect(child.personDy).toBeGreaterThan(child.familyDy);
     });
 
-    it("assigns distinct stable DOM ids", () => {
+    it("assigns distinct stable DOM ids (familyId may be null for child branch using existingFamilyId)", () => {
         const index = new StemmaIndex(makeStemma());
         const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
-        const allIds = branches.flatMap((b) => [b.familyId, b.personId]).filter(Boolean);
+        const allIds = branches.flatMap((b) => [b.familyId, b.personId]).filter((id): id is string => id !== null);
         const unique = new Set(allIds);
         expect(unique.size).toBe(allIds.length);
     });
@@ -192,13 +195,23 @@ describe("deriveGhostBranches — focused person without parent family", () => {
 describe("deriveGhostBranches — focused person with parent family", () => {
     it("returns 2 branches: spouse and child (no parent branch)", () => {
         const index = new StemmaIndex(makeStemma());
-        // p3 is a child in f1
+        // p3 is a child in f1 but NOT a parent in any spouse-family
         const branches = deriveGhostBranches({ kind: "person", id: "p3" }, index);
         expect(branches).toHaveLength(2);
         const kinds = branches.map((b) => b.kind);
         expect(kinds).toContain("spouse");
         expect(kinds).toContain("child");
         expect(kinds).not.toContain("parent");
+    });
+
+    it("child branch falls back to new ghost family when person has no spouse-families", () => {
+        const index = new StemmaIndex(makeStemma());
+        // p3 is a child in f1 but NOT a parent in any family
+        const branches = deriveGhostBranches({ kind: "person", id: "p3" }, index);
+        const child = branches.find((b) => b.kind === "child")!;
+        // No spouse-family → new ghost family
+        expect(child.familyId).not.toBeNull();
+        expect(child.existingFamilyId).toBeUndefined();
     });
 });
 
@@ -232,6 +245,120 @@ describe("deriveGhostBranches — isolated person", () => {
         expect(kinds).toContain("spouse");
         expect(kinds).toContain("parent");
         expect(kinds).toContain("child");
+    });
+
+    it("child branch uses new ghost family (no existingFamilyId) for isolated person", () => {
+        const isolatedStemma: Stemma = {
+            type: "Stemma",
+            people: [{ type: "PersonDescription", id: "lone", name: "Lone", readOnly: false }],
+            families: [],
+        };
+        const index = new StemmaIndex(isolatedStemma);
+        const branches = deriveGhostBranches({ kind: "person", id: "lone" }, index);
+        const child = branches.find((b) => b.kind === "child")!;
+        expect(child.familyId).not.toBeNull();
+        expect(child.existingFamilyId).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deriveGhostBranches — existingFamilyId new acceptance cases (issue #206)
+// ---------------------------------------------------------------------------
+
+describe("deriveGhostBranches — spouse-family with ≥1 child → child branch uses existingFamilyId", () => {
+    it("ghost child uses existingFamilyId when spouse-family has existing children", () => {
+        // p1 is a parent in f1 which already has child p3
+        const index = new StemmaIndex(makeStemma());
+        const branches = deriveGhostBranches({ kind: "person", id: "p1" }, index);
+        const childBranches = branches.filter((b) => b.kind === "child");
+        expect(childBranches).toHaveLength(1);
+        expect(childBranches[0].existingFamilyId).toBe("f1");
+        expect(childBranches[0].familyId).toBeNull();
+    });
+});
+
+describe("deriveGhostBranches — spouse-family with 0 children → child branch uses existingFamilyId", () => {
+    it("ghost child uses existingFamilyId when spouse-family has no children yet", () => {
+        const emptyStemma: Stemma = {
+            type: "Stemma",
+            people: [
+                { type: "PersonDescription", id: "a", name: "A", readOnly: false },
+                { type: "PersonDescription", id: "b", name: "B", readOnly: false },
+            ],
+            families: [
+                { type: "FamilyDescription", id: "fAB", parents: ["a", "b"], children: [], readOnly: false },
+            ],
+        };
+        const index = new StemmaIndex(emptyStemma);
+        const branches = deriveGhostBranches({ kind: "person", id: "a" }, index);
+        const childBranches = branches.filter((b) => b.kind === "child");
+        expect(childBranches).toHaveLength(1);
+        expect(childBranches[0].existingFamilyId).toBe("fAB");
+        expect(childBranches[0].familyId).toBeNull();
+    });
+});
+
+describe("deriveGhostBranches — multiple spouse-families → one ghost-child per family", () => {
+    it("emits one child branch per spouse-family", () => {
+        const multiStemma: Stemma = {
+            type: "Stemma",
+            people: [
+                { type: "PersonDescription", id: "a", name: "A", readOnly: false },
+                { type: "PersonDescription", id: "b", name: "B", readOnly: false },
+                { type: "PersonDescription", id: "c", name: "C", readOnly: false },
+                { type: "PersonDescription", id: "d", name: "D", readOnly: false },
+            ],
+            families: [
+                { type: "FamilyDescription", id: "fAB", parents: ["a", "b"], children: [], readOnly: false },
+                { type: "FamilyDescription", id: "fAC", parents: ["a", "c"], children: ["d"], readOnly: false },
+            ],
+        };
+        const index = new StemmaIndex(multiStemma);
+        const branches = deriveGhostBranches({ kind: "person", id: "a" }, index);
+        const childBranches = branches.filter((b) => b.kind === "child");
+        expect(childBranches).toHaveLength(2);
+        const familyIds = childBranches.map((b) => b.existingFamilyId);
+        expect(familyIds).toContain("fAB");
+        expect(familyIds).toContain("fAC");
+        // all child branches use existingFamilyId (no ghost family)
+        for (const b of childBranches) {
+            expect(b.familyId).toBeNull();
+        }
+    });
+
+    it("assigns distinct ghost-person DOM ids for each child branch", () => {
+        const multiStemma: Stemma = {
+            type: "Stemma",
+            people: [
+                { type: "PersonDescription", id: "a", name: "A", readOnly: false },
+                { type: "PersonDescription", id: "b", name: "B", readOnly: false },
+                { type: "PersonDescription", id: "c", name: "C", readOnly: false },
+            ],
+            families: [
+                { type: "FamilyDescription", id: "fAB", parents: ["a", "b"], children: [], readOnly: false },
+                { type: "FamilyDescription", id: "fAC", parents: ["a", "c"], children: [], readOnly: false },
+            ],
+        };
+        const index = new StemmaIndex(multiStemma);
+        const branches = deriveGhostBranches({ kind: "person", id: "a" }, index);
+        const personIds = branches.map((b) => b.personId);
+        const unique = new Set(personIds);
+        expect(unique.size).toBe(personIds.length);
+    });
+});
+
+describe("deriveGhostBranches — no spouse-family → fallback to new ghost family + ghost-child", () => {
+    it("child branch creates new ghost family when person has no spouse-families", () => {
+        const isolatedStemma: Stemma = {
+            type: "Stemma",
+            people: [{ type: "PersonDescription", id: "lone", name: "Lone", readOnly: false }],
+            families: [],
+        };
+        const index = new StemmaIndex(isolatedStemma);
+        const branches = deriveGhostBranches({ kind: "person", id: "lone" }, index);
+        const child = branches.find((b) => b.kind === "child")!;
+        expect(child.familyId).not.toBeNull();
+        expect(child.existingFamilyId).toBeUndefined();
     });
 });
 

--- a/frontend/src/v3/ghostHelpers.ts
+++ b/frontend/src/v3/ghostHelpers.ts
@@ -30,7 +30,11 @@ export type GhostDescriptor = {
  * ghost person node, both positioned relative to the focused real node.
  *
  * When the focused entity is a family, there is no intermediate ghost family —
- * only a ghost person (child).  In that case `family` is null.
+ * only a ghost person (child).  In that case `familyId` is null.
+ *
+ * For a child branch attached to an existing spouse-family: `familyId` is null
+ * and `existingFamilyId` is the real family id.  The ghost-person becomes a
+ * sibling inside that existing family via link forces.
  */
 export type GhostBranch = {
     kind: GhostKind;
@@ -47,6 +51,12 @@ export type GhostBranch = {
     familyDy: number;
     personDx: number;
     personDy: number;
+    /**
+     * When set, the ghost child belongs to this existing real family rather than
+     * a new ghost family.  The sim links the real family node to the ghost-person
+     * so existing siblings shift via collision + link forces.
+     */
+    existingFamilyId?: string;
 };
 
 const GHOST_OFFSETS: Record<GhostKind, { dx: number; dy: number }> = {
@@ -163,10 +173,17 @@ export function immediateNeighborIds(focusedId: FocusedId, stemmaIndex: StemmaIn
  * and an endpoint ghost person node.  For a focused family the branch has no
  * intermediate ghost family (the family already exists) — only a ghost person.
  *
+ * Child-branch rules for a focused person:
+ * - If the person is a parent in one or more spouse-families: emit one child
+ *   branch per spouse-family with `existingFamilyId` set (no ghost family).
+ * - If the person has no spouse-families: emit one child branch with a new
+ *   ghost family (legacy behavior).
+ *
  * Seed offsets (SVG user-space, relative to focused node center):
  * - spouse:  ghost family at (+80, 0), ghost person at (+160, 0)
  * - parent:  ghost family at (0, -80), ghost person at (0, -160)
- * - child (person-focused): ghost family at (0, +80), ghost person at (0, +160)
+ * - child (existing family): ghost person at (0, +100) — linked to real family
+ * - child (new ghost family): ghost family at (0, +80), ghost person at (0, +160)
  * - child (family-focused): ghost person at (0, +100) — no ghost family
  */
 export function deriveGhostBranches(
@@ -200,16 +217,34 @@ export function deriveGhostBranches(
                 personDy: -160,
             });
         }
-        branches.push({
-            kind: "child",
-            familyId: "ghost-family-child",
-            personId: "ghost-person-child",
-            labelKey: GHOST_LABEL_KEYS["child"],
-            familyDx: 0,
-            familyDy: 80,
-            personDx: 0,
-            personDy: 160,
-        });
+
+        const spouseFamilies = stemmaIndex.spouseFamilyIds(focusedId.id);
+        if (spouseFamilies.length > 0) {
+            spouseFamilies.forEach((familyId, i) => {
+                branches.push({
+                    kind: "child",
+                    familyId: null,
+                    personId: `ghost-person-child-${i}`,
+                    labelKey: GHOST_LABEL_KEYS["child"],
+                    familyDx: 0,
+                    familyDy: 0,
+                    personDx: 0,
+                    personDy: 100,
+                    existingFamilyId: familyId,
+                });
+            });
+        } else {
+            branches.push({
+                kind: "child",
+                familyId: "ghost-family-child",
+                personId: "ghost-person-child",
+                labelKey: GHOST_LABEL_KEYS["child"],
+                familyDx: 0,
+                familyDy: 80,
+                personDx: 0,
+                personDy: 160,
+            });
+        }
         return branches;
     }
 

--- a/frontend/src/v3/v3MutationActions.ts
+++ b/frontend/src/v3/v3MutationActions.ts
@@ -212,12 +212,19 @@ export class V3MutationActions {
         kind: GhostKind,
         focused: FocusedId | null,
         ghostPos: { x: number; y: number },
+        existingFamilyId?: string,
     ): void {
         if (!focused) return;
 
         // Family-focused child ghost — material family already exists; create a child into it.
         if (kind === "child" && focused.kind === "family") {
             this.createPersonInFamily(focused.id, "child", this.t("v3.addChild"), ghostPos);
+            return;
+        }
+
+        // Person-focused child ghost with an existing spouse-family — add sibling into that family.
+        if (kind === "child" && focused.kind === "person" && existingFamilyId) {
+            this.createPersonInFamily(existingFamilyId, "child", this.t("v3.addChild"), ghostPos);
             return;
         }
 


### PR DESCRIPTION
## Summary

- `ghostHelpers.ts` — `deriveGhostBranches` now emits one child branch per spouse-family (where the focused person is a parent) with `existingFamilyId` set and `familyId = null`. Falls back to the previous ghost-family + ghost-child behavior when the person has no spouse-families.
- `StemmaIndex` — new `spouseFamilyIds(personId)` method returns ids of families where the person is a parent.
- `V3GhostLayer.svelte` — sim gains `forceLink` (distance=85, matching `configureSimulation`) over all branch edges; for `existingFamilyId` branches the real family node is linked to the ghost-person so existing siblings physically shift via collision + link forces; the edge source (x1/y1) is updated on each tick to track the real family node; the snap-back on blur path is unchanged.
- `v3MutationActions.ts` — `onGhostClick` routes an `existingFamilyId` child click to `createPersonInFamily` on the existing family, opening the create-person modal which materializes as a sibling.

## Test plan

- [x] `npm test` — 202 tests pass (21 suites); new acceptance tests cover all four scenarios from issue #206
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] e2e v3 smoke — skipped locally; full Docker stack not available in this session; CI will cover it

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)