### PR TITLE
v3 ghost physics push + wider hover radius

### DIFF
--- a/frontend/src/v3/components/V3FocusController.svelte
+++ b/frontend/src/v3/components/V3FocusController.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import {
         FOCUS_RADIUS_SVG,
+        GHOST_HOVER_RADIUS_SVG,
         MOUSE_LEAVE_DEBOUNCE_MS,
         nearestNodeWithinRadius,
         cursorNearGhost,
@@ -8,7 +9,6 @@
     } from "../focusGesture";
     import { isPendingId } from "../pendingState";
     import { clientToSvgPoint } from "../v3DomGeometry";
-    import { personR } from "../../graphStyles";
 
 
     type Props = {
@@ -45,7 +45,7 @@
             const svgPt = clientToSvgPoint(svgEl as unknown as SVGSVGElement, e.clientX, e.clientY);
             const next = nearestNodeWithinRadius(mainG, svgPt.x, svgPt.y, FOCUS_RADIUS_SVG, isPendingId);
             if (!next) {
-                if (cursorNearGhost(ghostSimPositions, svgPt.x, svgPt.y, personR)) {
+                if (cursorNearGhost(ghostSimPositions, svgPt.x, svgPt.y, GHOST_HOVER_RADIUS_SVG)) {
                     cancelLeave();
                     return;
                 }

--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import * as d3 from "d3";
     import { normalizeId } from "../../graphTools";
     import {
         personR,
@@ -14,6 +15,7 @@
     import {
         deriveGhostLayout,
         FOCUSED_FAMILY_REF,
+        immediateNeighborIds,
         realFamilyIdFromRef,
         type GhostKind,
     } from "../ghostHelpers";
@@ -42,6 +44,7 @@
     const GHOST_COLOR = "#6c757d";
     const GHOST_ARROW_TO_FAMILY_ID = "v3-ghost-arrow-to-family";
     const GHOST_ARROW_TO_PERSON_ID = "v3-ghost-arrow-to-person";
+    const GHOST_COLLIDE_RADIUS = 36;
 
     let fadingOutGhostEls: Element[] = [];
 
@@ -240,10 +243,94 @@
 
         onpositionsChange([...familyAnchor.values(), ...personPos.values()]);
 
+        // One-way physics: ghosts are frozen at their planned positions but
+        // their collision circles push 1-hop real neighbours aside so existing
+        // nodes don't sit on top of the affordances. Real non-neighbour nodes
+        // stay pinned at their current positions.
+        type SimNode = {
+            id: string;
+            x: number;
+            y: number;
+            fx?: number | null;
+            fy?: number | null;
+            isGhost: boolean;
+            el?: SVGGElement | null;
+            datum?: any;
+        };
+
+        const neighborDomIds = new Set(
+            immediateNeighborIds(focusedId, stemmaIndex).map((n) => normalizeId(n.kind, n.id)),
+        );
+        const positionSnapshot = new Map<string, { x: number; y: number }>();
+        const simNodes: SimNode[] = [];
+        const neighborSims: SimNode[] = [];
+
+        d3.select("g.main").selectAll<SVGGElement, any>("g").each(function (this: SVGGElement, d: any) {
+            if (!d || d.x == null || d.y == null) return;
+            positionSnapshot.set(d.id, { x: d.x, y: d.y });
+            const isNeighbor = neighborDomIds.has(d.id);
+            const sim: SimNode = {
+                id: d.id,
+                x: d.x,
+                y: d.y,
+                fx: isNeighbor ? null : d.x,
+                fy: isNeighbor ? null : d.y,
+                isGhost: false,
+                el: this,
+                datum: d,
+            };
+            simNodes.push(sim);
+            if (isNeighbor) neighborSims.push(sim);
+        });
+
+        // Ghost sim nodes: frozen at the static plan positions.
+        for (const f of layout.families) {
+            const pos = familyAnchor.get(f.id);
+            if (!pos) continue;
+            simNodes.push({ id: f.id, x: pos.x, y: pos.y, fx: pos.x, fy: pos.y, isGhost: true });
+        }
+        for (const p of layout.persons) {
+            const pos = personPos.get(p.id);
+            if (!pos) continue;
+            simNodes.push({ id: p.id, x: pos.x, y: pos.y, fx: pos.x, fy: pos.y, isGhost: true });
+        }
+
+        const sim = d3
+            .forceSimulation<SimNode>(simNodes)
+            .force("collide", d3.forceCollide<SimNode>().radius(GHOST_COLLIDE_RADIUS).strength(0.9))
+            .alphaDecay(0.04)
+            .velocityDecay(0.5);
+
+        sim.on("tick", () => {
+            for (const n of neighborSims) {
+                if (!n.el) continue;
+                n.el.setAttribute("transform", `translate(${n.x},${n.y})`);
+                if (n.datum) {
+                    n.datum.x = n.x;
+                    n.datum.y = n.y;
+                }
+            }
+        });
+
         return () => {
             fadeInCancelled = true;
+            sim.stop();
             onpositionsChange([]);
             fadeOutAndRemove(allGhostEls);
+
+            // Hard-snap neighbours back to their pre-focus positions
+            // synchronously so the next focus snapshot doesn't pick up
+            // mid-physics coordinates. Datum fx/fy is left as FullStemma set
+            // it — edit mode keeps every real node pinned anyway.
+            for (const n of neighborSims) {
+                const snap = positionSnapshot.get(n.id);
+                if (!snap) continue;
+                if (n.datum) {
+                    n.datum.x = snap.x;
+                    n.datum.y = snap.y;
+                }
+                if (n.el) n.el.setAttribute("transform", `translate(${snap.x},${snap.y})`);
+            }
         };
     });
 </script>

--- a/frontend/src/v3/focusGesture.ts
+++ b/frontend/src/v3/focusGesture.ts
@@ -17,6 +17,14 @@ export const TAP_MAX_MOVE_PX = 10;
 export const FOCUS_RADIUS_SVG = 150;
 
 /**
+ * Hit radius for the "cursor still near a ghost" check that keeps the focused
+ * node from blurring while the user is moving toward a ghost. Larger than the
+ * ghost circle radius so the dashed circle plus its label sit inside the zone
+ * and small cursor jitters between ghosts don't drop the focus.
+ */
+export const GHOST_HOVER_RADIUS_SVG = 60;
+
+/**
  * Returns true when the cursor position is within `hitRadius` SVG user-space
  * units of any ghost position.
  *

--- a/frontend/src/v3/ghostHelpers.test.ts
+++ b/frontend/src/v3/ghostHelpers.test.ts
@@ -117,7 +117,7 @@ describe("deriveGhostLayout — focused person with parent family", () => {
 });
 
 describe("deriveGhostLayout — focused person with existing spouse-families", () => {
-    it("emits one child ghost per existing spouse-family instead of in the east family", () => {
+    it("keeps a single child ghost in the east family regardless of existing families", () => {
         const stemma: Stemma = {
             type: "Stemma",
             people: [
@@ -133,11 +133,8 @@ describe("deriveGhostLayout — focused person with existing spouse-families", (
         const index = new StemmaIndex(stemma);
         const layout = deriveGhostLayout({ kind: "person", id: "p1" }, index);
         const childPlans = layout.persons.filter((p) => p.kind === "child");
-        expect(childPlans).toHaveLength(2);
-        const refs = childPlans.map((p) => p.familyId).sort();
-        expect(refs).toEqual([existingFamilyRef("fA"), existingFamilyRef("fB")].sort());
-        // None of the child ghosts hang off the east ghost family.
-        expect(childPlans.every((p) => !p.familyId.startsWith("ghost-family"))).toBe(true);
+        expect(childPlans).toHaveLength(1);
+        expect(childPlans[0].familyId).toBe("ghost-family-east");
     });
 });
 

--- a/frontend/src/v3/ghostHelpers.ts
+++ b/frontend/src/v3/ghostHelpers.ts
@@ -62,6 +62,54 @@ export function realFamilyIdFromRef(familyRef: string): string | null {
     return familyRef.slice(EXISTING_FAMILY_PREFIX.length);
 }
 
+export type NeighborRef = { kind: "person" | "family"; id: string };
+
+/**
+ * 1-hop neighbors of the focused entity. The ghost-layer sim leaves these
+ * unfrozen so ghost circles can push them aside via collision force. The
+ * focused node itself is excluded — it is frozen separately.
+ */
+export function immediateNeighborIds(
+    focusedId: FocusedId,
+    stemmaIndex: StemmaIndex,
+): readonly NeighborRef[] {
+    const seen = new Set<string>();
+    const refs: NeighborRef[] = [];
+
+    const addPerson = (id: string) => {
+        if (!seen.has(id) && id !== focusedId.id) {
+            seen.add(id);
+            refs.push({ kind: "person", id });
+        }
+    };
+    const addFamily = (id: string) => {
+        if (!seen.has(id) && id !== focusedId.id) {
+            seen.add(id);
+            refs.push({ kind: "family", id });
+        }
+    };
+
+    if (focusedId.kind === "person") {
+        for (const f of stemmaIndex.relatedFamilies(focusedId.id)) {
+            addFamily(f.id);
+            for (const pid of f.parents) addPerson(pid);
+            for (const pid of f.children) addPerson(pid);
+        }
+        return refs;
+    }
+
+    if (focusedId.kind === "family") {
+        const f = stemmaIndex.family(focusedId.id);
+        if (f) {
+            for (const pid of f.parents) addPerson(pid);
+            for (const pid of f.children) addPerson(pid);
+        }
+        return refs;
+    }
+
+    return refs;
+}
+
 export function deriveGhostLayout(
     focusedId: FocusedId | null,
     stemmaIndex: StemmaIndex,
@@ -73,9 +121,10 @@ export function deriveGhostLayout(
         const persons: GhostPersonPlan[] = [];
         const anchorEdges: GhostAnchorEdge[] = [];
 
-        // Shared east-side ghost family — "add another spouse" hangs off it; if
-        // the focused person has no existing spouse-family, "add child" also
-        // hangs off this same family.
+        // Shared east-side ghost family hosts both "add another spouse" and
+        // "add child". Click on the child slot creates a new family with the
+        // focused person as the sole parent; users wanting to extend an
+        // existing spouse-family use the drag gesture or the family card.
         const eastFamily: GhostFamilyPlan = { id: "ghost-family-east", dx: 100, dy: 0 };
         families.push(eastFamily);
         anchorEdges.push({ familyId: eastFamily.id, focusedRole: "parent" });
@@ -88,31 +137,15 @@ export function deriveGhostLayout(
             dx: 200,
             dy: 0,
         });
-
-        const spouseFamilies = stemmaIndex.spouseFamilyIds(focusedId.id);
-        if (spouseFamilies.length === 0) {
-            persons.push({
-                id: "ghost-person-child",
-                kind: "child",
-                labelKey: LABEL_KEYS.child,
-                familyId: eastFamily.id,
-                role: "child",
-                dx: 100,
-                dy: 100,
-            });
-        } else {
-            spouseFamilies.forEach((realFamilyId, i) => {
-                persons.push({
-                    id: `ghost-person-child-${i}`,
-                    kind: "child",
-                    labelKey: LABEL_KEYS.child,
-                    familyId: existingFamilyRef(realFamilyId),
-                    role: "child",
-                    dx: 0,
-                    dy: 100,
-                });
-            });
-        }
+        persons.push({
+            id: "ghost-person-child",
+            kind: "child",
+            labelKey: LABEL_KEYS.child,
+            familyId: eastFamily.id,
+            role: "child",
+            dx: 100,
+            dy: 100,
+        });
 
         if (!stemmaIndex.hasParentFamily(focusedId.id)) {
             const parentFamily: GhostFamilyPlan = { id: "ghost-family-parent", dx: 0, dy: -100 };


### PR DESCRIPTION
Stacked on top of #214 — review that one first.

## Summary
- One-way d3 force simulation around the ghost layer. Ghosts are pinned at their static plan positions; the focused node's 1-hop real neighbours are the only nodes that move. A collide force at radius 36 lets the ghost circles physically push existing neighbours aside so the affordances no longer sit on top of the real graph. Non-neighbour real nodes stay pinned. Cleanup hard-snaps neighbours back to the snapshot position synchronously.
- Widen the cursor-near-ghost hit radius from `personR` (15) to a dedicated `GHOST_HOVER_RADIUS_SVG = 60` so small cursor jitter between ghosts no longer drops the focus.
- Drop the multi-spouse-family child branch: a focused person always gets a single child ghost in the shared east ghost family. Previously the per-family child ghosts rendered far from the focused node and broke the planned `A → * ← spouse / * → child` shape; users who need to extend an existing real family still have the drag gesture and the family card.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm test` (190/190 jest pass; updated `deriveGhostLayout` test now asserts a single child ghost in the east family even with existing spouse-families)
- [ ] CI: e2e ghost-layout assertion already covers the orphan case; manual repro for the push-aside case = focus a person who has a tightly clustered neighbour east of them and confirm the neighbour shifts before the ghost spouse renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)