### PR TITLE
fix: clear dependabot alerts (starlette + d3-color)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115",
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.32",
     "boto3>=1.35",
     "pydantic>=2.9",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -827,14 +827,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -849,6 +849,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "requests" },
+    { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -872,6 +873,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9" },
     { name = "python-dateutil", specifier = ">=2.9" },
     { name = "requests", specifier = ">=2.32" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3980,12 +3980,6 @@
         "d3-transition": "^1.0.0"
       }
     },
-    "node_modules/d3fc-data-join/node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3fc-data-join/node_modules/d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
@@ -4050,12 +4044,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3fc-label-layout/node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/d3fc-label-layout/node_modules/d3-format": {
@@ -10356,7 +10344,7 @@
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
-        "d3-color": "3",
+        "d3-color": "^3.1.0",
         "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
@@ -10538,7 +10526,7 @@
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dev": true,
       "requires": {
-        "d3-color": "1 - 3"
+        "d3-color": "^3.1.0"
       }
     },
     "d3-path": {
@@ -10584,7 +10572,7 @@
       "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
       "dev": true,
       "requires": {
-        "d3-color": "1 - 3",
+        "d3-color": "^3.1.0",
         "d3-interpolate": "1 - 3"
       }
     },
@@ -10633,7 +10621,7 @@
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "dev": true,
       "requires": {
-        "d3-color": "1 - 3",
+        "d3-color": "^3.1.0",
         "d3-dispatch": "1 - 3",
         "d3-ease": "1 - 3",
         "d3-interpolate": "1 - 3",
@@ -10662,11 +10650,6 @@
         "d3-transition": "^1.0.0"
       },
       "dependencies": {
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        },
         "d3-dispatch": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
@@ -10682,7 +10665,7 @@
           "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
           "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
           "requires": {
-            "d3-color": "1"
+            "d3-color": "^3.1.0"
           }
         },
         "d3-selection": {
@@ -10700,7 +10683,7 @@
           "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
           "integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
           "requires": {
-            "d3-color": "1",
+            "d3-color": "^3.1.0",
             "d3-dispatch": "1",
             "d3-ease": "1",
             "d3-interpolate": "1",
@@ -10727,11 +10710,6 @@
           "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
           "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
         },
-        "d3-color": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-          "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-        },
         "d3-format": {
           "version": "1.4.5",
           "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
@@ -10742,7 +10720,7 @@
           "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
           "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
           "requires": {
-            "d3-color": "1"
+            "d3-color": "^3.1.0"
           }
         },
         "d3-scale": {
@@ -10752,7 +10730,7 @@
           "requires": {
             "d3-array": "^1.2.0",
             "d3-collection": "1",
-            "d3-color": "1",
+            "d3-color": "^3.1.0",
             "d3-format": "1",
             "d3-interpolate": "1",
             "d3-time": "1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,5 +54,8 @@
     "sirv-cli": "^3.0.1",
     "svelte-loading-spinners": "^0.3.6",
     "svelte-select": "^5.8.3"
+  },
+  "overrides": {
+    "d3-color": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Pin `starlette>=1.0.1` in backend deps so the bumped fastapi resolution drops the 1.0.0 host-header bug (Dependabot #52, medium).
- Add npm `overrides` for `d3-color^3.1.0` to evict the 1.4.1 copy still pulled in by `d3fc-data-join` / `d3fc-label-layout` (Dependabot #51, high — ReDoS).

## Test plan
- [x] `uv run pytest` (109/109)
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `npm run check`
- [x] `npm test` (213/213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)