### PR TITLE
v3 ghost-layer: real edit-mode physics on ghost + 1-hop neighbours

### DIFF
--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -109,8 +109,6 @@
             return el ? nodeCenter(el) : null;
         };
 
-        // Seed positions for ghost nodes. Families derive from their declared
-        // offset relative to either the focused node or an existing family.
         const familyAnchor = new Map<string, Pos>();
         for (const f of layout.families) {
             familyAnchor.set(f.id, { x: origin.x + f.dx, y: origin.y + f.dy });
@@ -221,8 +219,10 @@
             const capturedFocused = focusedId;
             g.addEventListener("pointerup", (ev: PointerEvent) => {
                 ev.stopPropagation();
-                const personPosNow = positionsById.get(id) ?? pos;
-                const famPosNow = positionsById.get(familyId) ?? null;
+                const personNode = nodesById.get(id);
+                const famNode = nodesById.get(familyId);
+                const personPosNow = personNode ?? pos;
+                const famPosNow = famNode ? { x: famNode.x, y: famNode.y } : null;
                 onghostClick(kind, capturedFocused, {
                     person: { x: personPosNow.x, y: personPosNow.y },
                     family: famPosNow,
@@ -230,7 +230,12 @@
             });
         };
 
-        // Render ghost DOM elements at seed positions.
+        const resolveAnchorSimId = (familyRef: string): string => {
+            if (familyRef === FOCUSED_FAMILY_REF) return focusDomId;
+            const real = realFamilyIdFromRef(familyRef);
+            return real ? normalizeId("family", real) : familyRef;
+        };
+
         for (const f of layout.families) {
             const pos = familyAnchor.get(f.id);
             if (pos) makeGhostFamilyEl(f.id, pos);
@@ -239,14 +244,9 @@
             const pos = personPos.get(p.id);
             if (!pos) continue;
             const existingFamilyId = realFamilyIdFromRef(p.familyId) ?? undefined;
-            const ghostFamilyId = p.familyId === FOCUSED_FAMILY_REF
-                ? focusDomId
-                : (realFamilyIdFromRef(p.familyId) ? normalizeId("family", realFamilyIdFromRef(p.familyId)!) : p.familyId);
-            makeGhostPersonEl(p.id, pos, p.labelKey, p.kind, existingFamilyId, ghostFamilyId);
+            makeGhostPersonEl(p.id, pos, p.labelKey, p.kind, existingFamilyId, resolveAnchorSimId(p.familyId));
         }
 
-        // Ghost edges — anchor edges link focused ↔ ghost-family; person edges
-        // link each ghost person to its anchor family (ghost or real).
         for (const a of layout.anchorEdges) {
             const familyPos = familyAnchor.get(a.familyId);
             if (!familyPos) continue;
@@ -260,9 +260,7 @@
             const pos = personPos.get(p.id);
             const anchorPos = familyAnchor.get(p.familyId);
             if (!pos || !anchorPos) continue;
-            const anchorSimId = p.familyId === FOCUSED_FAMILY_REF
-                ? focusDomId
-                : (realFamilyIdFromRef(p.familyId) ? normalizeId("family", realFamilyIdFromRef(p.familyId)!) : p.familyId);
+            const anchorSimId = resolveAnchorSimId(p.familyId);
             if (p.role === "parent") {
                 makeLine(p.id, anchorSimId, pos, anchorPos, "focusToFamily");
             } else {
@@ -270,8 +268,6 @@
             }
         }
 
-        // Set up sim. Real neighbours participate; non-neighbours stay pinned
-        // at their current positions and are excluded from the sim.
         const neighborDomIds = ghostSimNeighborDomIds(focusedId, stemmaIndex);
         const positionSnapshot = new Map<string, Pos>();
         const neighborEls = new Map<string, SVGGElement>();
@@ -305,25 +301,23 @@
         });
         const sim = configureGhostSim(graph, origin);
 
-        // Live position map shared with ghost-click handler and the focus
-        // controller hover-detection callback.
-        const positionsById = new Map<string, Pos>();
-        for (const n of graph.nodes) positionsById.set(n.id, { x: n.x, y: n.y });
+        const nodesById = new Map(graph.nodes.map((n) => [n.id, n]));
 
         const emitPositions = () => {
             const live: Pos[] = [];
             for (const n of graph.nodes) {
-                if (!n.isGhost) continue;
-                live.push({ x: n.x, y: n.y });
+                if (n.isGhost) live.push({ x: n.x, y: n.y });
             }
             onpositionsChange(live);
         };
 
+        // Initial emit covers the seed positions so V3FocusController has
+        // ghost coordinates before the sim's first tick; the on("end") emit
+        // refreshes them once the sim has settled.
         emitPositions();
 
         sim.on("tick", () => {
             for (const n of graph.nodes) {
-                positionsById.set(n.id, { x: n.x, y: n.y });
                 if (n.isGhost) {
                     const fEl = ghostFamilyEls.get(n.id);
                     if (fEl) fEl.setAttribute("transform", `translate(${n.x},${n.y})`);
@@ -341,12 +335,13 @@
                 }
             }
             for (const e of edgeRefs) {
-                const s = positionsById.get(e.sourceId);
-                const t = positionsById.get(e.targetId);
+                const s = nodesById.get(e.sourceId);
+                const t = nodesById.get(e.targetId);
                 if (s && t) applyEdgeEndpoints(e, s, t);
             }
-            emitPositions();
         });
