### PR TITLE
fix: ship requests in Lambda layer so BFF auth boots

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "cryptography>=43",
     "google-auth>=2.35",
     "python-dateutil>=2.9",
+    "requests>=2.32",
 ]
 
 [dependency-groups]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -848,6 +848,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "pydantic" },
     { name = "python-dateutil" },
+    { name = "requests" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -870,6 +871,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.35" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "python-dateutil", specifier = ">=2.9" },
+    { name = "requests", specifier = ">=2.32" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 


### PR DESCRIPTION
## Summary
- Prod Lambda has been returning 500 on every `/stemma` POST since the BFF cookie-auth migration (#235) — `lambda_main` import dies with `Runtime.ImportModuleError: ... requests library is not installed`.
- `GoogleTokenVerifier` (new in that PR) pulls in `google.auth.transport.requests`, which imports the `requests` package at module load. Pre-BFF, token verification ran in API Gateway's JWT authorizer, so Python never needed `requests`.
- `requests` was only in the lockfile transitively via dev deps; `uv export --no-dev` in CD stripped it out of the layer.
- Fix: promote `requests>=2.32` to a prod dep.

## Test plan
- [x] `uv run pytest` (102 passed)
- [x] `uv export --no-dev` now lists `requests==2.34.2`
- [ ] After merge, watch CD redeploy and confirm login works against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)