### PR TITLE
Add close (X) button to FamilyCard header

### DIFF
--- a/frontend/src/components/FamilyCard.svelte
+++ b/frontend/src/components/FamilyCard.svelte
@@ -54,6 +54,14 @@
 <div>
     <div class="family-title">
         <span class="title-text">{familyTitle}</span>
+        <button
+            type="button"
+            class="card-close"
+            aria-label={$t("common.close")}
+            onclick={() => onclose?.()}
+        >
+            <i class="bi bi-x-lg"></i>
+        </button>
     </div>
 
     {#if family && family.parents.length > 0}
@@ -99,6 +107,10 @@
 
 <style>
     .family-title {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
         margin-bottom: 14px;
         line-height: 1.35;
     }
@@ -106,6 +118,32 @@
     .title-text {
         font-weight: 700;
         font-size: 0.95rem;
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .card-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: transparent;
+        border: none;
+        color: var(---text-muted);
+        cursor: pointer;
+        font-size: var(---fs-label);
+        transition: background-color 0.12s ease, color 0.12s ease;
+        flex-shrink: 0;
+    }
+
+    .card-close:hover {
+        background: #f1f3f5;
+        color: var(---text-primary);
     }
 
     .section-label {


### PR DESCRIPTION
## Summary
- Family description sheet now has an X close button in the header
- Markup + style copied from `Modal.svelte` `.modal-close` (`bi bi-x-lg`, 28×28 circular)
- Closes #224

## Test plan
- [x] `npm test` (23 suites, 204 tests pass)
- [x] `npm run check` (0 errors / 0 warnings)
- [ ] Manual: open family sheet, click X → closes without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)