+
+        sim.on("end", emitPositions);
 
         let fadeInCancelled = false;
         requestAnimationFrame(() => {

--- a/frontend/src/v3/components/V3GhostLayer.svelte
+++ b/frontend/src/v3/components/V3GhostLayer.svelte
@@ -15,12 +15,16 @@
     import {
         deriveGhostLayout,
         FOCUSED_FAMILY_REF,
-        immediateNeighborIds,
         realFamilyIdFromRef,
         type GhostKind,
     } from "../ghostHelpers";
     import { nodeCenter } from "../v3DomGeometry";
     import { trimToCircle, GHOST_EDGE_GAP } from "../ghostEdgeGeometry";
+    import {
+        buildGhostSimGraph,
+        configureGhostSim,
+        ghostSimNeighborDomIds,
+    } from "../ghostSim";
 
     type Props = {
         focusedId: FocusedId | null;
@@ -44,7 +48,6 @@
     const GHOST_COLOR = "#6c757d";
     const GHOST_ARROW_TO_FAMILY_ID = "v3-ghost-arrow-to-family";
     const GHOST_ARROW_TO_PERSON_ID = "v3-ghost-arrow-to-person";
-    const GHOST_COLLIDE_RADIUS = 36;
 
     let fadingOutGhostEls: Element[] = [];
 
@@ -106,6 +109,8 @@
             return el ? nodeCenter(el) : null;
         };
 
+        // Seed positions for ghost nodes. Families derive from their declared
+        // offset relative to either the focused node or an existing family.
         const familyAnchor = new Map<string, Pos>();
         for (const f of layout.families) {
             familyAnchor.set(f.id, { x: origin.x + f.dx, y: origin.y + f.dy });
@@ -126,21 +131,23 @@
             personPos.set(p.id, { x: base.x + p.dx, y: base.y + p.dy });
         }
 
+        type GhostEdgeRef = {
+            line: SVGLineElement;
+            sourceId: string;
+            targetId: string;
+            edgeKind: "focusToFamily" | "familyToPerson";
+        };
+        const edgeRefs: GhostEdgeRef[] = [];
+
         const makeLine = (
-            source: Pos,
-            target: Pos,
+            sourceId: string,
+            targetId: string,
+            sourcePos: Pos,
+            targetPos: Pos,
             edgeKind: "focusToFamily" | "familyToPerson",
         ): void => {
-            const sourceR = edgeKind === "focusToFamily" ? personR : familyR;
-            const targetR = edgeKind === "focusToFamily" ? familyR : personR;
-            const tip = trimToCircle(source.x, source.y, target.x, target.y, targetR + GHOST_EDGE_GAP);
-            const tail = trimToCircle(target.x, target.y, source.x, source.y, sourceR + GHOST_EDGE_GAP);
             const line = document.createElementNS(SVG_NS, "line") as SVGLineElement;
             line.setAttribute("class", "v3-ghost-edge");
-            line.setAttribute("x1", String(tail.x));
-            line.setAttribute("y1", String(tail.y));
-            line.setAttribute("x2", String(tip.x));
-            line.setAttribute("y2", String(tip.y));
             if (edgeKind === "focusToFamily") {
                 line.setAttribute("stroke-width", familyRelationWidth);
                 line.setAttribute("marker-end", `url(#${GHOST_ARROW_TO_FAMILY_ID})`);
@@ -151,7 +158,23 @@
             line.style.opacity = "0";
             mainG.appendChild(line);
             allGhostEls.push(line);
+            edgeRefs.push({ line, sourceId, targetId, edgeKind });
+            applyEdgeEndpoints(edgeRefs[edgeRefs.length - 1], sourcePos, targetPos);
         };
+
+        const applyEdgeEndpoints = (ref: GhostEdgeRef, source: Pos, target: Pos): void => {
+            const sourceR = ref.edgeKind === "focusToFamily" ? personR : familyR;
+            const targetR = ref.edgeKind === "focusToFamily" ? familyR : personR;
+            const tip = trimToCircle(source.x, source.y, target.x, target.y, targetR + GHOST_EDGE_GAP);
+            const tail = trimToCircle(target.x, target.y, source.x, source.y, sourceR + GHOST_EDGE_GAP);
+            ref.line.setAttribute("x1", String(tail.x));
+            ref.line.setAttribute("y1", String(tail.y));
+            ref.line.setAttribute("x2", String(tip.x));
+            ref.line.setAttribute("y2", String(tip.y));
+        };
+
+        const ghostFamilyEls = new Map<string, SVGGElement>();
+        const ghostPersonEls = new Map<string, SVGGElement>();
 
         const makeGhostFamilyEl = (id: string, pos: Pos): void => {
             const g = document.createElementNS(SVG_NS, "g") as SVGGElement;
@@ -165,6 +188,7 @@
             g.appendChild(c);
             mainG.appendChild(g);
             allGhostEls.push(g);
+            ghostFamilyEls.set(id, g);
         };
 
         const makeGhostPersonEl = (
@@ -173,7 +197,7 @@
             labelKey: string,
             kind: GhostKind,
             existingFamilyId: string | undefined,
-            familyPos: Pos | null,
+            familyId: string,
         ): void => {
             const g = document.createElementNS(SVG_NS, "g") as SVGGElement;
             g.setAttribute("id", id);
@@ -192,14 +216,21 @@
             g.appendChild(label);
             mainG.appendChild(g);
             allGhostEls.push(g);
+            ghostPersonEls.set(id, g);
 
             const capturedFocused = focusedId;
             g.addEventListener("pointerup", (ev: PointerEvent) => {
                 ev.stopPropagation();
-                onghostClick(kind, capturedFocused, { person: pos, family: familyPos }, existingFamilyId);
+                const personPosNow = positionsById.get(id) ?? pos;
+                const famPosNow = positionsById.get(familyId) ?? null;
+                onghostClick(kind, capturedFocused, {
+                    person: { x: personPosNow.x, y: personPosNow.y },
+                    family: famPosNow,
+                }, existingFamilyId);
             });
         };
 
+        // Render ghost DOM elements at seed positions.
         for (const f of layout.families) {
             const pos = familyAnchor.get(f.id);
             if (pos) makeGhostFamilyEl(f.id, pos);
@@ -208,106 +239,119 @@
             const pos = personPos.get(p.id);
             if (!pos) continue;
             const existingFamilyId = realFamilyIdFromRef(p.familyId) ?? undefined;
-            const famPos = familyAnchor.get(p.familyId) ?? null;
-            makeGhostPersonEl(p.id, pos, p.labelKey, p.kind, existingFamilyId, famPos);
+            const ghostFamilyId = p.familyId === FOCUSED_FAMILY_REF
+                ? focusDomId
+                : (realFamilyIdFromRef(p.familyId) ? normalizeId("family", realFamilyIdFromRef(p.familyId)!) : p.familyId);
+            makeGhostPersonEl(p.id, pos, p.labelKey, p.kind, existingFamilyId, ghostFamilyId);
         }
 
+        // Ghost edges — anchor edges link focused ↔ ghost-family; person edges
+        // link each ghost person to its anchor family (ghost or real).
         for (const a of layout.anchorEdges) {
             const familyPos = familyAnchor.get(a.familyId);
             if (!familyPos) continue;
             if (a.focusedRole === "parent") {
-                makeLine(origin, familyPos, "focusToFamily");
+                makeLine(focusDomId, a.familyId, origin, familyPos, "focusToFamily");
             } else {
-                makeLine(familyPos, origin, "familyToPerson");
+                makeLine(a.familyId, focusDomId, familyPos, origin, "familyToPerson");
             }
         }
-
         for (const p of layout.persons) {
             const pos = personPos.get(p.id);
             const anchorPos = familyAnchor.get(p.familyId);
             if (!pos || !anchorPos) continue;
+            const anchorSimId = p.familyId === FOCUSED_FAMILY_REF
+                ? focusDomId
+                : (realFamilyIdFromRef(p.familyId) ? normalizeId("family", realFamilyIdFromRef(p.familyId)!) : p.familyId);
             if (p.role === "parent") {
-                makeLine(pos, anchorPos, "focusToFamily");
+                makeLine(p.id, anchorSimId, pos, anchorPos, "focusToFamily");
             } else {
-                makeLine(anchorPos, pos, "familyToPerson");
+                makeLine(anchorSimId, p.id, anchorPos, pos, "familyToPerson");
             }
         }
+
+        // Set up sim. Real neighbours participate; non-neighbours stay pinned
+        // at their current positions and are excluded from the sim.
+        const neighborDomIds = ghostSimNeighborDomIds(focusedId, stemmaIndex);
+        const positionSnapshot = new Map<string, Pos>();
+        const neighborEls = new Map<string, SVGGElement>();
+        const neighborDatums = new Map<string, any>();
+        const neighborPositions = new Map<string, Pos>();
+
+        d3.select("g.main").selectAll<SVGGElement, any>("g").each(function (this: SVGGElement, d: any) {
+            if (!d || d.x == null || d.y == null) return;
+            positionSnapshot.set(d.id, { x: d.x, y: d.y });
+            if (neighborDomIds.has(d.id)) {
+                neighborEls.set(d.id, this);
+                neighborDatums.set(d.id, d);
+                neighborPositions.set(d.id, { x: d.x, y: d.y });
+            }
+        });
+
+        const ghostSeedPositions = new Map<string, Pos>();
+        for (const f of layout.families) {
+            const pos = familyAnchor.get(f.id);
+            if (pos) ghostSeedPositions.set(f.id, pos);
+        }
+        for (const p of layout.persons) {
+            const pos = personPos.get(p.id);
+            if (pos) ghostSeedPositions.set(p.id, pos);
+        }
+
+        const graph = buildGhostSimGraph(focusedId, stemmaIndex, layout, {
+            origin,
+            neighborPositions,
+            ghostPositions: ghostSeedPositions,
+        });
+        const sim = configureGhostSim(graph, origin);
+
+        // Live position map shared with ghost-click handler and the focus
+        // controller hover-detection callback.
+        const positionsById = new Map<string, Pos>();
+        for (const n of graph.nodes) positionsById.set(n.id, { x: n.x, y: n.y });
+
+        const emitPositions = () => {
+            const live: Pos[] = [];
+            for (const n of graph.nodes) {
+                if (!n.isGhost) continue;
+                live.push({ x: n.x, y: n.y });
+            }
+            onpositionsChange(live);
+        };
+
+        emitPositions();
+
+        sim.on("tick", () => {
+            for (const n of graph.nodes) {
+                positionsById.set(n.id, { x: n.x, y: n.y });
+                if (n.isGhost) {
+                    const fEl = ghostFamilyEls.get(n.id);
+                    if (fEl) fEl.setAttribute("transform", `translate(${n.x},${n.y})`);
+                    const pEl = ghostPersonEls.get(n.id);
+                    if (pEl) pEl.setAttribute("transform", `translate(${n.x},${n.y})`);
+                } else {
+                    const el = neighborEls.get(n.id);
+                    if (!el) continue;
+                    el.setAttribute("transform", `translate(${n.x},${n.y})`);
+                    const d = neighborDatums.get(n.id);
+                    if (d) {
+                        d.x = n.x;
+                        d.y = n.y;
+                    }
+                }
+            }
+            for (const e of edgeRefs) {
+                const s = positionsById.get(e.sourceId);
+                const t = positionsById.get(e.targetId);
+                if (s && t) applyEdgeEndpoints(e, s, t);
+            }
+            emitPositions();
+        });
 
         let fadeInCancelled = false;
         requestAnimationFrame(() => {
             if (fadeInCancelled) return;
             for (const el of allGhostEls) el.style.opacity = "";
-        });
-
-        onpositionsChange([...familyAnchor.values(), ...personPos.values()]);
-
-        // One-way physics: ghosts are frozen at their planned positions but
-        // their collision circles push 1-hop real neighbours aside so existing
-        // nodes don't sit on top of the affordances. Real non-neighbour nodes
-        // stay pinned at their current positions.
-        type SimNode = {
-            id: string;
-            x: number;
-            y: number;
-            fx?: number | null;
-            fy?: number | null;
-            isGhost: boolean;
-            el?: SVGGElement | null;
-            datum?: any;
-        };
-
-        const neighborDomIds = new Set(
-            immediateNeighborIds(focusedId, stemmaIndex).map((n) => normalizeId(n.kind, n.id)),
-        );
-        const positionSnapshot = new Map<string, { x: number; y: number }>();
-        const simNodes: SimNode[] = [];
-        const neighborSims: SimNode[] = [];
-
-        d3.select("g.main").selectAll<SVGGElement, any>("g").each(function (this: SVGGElement, d: any) {
-            if (!d || d.x == null || d.y == null) return;
-            positionSnapshot.set(d.id, { x: d.x, y: d.y });
-            const isNeighbor = neighborDomIds.has(d.id);
-            const sim: SimNode = {
-                id: d.id,
-                x: d.x,
-                y: d.y,
-                fx: isNeighbor ? null : d.x,
-                fy: isNeighbor ? null : d.y,
-                isGhost: false,
-                el: this,
-                datum: d,
-            };
-            simNodes.push(sim);
-            if (isNeighbor) neighborSims.push(sim);
-        });
-
-        // Ghost sim nodes: frozen at the static plan positions.
-        for (const f of layout.families) {
-            const pos = familyAnchor.get(f.id);
-            if (!pos) continue;
-            simNodes.push({ id: f.id, x: pos.x, y: pos.y, fx: pos.x, fy: pos.y, isGhost: true });
-        }
-        for (const p of layout.persons) {
-            const pos = personPos.get(p.id);
-            if (!pos) continue;
-            simNodes.push({ id: p.id, x: pos.x, y: pos.y, fx: pos.x, fy: pos.y, isGhost: true });
-        }
-
-        const sim = d3
-            .forceSimulation<SimNode>(simNodes)
-            .force("collide", d3.forceCollide<SimNode>().radius(GHOST_COLLIDE_RADIUS).strength(0.9))
-            .alphaDecay(0.04)
-            .velocityDecay(0.5);
-
-        sim.on("tick", () => {
-            for (const n of neighborSims) {
-                if (!n.el) continue;
-                n.el.setAttribute("transform", `translate(${n.x},${n.y})`);
-                if (n.datum) {
-                    n.datum.x = n.x;
-                    n.datum.y = n.y;
-                }
-            }
         });
 
         return () => {
@@ -320,14 +364,15 @@
             // synchronously so the next focus snapshot doesn't pick up
             // mid-physics coordinates. Datum fx/fy is left as FullStemma set
             // it — edit mode keeps every real node pinned anyway.
-            for (const n of neighborSims) {
-                const snap = positionSnapshot.get(n.id);
+            for (const [id, el] of neighborEls) {
+                const snap = positionSnapshot.get(id);
                 if (!snap) continue;
-                if (n.datum) {
-                    n.datum.x = snap.x;
-                    n.datum.y = snap.y;
+                const d = neighborDatums.get(id);
+                if (d) {
+                    d.x = snap.x;
+                    d.y = snap.y;
                 }
-                if (n.el) n.el.setAttribute("transform", `translate(${snap.x},${snap.y})`);
+                el.setAttribute("transform", `translate(${snap.x},${snap.y})`);
             }
         };
     });

--- a/frontend/src/v3/ghostSim.test.ts
+++ b/frontend/src/v3/ghostSim.test.ts
@@ -17,9 +17,9 @@ import { normalizeId } from "../graphTools";
 
 describe("ghost sim tuning constants", () => {
     it("decay constants are heavier than the main edit-off sim defaults", () => {
-        // d3 defaults: alphaDecay ≈ 0.0228, velocityDecay = 0.4.
-        // Main edit-off sim uses velocityDecay 0.8. Ghost must be strictly heavier
-        // so it settles inside the 300–500 ms budget called out in #219.
+        // d3 defaults: alphaDecay ≈ 0.0228, velocityDecay = 0.4. Main edit-off
+        // sim uses velocityDecay 0.8. Ghost must be strictly heavier so it
+        // settles inside the 300–500 ms target.
         expect(GHOST_SIM_ALPHA_DECAY).toBeGreaterThan(0.1);
         expect(GHOST_SIM_VELOCITY_DECAY).toBeGreaterThanOrEqual(0.8);
     });

--- a/frontend/src/v3/ghostSim.test.ts
+++ b/frontend/src/v3/ghostSim.test.ts
@@ -1,0 +1,265 @@
+import {
+    GHOST_SIM_ALPHA_DECAY,
+    GHOST_SIM_CENTER_STRENGTH,
+    GHOST_SIM_CHARGE_STRENGTH,
+    GHOST_SIM_COLLIDE_RADIUS,
+    GHOST_SIM_LINK_DISTANCE,
+    GHOST_SIM_LINK_STRENGTH,
+    GHOST_SIM_VELOCITY_DECAY,
+    buildGhostSimGraph,
+    configureGhostSim,
+    ghostSimNeighborDomIds,
+} from "./ghostSim";
+import { deriveGhostLayout } from "./ghostHelpers";
+import type { Stemma } from "../model";
+import { StemmaIndex } from "../stemmaIndex";
+import { normalizeId } from "../graphTools";
+
+describe("ghost sim tuning constants", () => {
+    it("decay constants are heavier than the main edit-off sim defaults", () => {
+        // d3 defaults: alphaDecay ≈ 0.0228, velocityDecay = 0.4.
+        // Main edit-off sim uses velocityDecay 0.8. Ghost must be strictly heavier
+        // so it settles inside the 300–500 ms budget called out in #219.
+        expect(GHOST_SIM_ALPHA_DECAY).toBeGreaterThan(0.1);
+        expect(GHOST_SIM_VELOCITY_DECAY).toBeGreaterThanOrEqual(0.8);
+    });
+
+    it("link force is attractive, charge force is repulsive", () => {
+        expect(GHOST_SIM_LINK_DISTANCE).toBeGreaterThan(0);
+        expect(GHOST_SIM_LINK_STRENGTH).toBeGreaterThan(0);
+        expect(GHOST_SIM_CHARGE_STRENGTH).toBeLessThan(0);
+    });
+
+    it("centring and collide are positive", () => {
+        expect(GHOST_SIM_CENTER_STRENGTH).toBeGreaterThan(0);
+        expect(GHOST_SIM_COLLIDE_RADIUS).toBeGreaterThan(0);
+    });
+});
+
+function isolatedStemma(): Stemma {
+    return {
+        type: "Stemma",
+        people: [{ type: "PersonDescription", id: "lone", name: "Lone", readOnly: false }],
+        families: [],
+    };
+}
+
+function familyStemma(): Stemma {
+    return {
+        type: "Stemma",
+        people: [
+            { type: "PersonDescription", id: "p1", name: "Alice", readOnly: false },
+            { type: "PersonDescription", id: "p2", name: "Bob", readOnly: false },
+            { type: "PersonDescription", id: "p3", name: "Carol", readOnly: false },
+            { type: "PersonDescription", id: "p4", name: "Far", readOnly: false },
+        ],
+        families: [
+            { type: "FamilyDescription", id: "f1", parents: ["p1", "p2"], children: ["p3"], readOnly: false },
+        ],
+    };
+}
+
+describe("buildGhostSimGraph — neighbour selection", () => {
+    it("includes focused, 1-hop neighbours, and ghosts; excludes non-neighbour real nodes", () => {
+        const index = new StemmaIndex(familyStemma());
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const neighborIds = ghostSimNeighborDomIds(focused, index);
+        const seed = {
+            origin: { x: 0, y: 0 },
+            neighborPositions: new Map([...neighborIds].map((id) => [id, { x: 0, y: 0 }])),
+            ghostPositions: new Map(
+                layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }]),
+            ),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const ids = new Set(graph.nodes.map((n) => n.id));
+        expect(ids.has(normalizeId("family", "f1"))).toBe(true);
+        expect(ids.has(normalizeId("person", "p1"))).toBe(true);
+        expect(ids.has(normalizeId("person", "p2"))).toBe(true);
+        expect(ids.has(normalizeId("person", "p3"))).toBe(true);
+        expect(ids.has(normalizeId("person", "p4"))).toBe(false);
+        expect(ids.has("ghost-person-child")).toBe(true);
+    });
+
+    it("pins focused node at origin (fx/fy set)", () => {
+        const index = new StemmaIndex(familyStemma());
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const seed = {
+            origin: { x: 100, y: 200 },
+            neighborPositions: new Map(),
+            ghostPositions: new Map(layout.persons.map((p) => [p.id, { x: 100 + p.dx, y: 200 + p.dy }])),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const focusedNode = graph.nodes.find((n) => n.id === normalizeId("family", "f1"))!;
+        expect(focusedNode.fx).toBe(100);
+        expect(focusedNode.fy).toBe(200);
+        expect(focusedNode.isGhost).toBe(false);
+    });
+
+    it("ghost nodes are unfrozen (no fx/fy)", () => {
+        const index = new StemmaIndex(isolatedStemma());
+        const focused = { kind: "person" as const, id: "lone" };
+        const layout = deriveGhostLayout(focused, index);
+        const seed = {
+            origin: { x: 0, y: 0 },
+            neighborPositions: new Map(),
+            ghostPositions: new Map([
+                ...layout.families.map((f) => [f.id, { x: f.dx, y: f.dy }] as const),
+                ...layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }] as const),
+            ]),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        for (const n of graph.nodes) {
+            if (!n.isGhost) continue;
+            expect(n.fx == null).toBe(true);
+            expect(n.fy == null).toBe(true);
+        }
+    });
+
+    it("excludes pending entities from the neighbour set", () => {
+        const stemma: Stemma = {
+            type: "Stemma",
+            people: [
+                { type: "PersonDescription", id: "p1", name: "Alice", readOnly: false },
+                { type: "PersonDescription", id: "p2", name: "Bob", readOnly: false },
+            ],
+            families: [
+                { type: "FamilyDescription", id: "fReal", parents: ["p1", "p2"], children: [], readOnly: false },
+                {
+                    type: "FamilyDescription",
+                    id: "pending-family-xyz",
+                    parents: ["p1"],
+                    children: [],
+                    readOnly: true,
+                },
+            ],
+        };
+        const index = new StemmaIndex(stemma);
+        const focused = { kind: "person" as const, id: "p1" };
+        const ids = ghostSimNeighborDomIds(focused, index);
+        expect(ids.has(normalizeId("family", "pending-family-xyz"))).toBe(false);
+        expect(ids.has(normalizeId("family", "fReal"))).toBe(true);
+        expect(ids.has(normalizeId("person", "p2"))).toBe(true);
+    });
+
+    it("builds real-family links among focused + neighbours", () => {
+        const index = new StemmaIndex(familyStemma());
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const neighborIds = ghostSimNeighborDomIds(focused, index);
+        const seed = {
+            origin: { x: 0, y: 0 },
+            neighborPositions: new Map([...neighborIds].map((id) => [id, { x: 0, y: 0 }])),
+            ghostPositions: new Map(layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }])),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const famDom = normalizeId("family", "f1");
+        const hasLink = (a: string, b: string) =>
+            graph.links.some((l) => l.source === a && l.target === b);
+        expect(hasLink(normalizeId("person", "p1"), famDom)).toBe(true);
+        expect(hasLink(normalizeId("person", "p2"), famDom)).toBe(true);
+        expect(hasLink(famDom, normalizeId("person", "p3"))).toBe(true);
+    });
+
+    it("links the focused-family ghost-child to the focused family", () => {
+        const index = new StemmaIndex(familyStemma());
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const seed = {
+            origin: { x: 0, y: 0 },
+            neighborPositions: new Map(),
+            ghostPositions: new Map(layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }])),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const famDom = normalizeId("family", "f1");
+        const hasLink = (a: string, b: string) =>
+            graph.links.some((l) => l.source === a && l.target === b);
+        expect(hasLink(famDom, "ghost-person-child")).toBe(true);
+    });
+});
+
+describe("configureGhostSim — runs to completion", () => {
+    it("settles below alphaMin within ~50 ticks", () => {
+        const index = new StemmaIndex(familyStemma());
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const neighborIds = ghostSimNeighborDomIds(focused, index);
+        const seed = {
+            origin: { x: 0, y: 0 },
+            neighborPositions: new Map([...neighborIds].map((id, i) => [id, { x: i * 30, y: i * 10 }])),
+            ghostPositions: new Map(layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }])),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const sim = configureGhostSim(graph, seed.origin);
+        sim.stop();
+        for (let i = 0; i < 50; i++) sim.tick();
+        expect(sim.alpha()).toBeLessThan(0.001);
+    });
+
+    it("keeps the focused node pinned at origin throughout the sim", () => {
+        const index = new StemmaIndex(familyStemma());
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const neighborIds = ghostSimNeighborDomIds(focused, index);
+        const origin = { x: 50, y: 60 };
+        const seed = {
+            origin,
+            neighborPositions: new Map([...neighborIds].map((id, i) => [id, { x: i * 30, y: i * 10 }])),
+            ghostPositions: new Map(layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }])),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const sim = configureGhostSim(graph, origin);
+        sim.stop();
+        for (let i = 0; i < 50; i++) sim.tick();
+        const focusedNode = graph.nodes.find((n) => n.id === normalizeId("family", "f1"))!;
+        expect(focusedNode.x).toBe(origin.x);
+        expect(focusedNode.y).toBe(origin.y);
+    });
+
+    it("spreads a real child and a ghost child so they end up well apart around the family", () => {
+        // AC: "With one real child + one ghost-child under a focused family,
+        // the two siblings end up at roughly opposite angles around the family."
+        // Single-parent family so the symmetry isn't biased by a second parent.
+        const stemma: Stemma = {
+            type: "Stemma",
+            people: [
+                { type: "PersonDescription", id: "p1", name: "Alice", readOnly: false },
+                { type: "PersonDescription", id: "p3", name: "Carol", readOnly: false },
+            ],
+            families: [
+                { type: "FamilyDescription", id: "f1", parents: ["p1"], children: ["p3"], readOnly: false },
+            ],
+        };
+        const index = new StemmaIndex(stemma);
+        const focused = { kind: "family" as const, id: "f1" };
+        const layout = deriveGhostLayout(focused, index);
+        const origin = { x: 0, y: 0 };
+        const childDom = normalizeId("person", "p3");
+        const seed = {
+            origin,
+            neighborPositions: new Map([
+                [normalizeId("person", "p1"), { x: 0, y: -100 }],
+                [childDom, { x: 60, y: 60 }],
+            ]),
+            ghostPositions: new Map(layout.persons.map((p) => [p.id, { x: p.dx, y: p.dy }])),
+        };
+        const graph = buildGhostSimGraph(focused, index, layout, seed);
+        const sim = configureGhostSim(graph, origin);
+        sim.stop();
+        for (let i = 0; i < 80; i++) sim.tick();
+        const realChild = graph.nodes.find((n) => n.id === childDom)!;
+        const ghostChild = graph.nodes.find((n) => n.id === "ghost-person-child")!;
+        // Siblings end up clearly separated so the user can click either
+        // without overlap. >1.5× collide-radius covers the practical case.
+        const sepDist = Math.hypot(realChild.x - ghostChild.x, realChild.y - ghostChild.y);
+        expect(sepDist).toBeGreaterThan(GHOST_SIM_COLLIDE_RADIUS * 1.5);
+        // And the angle between them around the family is wide (≥ 45°), so
+        // they sit on visibly different arcs around the family node.
+        const dot = realChild.x * ghostChild.x + realChild.y * ghostChild.y;
+        const magReal = Math.hypot(realChild.x, realChild.y);
+        const magGhost = Math.hypot(ghostChild.x, ghostChild.y);
+        expect(dot / (magReal * magGhost)).toBeLessThan(0.7);
+    });
+});

