### PR TITLE
fix: directed cycle check allows consanguineous marriages

### DIFF
--- a/backend/src/stemma/services/stemma_dfs.py
+++ b/backend/src/stemma/services/stemma_dfs.py
@@ -5,35 +5,38 @@ from stemma.domain.responses import Stemma
 
 def has_cycles(stemma: Stemma) -> bool:
     adjacency: dict[str, list[str]] = defaultdict(list)
+    nodes: set[str] = set()
     for family in stemma.families:
-        fid = f"family_{family.id}"
-        parent_nodes = [f"person_{pid}" for pid in family.parents]
-        child_nodes = [f"person_{cid}" for cid in family.children]
-        adjacency[fid].extend(parent_nodes)
-        adjacency[fid].extend(child_nodes)
-        for pnode in parent_nodes:
-            adjacency[pnode].append(fid)
-        for cnode in child_nodes:
-            adjacency[cnode].append(fid)
+        for parent in family.parents:
+            nodes.add(parent)
+            for child in family.children:
+                nodes.add(child)
+                adjacency[parent].append(child)
 
-    visited: set[str] = set()
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {node: WHITE for node in nodes}
 
     def is_cyclic(start: str) -> bool:
-        stack: list[tuple[str, str | None]] = [(start, None)]
+        stack: list[tuple[str, int]] = [(start, 0)]
+        color[start] = GRAY
         while stack:
-            node, parent = stack.pop()
-            if node in visited:
-                return True
-            visited.add(node)
-            for neighbor in adjacency[node]:
-                if neighbor == parent:
-                    continue
-                if neighbor in visited:
+            node, index = stack[-1]
+            neighbors = adjacency[node]
+            if index < len(neighbors):
+                stack[-1] = (node, index + 1)
+                neighbor = neighbors[index]
+                state = color.get(neighbor, WHITE)
+                if state == GRAY:
                     return True
-                stack.append((neighbor, node))
+                if state == WHITE:
+                    color[neighbor] = GRAY
+                    stack.append((neighbor, 0))
+            else:
+                color[node] = BLACK
+                stack.pop()
         return False
 
-    for node in list(adjacency):
-        if node not in visited and is_cyclic(node):
+    for node in nodes:
+        if color[node] == WHITE and is_cyclic(node):
             return True
     return False

--- a/backend/src/stemma/services/stemma_dfs.py
+++ b/backend/src/stemma/services/stemma_dfs.py
@@ -7,14 +7,13 @@ def has_cycles(stemma: Stemma) -> bool:
     adjacency: dict[str, list[str]] = defaultdict(list)
     nodes: set[str] = set()
     for family in stemma.families:
+        nodes.update(family.parents)
+        nodes.update(family.children)
         for parent in family.parents:
-            nodes.add(parent)
-            for child in family.children:
-                nodes.add(child)
-                adjacency[parent].append(child)
+            adjacency[parent].extend(family.children)
 
     WHITE, GRAY, BLACK = 0, 1, 2
-    color: dict[str, int] = {node: WHITE for node in nodes}
+    color: dict[str, int] = dict.fromkeys(nodes, WHITE)
 
     def is_cyclic(start: str) -> bool:
         stack: list[tuple[str, int]] = [(start, 0)]
@@ -25,7 +24,7 @@ def has_cycles(stemma: Stemma) -> bool:
             if index < len(neighbors):
                 stack[-1] = (node, index + 1)
                 neighbor = neighbors[index]
-                state = color.get(neighbor, WHITE)
+                state = color[neighbor]
                 if state == GRAY:
                     return True
                 if state == WHITE:

--- a/backend/tests/test_stemma_dfs.py
+++ b/backend/tests/test_stemma_dfs.py
@@ -11,7 +11,7 @@ def test_minimal_stemma_has_no_cycles() -> None:
     assert has_cycles(stemma) is False
 
 
-def test_detects_cycle() -> None:
+def test_marriage_between_shared_ancestor_descendants_is_not_a_cycle() -> None:
     stemma = Stemma(
         people=[],
         families=[
@@ -20,7 +20,7 @@ def test_detects_cycle() -> None:
             _family("3", ["Petr", "Ekaterina"], []),
         ],
     )
