### PR TITLE
fix: stop double-suffixing Google OAuth audience

### DIFF
--- a/backend/src/stemma/apps/auth.py
+++ b/backend/src/stemma/apps/auth.py
@@ -20,7 +20,7 @@ class AllowAnyTokenVerifier:
 
 class GoogleTokenVerifier:
     def __init__(self, client_id: str) -> None:
-        self._audience = f"{client_id}.apps.googleusercontent.com"
+        self._audience = client_id
         self._request = google_requests.Request()
 
     def email_from(self, token: str) -> str:


### PR DESCRIPTION
## Summary
- After #236 unblocked the Lambda import, login still 401'd with `Token has wrong audience ...googleusercontent.com, expected one of [...googleusercontent.com.apps.googleusercontent.com]`.
- `GoogleTokenVerifier.__init__` was appending `.apps.googleusercontent.com` to `client_id`, but the value in `template.yaml` (and the frontend env) already includes the suffix.
- Use `client_id` verbatim.

## Test plan
- [x] `uv run pytest` (102 passed)
- [ ] After merge, login against prod and confirm session cookie is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)