--- a/frontend/src/v3/ghostSim.ts
+++ b/frontend/src/v3/ghostSim.ts
@@ -1,0 +1,175 @@
+import * as d3 from "d3";
+import { normalizeId } from "../graphTools";
+import type { StemmaIndex } from "../stemmaIndex";
+import type { FocusedId } from "./focusGesture";
+import {
+    FOCUSED_FAMILY_REF,
+    immediateNeighborIds,
+    realFamilyIdFromRef,
+    type GhostLayout,
+} from "./ghostHelpers";
+
+/**
+ * Force tuning for the ghost-mode mini-simulation. The topology mirrors the
+ * main edit-off chart (link + repulsion + centring) but the decays are heavy
+ * so the system settles in well under a second: ~20 ticks (333 ms @ 60fps)
+ * to alpha < 0.01, ~31 ticks (517 ms) to alphaMin (default 0.001).
+ */
+export const GHOST_SIM_LINK_DISTANCE = 85;
+export const GHOST_SIM_LINK_STRENGTH = 2;
+export const GHOST_SIM_CHARGE_STRENGTH = -800;
+export const GHOST_SIM_CENTER_STRENGTH = 0.15;
+export const GHOST_SIM_VELOCITY_DECAY = 0.85;
+export const GHOST_SIM_ALPHA_DECAY = 0.2;
+export const GHOST_SIM_COLLIDE_RADIUS = 36;
+
+export type GhostSimNode = {
+    id: string;
+    x: number;
+    y: number;
+    fx?: number | null;
+    fy?: number | null;
+    isGhost: boolean;
+};
+
+export type GhostSimLink = { source: string; target: string };
+
+export type GhostSimGraph = {
+    nodes: GhostSimNode[];
+    links: GhostSimLink[];
+    focusedDomId: string;
+};
+
+export type GhostSimSeed = {
+    origin: { x: number; y: number };
+    /** dom-id (normalizeId) -> current position. Must already exclude pending entities and focused. */
+    neighborPositions: Map<string, { x: number; y: number }>;
+    /** ghost-id (raw layout id) -> seed position. */
+    ghostPositions: Map<string, { x: number; y: number }>;
+};
+
+/**
+ * Build the (nodes, links) graph used by the ghost sim. Topology:
+ *   - focused (pinned at origin)
+ *   - every 1-hop real neighbour (unfrozen)
+ *   - every ghost family + ghost person (unfrozen, seeded at plan position)
+ * Links replicate the real spouse→family / family→child relations among the
+ * focused-plus-neighbours subset, plus the ghost relations declared in
+ * `layout.anchorEdges` and `layout.persons[*].familyId`.
+ */
+export function buildGhostSimGraph(
+    focusedId: FocusedId,
+    stemmaIndex: StemmaIndex,
+    layout: GhostLayout,
+    seed: GhostSimSeed,
+): GhostSimGraph {
+    const focusedDomId = normalizeId(focusedId.kind, focusedId.id);
+    const nodes: GhostSimNode[] = [];
+    const present = new Set<string>();
+
+    nodes.push({
+        id: focusedDomId,
+        x: seed.origin.x,
+        y: seed.origin.y,
+        fx: seed.origin.x,
+        fy: seed.origin.y,
+        isGhost: false,
+    });
+    present.add(focusedDomId);
+
+    for (const [domId, pos] of seed.neighborPositions) {
+        if (present.has(domId)) continue;
+        nodes.push({ id: domId, x: pos.x, y: pos.y, isGhost: false });
+        present.add(domId);
+    }
+
+    for (const f of layout.families) {
+        const pos = seed.ghostPositions.get(f.id);
+        if (!pos) continue;
+        nodes.push({ id: f.id, x: pos.x, y: pos.y, isGhost: true });
+        present.add(f.id);
+    }
+    for (const p of layout.persons) {
+        const pos = seed.ghostPositions.get(p.id);
+        if (!pos) continue;
+        nodes.push({ id: p.id, x: pos.x, y: pos.y, isGhost: true });
+        present.add(p.id);
+    }
+
+    const links: GhostSimLink[] = [];
+    const addLink = (source: string, target: string) => {
+        if (!present.has(source) || !present.has(target)) return;
+        links.push({ source, target });
+    };
+
+    const familyIds: string[] = focusedId.kind === "person"
+        ? stemmaIndex.relatedFamilies(focusedId.id).map((f) => f.id)
+        : [focusedId.id];
+
+    const visited = new Set<string>();
+    for (const fid of familyIds) {
+        if (visited.has(fid)) continue;
+        visited.add(fid);
+        const fam = stemmaIndex.family(fid);
+        if (!fam) continue;
+        const famDom = normalizeId("family", fid);
+        for (const pid of fam.parents ?? []) addLink(normalizeId("person", pid), famDom);
+        for (const cid of fam.children ?? []) addLink(famDom, normalizeId("person", cid));
+    }
+
+    for (const e of layout.anchorEdges) {
+        if (e.focusedRole === "parent") addLink(focusedDomId, e.familyId);
+        else addLink(e.familyId, focusedDomId);
+    }
+
+    for (const p of layout.persons) {
+        let famNode: string | null = null;
+        if (p.familyId === FOCUSED_FAMILY_REF) famNode = focusedDomId;
+        else if (realFamilyIdFromRef(p.familyId)) {
+            famNode = normalizeId("family", realFamilyIdFromRef(p.familyId)!);
+        } else {
+            famNode = p.familyId;
+        }
+        if (p.role === "parent") addLink(p.id, famNode);
+        else addLink(famNode, p.id);
+    }
+
+    return { nodes, links, focusedDomId };
+}
+
+export function configureGhostSim(
+    graph: GhostSimGraph,
+    origin: { x: number; y: number },
+): d3.Simulation<GhostSimNode, GhostSimLink> {
+    return d3
+        .forceSimulation<GhostSimNode>(graph.nodes)
+        .force(
+            "link",
+            d3
+                .forceLink<GhostSimNode, GhostSimLink>(graph.links)
+                .id((n) => n.id)
+                .distance(GHOST_SIM_LINK_DISTANCE)
+                .strength(GHOST_SIM_LINK_STRENGTH),
+        )
+        .force("charge", d3.forceManyBody<GhostSimNode>().strength(GHOST_SIM_CHARGE_STRENGTH))
+        .force("x", d3.forceX<GhostSimNode>(origin.x).strength(GHOST_SIM_CENTER_STRENGTH))
+        .force("y", d3.forceY<GhostSimNode>(origin.y).strength(GHOST_SIM_CENTER_STRENGTH))
+        .force(
+            "collide",
+            d3.forceCollide<GhostSimNode>().radius(GHOST_SIM_COLLIDE_RADIUS).strength(0.9),
+        )
+        .velocityDecay(GHOST_SIM_VELOCITY_DECAY)
+        .alphaDecay(GHOST_SIM_ALPHA_DECAY);
+}
+
+/** Convenience: dom-ids of the 1-hop real neighbours that should participate in the sim. */
+export function ghostSimNeighborDomIds(
+    focusedId: FocusedId,
+    stemmaIndex: StemmaIndex,
+): Set<string> {
+    const out = new Set<string>();
+    for (const ref of immediateNeighborIds(focusedId, stemmaIndex)) {
+        out.add(normalizeId(ref.kind, ref.id));
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary
- Replace the static ghost-pinning + collide-only layer with a d3 mini-sim that mirrors the main edit-off topology (link + repulsion + centring) over the ghost nodes and their 1-hop real neighbours.
- Heavy `alphaDecay` (0.2) + `velocityDecay` (0.85) settle the system in ~300–500 ms so the user can immediately click a ghost without chasing it. Non-neighbour real nodes stay frozen; the existing snap-back-on-blur is preserved.
- Pulled the sim graph + tuning into `frontend/src/v3/ghostSim.ts` so the neighbour selection, decay constants and runs-to-completion guarantee are unit-tested.

Closes #219

## Test plan
- [x] `npm test` (frontend, 23 suites / 204 tests)
- [x] `npm run check` (svelte-check, 0 errors / 0 warnings)
- [ ] Manual: focus a person and a family with at least one child; confirm ghosts and real siblings spread to non-overlapping arcs around the family and stop drifting within ~500 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)