### PR TITLE
Fix v3 ghost anchoring and stuck hover highlight

### DIFF
--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -36,6 +36,7 @@
         hidden: boolean;
         viewMode: ViewMode;
         simulationActive?: boolean;
+        hoverHighlight?: boolean;
         onpersonSelected?: (person: any) => void;
         onfamilySelected?: (family: any) => void;
         onhighlightChanged?: () => void;
@@ -50,6 +51,7 @@
         hidden,
         viewMode,
         simulationActive = true,
+        hoverHighlight = true,
         onpersonSelected,
         onfamilySelected,
         onhighlightChanged,
@@ -255,6 +257,7 @@
                     return;
                 }
                 if (document.body.classList.contains("v2-linking")) return;
+                if (!hoverHighlight) return;
                 if (node.type == "person") {
                     highlight.pushPerson(denormalizeId(node.id));
                     renderFullStemma();
@@ -271,10 +274,11 @@
             })
             .on("mouseleave", (_event: any, _node: any) => {
                 if (isDragging) {
-                    pendingMouseLeave = true;
+                    if (hoverHighlight) pendingMouseLeave = true;
                     return;
                 }
                 if (document.body.classList.contains("v2-linking")) return;
+                if (!hoverHighlight) return;
                 highlight.pop();
                 renderFullStemma();
                 onhighlightChanged?.();

--- a/frontend/src/v3/V3App.svelte
+++ b/frontend/src/v3/V3App.svelte
@@ -246,6 +246,7 @@
                     pinnedPeople={pinnedPeople!}
                     viewMode={ViewMode.ALL}
                     simulationActive={!editMode}
+                    hoverHighlight={!editMode}
                     onpersonSelected={handlePersonSelected}
                     onfamilySelected={handleFamilySelected}
                     onhighlightChanged={() => highlightVersion++}

--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -371,27 +371,18 @@
             onpositionsChange([]);
             fadeOutAndRemove(allGhostEls);
 
-            // Snap freed neighbors back to their pre-focus positions then
-            // release them so the main sim can resume.
-            const SNAP_BACK_MS = 250;
+            // Hard-snap synchronously: a deferred snap-back would let the next
+            // focus snapshot stale mid-animation coordinates.
             d3.select("g.main").selectAll<SVGGElement, any>("g").each((d: any) => {
                 if (!d) return;
                 const snap = positionSnapshot.get(d.id);
                 if (neighborDomIds.has(d.id) && snap) {
-                    d.fx = snap.x;
-                    d.fy = snap.y;
+                    d.x = snap.x;
+                    d.y = snap.y;
+                    d.fx = null;
+                    d.fy = null;
                     const gEl = mainG.querySelector(`#${CSS.escape(d.id)}`) as SVGGElement | null;
-                    if (gEl) {
-                        gEl.style.transition = `transform ${SNAP_BACK_MS}ms ease-out`;
-                        gEl.setAttribute("transform", `translate(${snap.x},${snap.y})`);
-                    }
-                    setTimeout(() => {
-                        d.x = snap.x;
-                        d.y = snap.y;
-                        d.fx = null;
-                        d.fy = null;
-                        if (gEl) gEl.style.transition = "";
-                    }, SNAP_BACK_MS);
+                    if (gEl) gEl.setAttribute("transform", `translate(${snap.x},${snap.y})`);
                 } else {
                     d.fx = null;
                     d.fy = null;


### PR DESCRIPTION
## Summary
- Disable hover-highlight in edit mode. `renderChart` iterates `g.main` descendants and dereferences `node.id` / `t.type` on datum, but the ghost `<circle>` / `<text>` / `<line>` / `<g>` elements appended by `V3GhostLayer` have no datum bound, so subsequent `renderFullStemma` calls threw and left the lineage highlight stuck on the first hovered family. `FullStemma` now takes a `hoverHighlight` prop; `V3App` passes `!editMode`.
- Hard-snap freed neighbors synchronously on ghost cleanup. The previous CSS transition + 250 ms `setTimeout` deferred the datum update, so the next focus snapshotted stale mid-animation coordinates and ghosts were seeded around a position the focused node was about to drift away from.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm test` (195/195 jest pass)
- [ ] manual: enter v3 edit mode, hover several persons/families in quick succession — ghosts anchor to the currently-focused node; family lineage no longer locks after the first hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)