### PR TITLE
v3 mobile long-press + ghost-family anchor fix

### DIFF
--- a/frontend/src/components/GhostLayer.svelte
+++ b/frontend/src/components/GhostLayer.svelte
@@ -219,7 +219,12 @@
         // semantic and must not drift under the sim's forceY/link pull. Ghosts
         // stay springy along x — collide + repel still push them rightward off
         // the focus and away from neighbours.
-        for (const extra of injection.extraNodes) (extra as any).fy = extra.y;
+        // ghost-family is an invisible-ish anchor for spouse/child edges; pin
+        // both axes so it stays at its seed and the arrows do not drift.
+        for (const extra of injection.extraNodes) {
+            (extra as any).fy = extra.y;
+            if (extra.type === "ghost-family") (extra as any).fx = extra.x;
+        }
 
         // Append ghost datums to main sim. d3.forceLink re-resolves string
         // source/target via the node-id accessor configured in


### PR DESCRIPTION
## Summary
- Mobile: long-press (≥`TAP_MAX_MS`) on a node opens edit modal; short-tap still focuses; desktop click opens modal.
- Fix ghost-family-east drifting sideways under d3 forces — pin `fx` (already pinned `fy`) so the anchor stays at its seed and ghost arrows line up with the focused node.

## Test plan
- [x] `npm run check`
- [x] `npm test` (204 passing)
- [ ] Manual: focus a person on desktop → spouse/child ghosts sit east, no stray dashed circle.
- [ ] Manual: long-press a person on mobile → edit modal opens. Short-tap → focus only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)