### PR TITLE
Add minimap overlay for edit-mode canvas navigation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -31,6 +31,7 @@
     import EditModeOverlay from "./components/EditModeOverlay.svelte";
     import Chrome from "./components/Chrome.svelte";
     import PendingVisuals from "./components/PendingVisuals.svelte";
+    import Minimap from "./components/Minimap.svelte";
     import { buildInviteLink } from "./inviteLinkBuilder";
     import { Circle2 } from "svelte-loading-spinners";
     import { normalizeId } from "./graphTools";
@@ -73,6 +74,7 @@
     let promptModal = $state<ReturnType<typeof PromptModal> | null>(null);
     let confirmModal = $state<ReturnType<typeof ConfirmModal> | null>(null);
     let stemmaChart = $state<ReturnType<typeof FullStemma> | null>(null);
+    let minimap = $state<ReturnType<typeof Minimap> | null>(null);
 
     const controller = new AppController(untrack(() => stemma_backend_url));
 
@@ -251,6 +253,7 @@
                     onpersonSelected={handlePersonSelected}
                     onfamilySelected={handleFamilySelected}
                     onhighlightChanged={() => highlightVersion++}
+                    onzoomChanged={() => minimap?.refresh()}
                 />
             {/if}
 
@@ -297,6 +300,15 @@
             removedPersonIds={pendingRemovedPersonIds}
             removedFamilyIds={pendingRemovedFamilyIds}
             stemmaChartReady={!!stemmaChart}
+        />
+
+        <Minimap
+            bind:this={minimap}
+            {editMode}
+            stemmaChartReady={!!stemmaChart}
+            getSimulation={() => stemmaChart?.getSimulation() ?? null}
+            getZoomTransform={() => stemmaChart?.getZoomTransform() ?? null}
+            applyZoomTranslate={(tx, ty) => stemmaChart?.applyZoomTranslate(tx, ty)}
         />
 
         <Chrome

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -40,6 +40,7 @@
         onpersonSelected?: (person: any) => void;
         onfamilySelected?: (family: any) => void;
         onhighlightChanged?: () => void;
+        onzoomChanged?: () => void;
     };
 
     let {
@@ -55,6 +56,7 @@
         onpersonSelected,
         onfamilySelected,
         onhighlightChanged,
+        onzoomChanged,
     }: Props = $props();
 
     const hoveredPersonR = 25;