-    assert has_cycles(stemma) is True
+    assert has_cycles(stemma) is False
 
 
 def test_more_complicated_stemma_with_no_cycles() -> None:
@@ -30,6 +30,30 @@ def test_more_complicated_stemma_with_no_cycles() -> None:
             _family("1", ["Marina", "Ivan"], ["Petr"]),
             _family("2", ["Petr"], ["Ekaterina"]),
             _family("3", ["Aleksei", "Ekaterina"], ["Eva"]),
+        ],
+    )
+    assert has_cycles(stemma) is False
+
+
+def test_self_descendant_directed_cycle_detected() -> None:
+    stemma = Stemma(
+        people=[],
+        families=[
+            _family("1", ["Jane"], ["Jill"]),
+            _family("2", ["Jill"], ["Jane"]),
+        ],
+    )
+    assert has_cycles(stemma) is True
+
+
+def test_cousin_marriage_with_children_not_a_cycle() -> None:
+    stemma = Stemma(
+        people=[],
+        families=[
+            _family("1", ["Ancestor"], ["Aunt", "Uncle"]),
+            _family("2", ["Aunt"], ["Cousin1"]),
+            _family("3", ["Uncle"], ["Cousin2"]),
+            _family("4", ["Cousin1", "Cousin2"], ["GreatGrandchild"]),
         ],
     )
     assert has_cycles(stemma) is False

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -408,7 +408,7 @@ def test_can_add_parents_if_child_has_spouse_and_child(storage: StorageService) 
     )
 
 
-def test_loops_prohibited(storage: StorageService) -> None:
+def test_consanguineous_marriage_allowed(storage: StorageService) -> None:
     user = storage.get_or_create_user("user1@test.com")
     sid = storage.create_stemma(user.user_id, "my first stemma")
     _, f1 = storage.create_family(user.user_id, sid, family(create_jane)(create_jill))
@@ -418,8 +418,21 @@ def test_loops_prohibited(storage: StorageService) -> None:
     josh_id = f2.children[0]
     _, f3 = storage.create_family(user.user_id, sid, family(existing(josh_id))(create_jabe))
     jabe_id = f3.children[0]
+    storage.create_family(user.user_id, sid, family(existing(jabe_id), existing(jill_id))())
+
+    stemma = storage.stemma(user.user_id, sid)
+    parent_pairs = {tuple(sorted(f.parents)) for f in stemma.families}
+    assert tuple(sorted([jabe_id, jill_id])) in parent_pairs
+
+
+def test_self_descendant_cycle_prohibited(storage: StorageService) -> None:
+    user = storage.get_or_create_user("user1@test.com")
+    sid = storage.create_stemma(user.user_id, "my first stemma")
+    _, f1 = storage.create_family(user.user_id, sid, family(create_jane)(create_jill))
+    jane_id = f1.parents[0]
+    jill_id = f1.children[0]
     with pytest.raises(StemmaHasCycles):
-        storage.create_family(user.user_id, sid, family(existing(jabe_id), existing(jill_id))())
+        storage.create_family(user.user_id, sid, family(existing(jill_id))(existing(jane_id)))
 
 
 @pytest.mark.parametrize("value", [None, ""])


### PR DESCRIPTION
## Summary
- Replace undirected DFS in `stemma_dfs.has_cycles` with a directed DFS over parent→child edges. Marriages between people sharing a distant ancestor no longer raise `StemmaHasCycles`; only true self-descendant cycles do.
- Storage layer / `RequestHandler` untouched — only the cycle predicate semantics changed.
- Updated existing cycle tests in `test_stemma_dfs.py` and `test_storage_service.py` to reflect the new contract; added regression tests for the self-descendant case and cousin-marriage-with-descendants.

Closes #233

## Test plan
- [x] `uv run pytest` (90 passed)
- [x] `uv run ruff check`
- [x] `uv run pyright`

🤖 Generated with [Claude Code](https://claude.com/claude-code)