@@ -150,12 +152,28 @@
 
     const zoomHandler = d3.zoom().on("zoom", (e) => {
         svg.select("g.main").attr("transform", e.transform);
+        onzoomChanged?.();
     });
 
     export function exportSvg(filename: string) {
         if (!svg) return;
         const node = svg.node() as SVGSVGElement | null;
         if (node) exportChartSvg(node, filename);
+    }
+
+    export function getZoomTransform(): d3.ZoomTransform {
+        const node = svg?.node() as SVGSVGElement | null;
+        if (!node) return d3.zoomIdentity;
+        return d3.zoomTransform(node);
+    }
+
+    export function applyZoomTranslate(tx: number, ty: number) {
+        if (!svg) return;
+        const node = svg.node() as SVGSVGElement | null;
+        if (!node) return;
+        const current = d3.zoomTransform(node);
+        const next = d3.zoomIdentity.translate(tx, ty).scale(current.k);
+        svg.call(zoomHandler.transform, next as d3.ZoomTransform);
     }
 
     export function setSimulationActive(active: boolean) {

--- a/frontend/src/components/Minimap.svelte
+++ b/frontend/src/components/Minimap.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+    import * as d3 from "d3";
+    import { t } from "../i18n";
+    import {
+        computeBounds,
+        computeLayout,
+        projectNodes,
+        projectViewport,
+        minimapClickToTranslate,
+        type NodeDot,
+        type MinimapLayout,
+    } from "../minimapProjection";
+
+    type SimNode = { x?: number | null; y?: number | null; type?: string };
+    type Sim = d3.Simulation<SimNode, undefined>;
+
+    type Props = {
+        editMode: boolean;
+        stemmaChartReady: boolean;
+        getSimulation: () => Sim | null;
+        getZoomTransform: () => d3.ZoomTransform | null | undefined;
+        applyZoomTranslate: (tx: number, ty: number) => void;
+    };
+
+    let {
+        editMode,
+        stemmaChartReady,
+        getSimulation,
+        getZoomTransform,
+        applyZoomTranslate,
+    }: Props = $props();
+
+    const CANVAS_W = 160;
+    const CANVAS_H = 120;
+    const PERSON_R = 2.5;
+    const FAMILY_R = 1.5;
+
+    let visible = $state(true);
+    let nodes = $state<NodeDot[]>([]);
+    let currentTransform = $state<d3.ZoomTransform>(d3.zoomIdentity);
+    let isDragging = $state(false);
+    let viewWidth = $state(typeof window !== "undefined" ? window.innerWidth : 0);
+    let viewHeight = $state(typeof window !== "undefined" ? window.innerHeight : 0);
+    let layout = $state<MinimapLayout>({
+        scale: 1,
+        offsetX: 0,
+        offsetY: 0,
+        contentWidth: 0,
+        contentHeight: 0,
+    });
+
+    function readSimNodes(sim: Sim): NodeDot[] {
+        const out: NodeDot[] = [];
+        for (const n of sim.nodes()) {
+            if ((n.type === "person" || n.type === "family") && n.x != null && n.y != null) {
+                out.push({ x: n.x, y: n.y, type: n.type });
+            }
+        }
+        return out;
+    }
+
+    export function refresh() {
+        const sim = getSimulation();
+        const raw = sim ? readSimNodes(sim) : [];
+        const bounds = computeBounds(raw);
+        layout = computeLayout(bounds, CANVAS_W, CANVAS_H);
+        nodes = projectNodes(raw, layout);
+        currentTransform = getZoomTransform() ?? d3.zoomIdentity;
+    }
+
+    $effect(() => {
+        if (!editMode || !stemmaChartReady) return;
+
+        let rafHandle = 0;
+        const scheduleRefresh = () => {
+            cancelAnimationFrame(rafHandle);
+            rafHandle = requestAnimationFrame(refresh);
+        };
+
+        const sim = getSimulation();
+        sim?.on("tick.minimap", scheduleRefresh);
+        sim?.on("end.minimap", scheduleRefresh);
+
+        const onResize = () => {
+            viewWidth = window.innerWidth;
+            viewHeight = window.innerHeight;
+        };
+        window.addEventListener("resize", onResize);
+
+        scheduleRefresh();
+
+        return () => {
+            cancelAnimationFrame(rafHandle);
+            sim?.on("tick.minimap", null);
+            sim?.on("end.minimap", null);
+            window.removeEventListener("resize", onResize);
+        };
+    });
+
+    const projectedViewport = $derived(
+        projectViewport(currentTransform, viewWidth, viewHeight, layout),
+    );
+
+    function onMinimapPointerDown(event: PointerEvent) {
+        event.preventDefault();
+        (event.currentTarget as Element).setPointerCapture(event.pointerId);
+        isDragging = true;
+        panToPointer(event.offsetX, event.offsetY);
+    }
+
+    function onMinimapPointerMove(event: PointerEvent) {
+        if (!isDragging) return;
+        panToPointer(event.offsetX, event.offsetY);
+    }
+
+    function onMinimapPointerUp(event: PointerEvent) {
+        isDragging = false;
+        (event.currentTarget as Element).releasePointerCapture(event.pointerId);
+    }
+
+    function panToPointer(clickX: number, clickY: number) {
+        const [tx, ty] = minimapClickToTranslate(
+            clickX,
+            clickY,
+            layout,
+            currentTransform,
+            viewWidth,
+            viewHeight,
+        );
+        applyZoomTranslate(tx, ty);
+        currentTransform = getZoomTransform() ?? d3.zoomIdentity;
+    }
+</script>
+
+{#if editMode}
+    <div class="minimap-container" class:collapsed={!visible}>
+        <button
+            class="minimap-toggle"
+            title={visible ? $t("minimap.hide") : $t("minimap.show")}
+            aria-label={visible ? $t("minimap.hide") : $t("minimap.show")}
+            onclick={() => (visible = !visible)}
+        >
+            {#if visible}
+                <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M2 8a.5.5 0 0 1 .5-.5h11a.5.5 0 0 1 0 1h-11A.5.5 0 0 1 2 8z" fill="currentColor"/>
+                </svg>
+            {:else}
+                <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z" fill="currentColor"/>
+                </svg>
+            {/if}
+        </button>
+
+        {#if visible}
+            <svg
+                class="minimap-canvas"
+                width={CANVAS_W}
+                height={CANVAS_H}
+                role="img"
+                aria-label={$t("minimap.show")}
+                style="cursor: {isDragging ? 'grabbing' : 'crosshair'}"
+                onpointerdown={onMinimapPointerDown}
+                onpointermove={onMinimapPointerMove}
+                onpointerup={onMinimapPointerUp}
+            >
+                {#each nodes as node}
+                    {#if node.type === "person"}
+                        <circle cx={node.x} cy={node.y} r={PERSON_R} class="minimap-person" />
+                    {:else}
+                        <circle cx={node.x} cy={node.y} r={FAMILY_R} class="minimap-family" />
+                    {/if}
+                {/each}
+
+                <rect
+                    x={projectedViewport.x}
+                    y={projectedViewport.y}
+                    width={projectedViewport.width}
+                    height={projectedViewport.height}
+                    class="minimap-viewport"
+                />
+            </svg>
+        {/if}
+    </div>
+{/if}
+
+<style>
+    .minimap-container {
+        position: absolute;
+        bottom: 20px;
+        right: 20px;
+        z-index: 100;
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid rgba(0, 0, 0, 0.12);
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        user-select: none;
+    }
+
+    .minimap-container.collapsed {
+        border-radius: 50%;
+        width: 28px;
+        height: 28px;
+    }
+
+    .minimap-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 4px 6px;
+        color: #495057;
+        font-size: 10px;
+        min-width: 28px;
+        min-height: 20px;
+        align-self: flex-end;
+        line-height: 1;
+    }
+
+    .minimap-container.collapsed .minimap-toggle {
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        align-self: auto;
+    }
+
+    .minimap-toggle:hover {
+        color: #212529;
+        background: rgba(0, 0, 0, 0.05);
+    }
+
+    .minimap-canvas {
+        display: block;
+        touch-action: none;
+    }
+
+    :global(.minimap-person) {
+        fill: #5a7fa0;
+        opacity: 0.7;
+    }
+
+    :global(.minimap-family) {
+        fill: #326f93;
+        opacity: 0.7;
+    }
+
+    :global(.minimap-viewport) {
+        fill: rgba(100, 149, 237, 0.12);
+        stroke: #4a80c4;
+        stroke-width: 1.5px;
+        pointer-events: none;
+    }
+</style>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -230,6 +230,8 @@ export const en: Record<string, string> = {
     'createParentTitleOf': "Add {names}'s parent",
     'panModeOn': 'Pan canvas',
     'panModeOff': 'Exit pan mode',
+    'minimap.show': 'Show minimap',
+    'minimap.hide': 'Hide minimap',
 };
 
 export const ru: Record<string, string> = {
@@ -430,6 +432,8 @@ export const ru: Record<string, string> = {
     'createParentTitleOf': 'Добавить родителя {names}',
     'panModeOn': 'Перемещать холст',
     'panModeOff': 'Выйти из режима перемещения',
+    'minimap.show': 'Показать миникарту',
+    'minimap.hide': 'Скрыть миникарту',
 };
 
 const dictionaries: Record<Locale, Record<string, string>> = { en, ru };

--- a/frontend/src/minimapProjection.test.ts
+++ b/frontend/src/minimapProjection.test.ts
@@ -1,0 +1,128 @@
+import {
+    computeBounds,
+    computeLayout,
+    projectNodes,
+    projectViewport,
+    minimapClickToTranslate,
+    type NodeDot,
+} from "./minimapProjection";
+import { zoomIdentity } from "d3";
+
+describe("computeBounds", () => {
+    it("returns zeros for empty array", () => {
+        expect(computeBounds([])).toEqual({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+    });
+
+    it("handles a single node", () => {
+        const nodes: NodeDot[] = [{ x: 10, y: 20, type: "person" }];
+        expect(computeBounds(nodes)).toEqual({ minX: 10, minY: 20, maxX: 10, maxY: 20 });
+    });
+
+    it("computes correct min/max across multiple nodes", () => {
+        const nodes: NodeDot[] = [
+            { x: 50, y: 100, type: "person" },
+            { x: -30, y: 200, type: "family" },
+            { x: 80, y: 0, type: "person" },
+        ];
+        expect(computeBounds(nodes)).toEqual({ minX: -30, minY: 0, maxX: 80, maxY: 200 });
+    });
+});
+
+describe("computeLayout", () => {
+    it("fits content into canvas with uniform scale", () => {
+        const bounds = { minX: 0, minY: 0, maxX: 200, maxY: 100 };
+        const layout = computeLayout(bounds, 100, 100);
+        // available area 84x84 (100 - 2*8), content 200x100
+        // scaleX = 84/200 = 0.42, scaleY = 84/100 = 0.84 → scale = 0.42
+        expect(layout.scale).toBeCloseTo(0.42, 2);
+    });
+
+    it("centers content that is narrower than canvas", () => {
+        const bounds = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+        const layout = computeLayout(bounds, 200, 200);
+        // available 184x184, content 100x100 → scale = 1.84
+        // scaledW = 184, offsetX = 8 + 0 - 0 = 8
+        expect(layout.scale).toBeCloseTo(1.84, 2);
+        expect(layout.offsetX).toBeCloseTo(8, 2);
+        expect(layout.offsetY).toBeCloseTo(8, 2);
+    });
+
+    it("returns stable layout for zero-size content", () => {
+        const bounds = { minX: 50, minY: 50, maxX: 50, maxY: 50 };
+        const layout = computeLayout(bounds, 100, 100);
+        expect(layout.offsetX).toBe(50);
+        expect(layout.offsetY).toBe(50);
+    });
+});
+
+describe("projectNodes", () => {
+    it("applies scale and offset to each node", () => {
+        const nodes: NodeDot[] = [{ x: 10, y: 20, type: "person" }];
+        const layout = { scale: 2, offsetX: 5, offsetY: 3, contentWidth: 100, contentHeight: 100 };
+        const projected = projectNodes(nodes, layout);
+        expect(projected[0]).toEqual({ x: 25, y: 43, type: "person" });
+    });
+
+    it("preserves node type", () => {
+        const nodes: NodeDot[] = [{ x: 0, y: 0, type: "family" }];
+        const layout = { scale: 1, offsetX: 0, offsetY: 0, contentWidth: 0, contentHeight: 0 };
+        expect(projectNodes(nodes, layout)[0].type).toBe("family");
+    });
+
+    it("does not mutate inputs", () => {
+        const nodes: NodeDot[] = [{ x: 10, y: 20, type: "person" }];
+        const layout = { scale: 2, offsetX: 5, offsetY: 3, contentWidth: 100, contentHeight: 100 };
+        projectNodes(nodes, layout);
+        expect(nodes[0].x).toBe(10);
+    });
+});
+
+describe("projectViewport", () => {
+    it("projects identity transform to full content area", () => {
+        const layout = { scale: 1, offsetX: 0, offsetY: 0, contentWidth: 200, contentHeight: 200 };
+        const rect = projectViewport(zoomIdentity, 100, 100, layout);
+        // identity: k=1, tx=0, ty=0 → sim covers [0,100]x[0,100]
+        expect(rect.x).toBe(0);
+        expect(rect.y).toBe(0);
+        expect(rect.width).toBe(100);
+        expect(rect.height).toBe(100);
+    });
+
+    it("accounts for zoom scale", () => {
+        const transform = zoomIdentity.translate(0, 0).scale(2);
+        const layout = { scale: 1, offsetX: 0, offsetY: 0, contentWidth: 200, contentHeight: 200 };
+        // k=2, tx=0, ty=0 → sim covers [0,50]x[0,50]
+        const rect = projectViewport(transform, 100, 100, layout);
+        expect(rect.width).toBeCloseTo(50, 5);
+        expect(rect.height).toBeCloseTo(50, 5);
+    });
+
+    it("accounts for pan translation", () => {
+        const transform = zoomIdentity.translate(-100, -50);
+        const layout = { scale: 1, offsetX: 0, offsetY: 0, contentWidth: 200, contentHeight: 200 };
+        // k=1, tx=-100, ty=-50 → simLeft=100, simTop=50
+        const rect = projectViewport(transform, 200, 200, layout);
+        expect(rect.x).toBeCloseTo(100, 5);
+        expect(rect.y).toBeCloseTo(50, 5);
+    });
+});
+
+describe("minimapClickToTranslate", () => {
+    it("centres the view on the clicked sim point", () => {
+        const layout = { scale: 0.5, offsetX: 10, offsetY: 10, contentWidth: 200, contentHeight: 200 };
+        // click at minimap (60, 60) → simX = (60-10)/0.5 = 100, simY = 100
+        // k=1, viewWidth=200, viewHeight=200 → tx = 100 - 100*1 = 0, ty = 0
+        const [tx, ty] = minimapClickToTranslate(60, 60, layout, zoomIdentity, 200, 200);
+        expect(tx).toBeCloseTo(0, 5);
+        expect(ty).toBeCloseTo(0, 5);
+    });
+
+    it("preserves current zoom scale", () => {
+        const layout = { scale: 1, offsetX: 0, offsetY: 0, contentWidth: 100, contentHeight: 100 };
+        const transform = zoomIdentity.scale(2);
+        // click at (50,50) → simX=50, simY=50
+        // tx = viewW/2 - simX*k = 100 - 50*2 = 0
+        const [tx] = minimapClickToTranslate(50, 50, layout, transform, 200, 200);
+        expect(tx).toBeCloseTo(0, 5);
+    });
+});

--- a/frontend/src/minimapProjection.ts
+++ b/frontend/src/minimapProjection.ts
@@ -1,0 +1,119 @@
+import type { ZoomTransform } from "d3";
+
+export type NodeDot = { x: number; y: number; type: "person" | "family" };
+
+export type MinimapBounds = {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+};
+
+export type MinimapLayout = {
+    scale: number;
+    offsetX: number;
+    offsetY: number;
+    contentWidth: number;
+    contentHeight: number;
+};
+
+export type ViewportRect = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+const PADDING = 8;
+
+export function computeBounds(nodes: NodeDot[]): MinimapBounds {
+    if (nodes.length === 0) return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+    let minX = nodes[0].x;
+    let minY = nodes[0].y;
+    let maxX = nodes[0].x;
+    let maxY = nodes[0].y;
+    for (const n of nodes) {
+        if (n.x < minX) minX = n.x;
+        if (n.y < minY) minY = n.y;
+        if (n.x > maxX) maxX = n.x;
+        if (n.y > maxY) maxY = n.y;
+    }
+    return { minX, minY, maxX, maxY };
+}
+
+export function computeLayout(
+    bounds: MinimapBounds,
+    canvasWidth: number,
+    canvasHeight: number,
+): MinimapLayout {
+    const contentWidth = bounds.maxX - bounds.minX;
+    const contentHeight = bounds.maxY - bounds.minY;
+
+    const availW = canvasWidth - PADDING * 2;
+    const availH = canvasHeight - PADDING * 2;
+
+    if (contentWidth === 0 && contentHeight === 0) {
+        return { scale: 1, offsetX: canvasWidth / 2, offsetY: canvasHeight / 2, contentWidth: 0, contentHeight: 0 };
+    }
+
+    const scaleX = contentWidth > 0 ? availW / contentWidth : 1;
+    const scaleY = contentHeight > 0 ? availH / contentHeight : 1;
+    const scale = Math.min(scaleX, scaleY);
+
+    const scaledW = contentWidth * scale;
+    const scaledH = contentHeight * scale;
+    const offsetX = PADDING + (availW - scaledW) / 2 - bounds.minX * scale;
+    const offsetY = PADDING + (availH - scaledH) / 2 - bounds.minY * scale;
+
+    return { scale, offsetX, offsetY, contentWidth, contentHeight };
+}
+
+export function projectNodes(nodes: NodeDot[], layout: MinimapLayout): NodeDot[] {
+    return nodes.map((n) => ({
+        x: n.x * layout.scale + layout.offsetX,
+        y: n.y * layout.scale + layout.offsetY,
+        type: n.type,
+    }));
+}
+
+export function projectViewport(
+    transform: ZoomTransform,
+    viewWidth: number,
+    viewHeight: number,
+    layout: MinimapLayout,
+): ViewportRect {
+    const { k, x: tx, y: ty } = transform;
+
+    const simLeft = -tx / k;
+    const simTop = -ty / k;
+    const simRight = (viewWidth - tx) / k;
+    const simBottom = (viewHeight - ty) / k;
+
+    return {
+        x: simLeft * layout.scale + layout.offsetX,
+        y: simTop * layout.scale + layout.offsetY,
+        width: (simRight - simLeft) * layout.scale,
+        height: (simBottom - simTop) * layout.scale,
+    };
+}
+
+/**
+ * Given a pointer click at (clickX, clickY) in minimap-canvas coordinates,
+ * returns the new d3 zoom translate [tx, ty] that centres the view on that
+ * sim-space point while preserving the current zoom scale.
+ */
+export function minimapClickToTranslate(
+    clickX: number,
+    clickY: number,
+    layout: MinimapLayout,
+    currentTransform: ZoomTransform,
+    viewWidth: number,
+    viewHeight: number,
+): [number, number] {
+    const simX = (clickX - layout.offsetX) / layout.scale;
+    const simY = (clickY - layout.offsetY) / layout.scale;
+    const { k } = currentTransform;
+    const tx = viewWidth / 2 - simX * k;
+    const ty = viewHeight / 2 - simY * k;
+    return [tx, ty];
+}


### PR DESCRIPTION
## Summary
- New `Minimap.svelte` shows scaled-down view of all persons/families with viewport rectangle, click + drag pans main canvas
- Pure projection math in `minimapProjection.ts` (14 unit tests)
- `FullStemma` exports `getZoomTransform` / `applyZoomTranslate` + `onzoomChanged` callback prop; App wires it to `Minimap.refresh()`
- Window resize listener keeps viewport rect accurate while sim is at rest
- i18n keys `minimap.show` / `minimap.hide` in en + ru
- Closes #223

## Test plan
- [x] `npm test` (24 suites, 218 tests pass — incl. new `minimapProjection.test.ts`)
- [x] `npm run check` (0 errors / 0 warnings)
- [ ] Manual: enter edit mode, confirm minimap appears bottom-right; pan main canvas → viewport rect tracks; click minimap → canvas pans; drag viewport rect → real-time pan; toggle hide/show; resize window
- [ ] Manual: trees with hundreds of nodes — confirm rAF throttle keeps it smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)