### PR TITLE
Enable FedCM One Tap, keep auto-select armed for returning users

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,7 +12,7 @@
     import { PinnedPeopleStorage } from "./pinnedPeopleStorage";
     import { ViewMode } from "./model";
     import { LocalizedError, t } from "./i18n";
-    import { disableAutoSelect, initializeGoogleAuth } from "./googleAuth";
+    import { initializeGoogleAuth } from "./googleAuth";
     import Authenticate from "./components/Authenticate.svelte";
     import FullStemma from "./components/FullStemma.svelte";
     import Sheet from "./components/Sheet.svelte";
@@ -105,11 +105,8 @@
     const session = new Session(
         controller.model,
         { get: () => signedIn, set: (v) => (signedIn = v) },
-        {
-            onSignIn: () => {
-                void loadStemmasOrSignOut();
-            },
-            onSignOut: () => disableAutoSelect(),
+        () => {
+            void loadStemmasOrSignOut();
         },
     );
 
@@ -236,8 +233,8 @@
             await controller.listStemmas();
             signedIn = true;
         } catch (err) {
+            if (signedIn) return;
             if ((err as { key?: string }).key === "error.sessionExpired") {
-                signedIn = false;
                 fetch(`${stemma_backend_url}/warmup`).catch(() => {});
                 return;
             }

--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -16,10 +16,10 @@ type Gsi = {
                 client_id: string;
                 callback: (resp: GsiCredentialResponse) => void;
                 auto_select?: boolean;
+                use_fedcm_for_prompt?: boolean;
             }) => void;
             prompt: (handler?: (n: GsiNotification) => void) => void;
             renderButton: (parent: HTMLElement, opts: Record<string, unknown>) => void;
-            disableAutoSelect: () => void;
         };
     };
 };
@@ -51,6 +51,7 @@ export function initializeGoogleAuth(clientId: string): Promise<void> {
                 for (const l of Array.from(listeners)) l(resp.credential);
             },
             auto_select: true,
+            use_fedcm_for_prompt: true,
         });
     });
     return initPromise;
@@ -70,7 +71,3 @@ export async function promptInitialSignIn(fallbackTarget: HTMLElement | null): P
     });
 }
 
-export function disableAutoSelect(): void {
-    const g = gsi();
-    if (g) g.accounts.id.disableAutoSelect();
-}

--- a/frontend/src/session.ts
+++ b/frontend/src/session.ts
@@ -1,18 +1,13 @@
 import { Model } from "./model";
 import type { Ref } from "./pendingState";
 
-type Listeners = {
-    onSignIn: () => void;
-    onSignOut: () => void;
-};
-
 export class Session {
     readonly e2eAutoLoginEnabled: boolean;
 
     constructor(
         private model: Model,
         private signedInRef: Ref<boolean>,
-        private listeners: Listeners,
+        private onSignIn: () => void,
     ) {
         this.e2eAutoLoginEnabled = typeof E2E_AUTO_LOGIN !== "undefined" && E2E_AUTO_LOGIN === "1";
     }
@@ -27,14 +22,14 @@ export class Session {
     async signIn(idToken: string): Promise<void> {
         await this.model.login(idToken);
         this.signedInRef.set(true);
-        this.listeners.onSignIn();
+        this.onSignIn();
     }
 
     async signInAsE2eUser(): Promise<void> {
         const override = (window as unknown as { __STEMMA_E2E_USER__?: string }).__STEMMA_E2E_USER__;
         await this.model.login(override || "e2e-user@stemma.local");
         this.signedInRef.set(true);
-        this.listeners.onSignIn();
+        this.onSignIn();
     }
 
     async signOut(): Promise<void> {
@@ -44,11 +39,9 @@ export class Session {
             // Even if the logout request fails (network, expired cookie), drop client state.
         }
         this.signedInRef.set(false);
-        this.listeners.onSignOut();
     }
 
     markSignedOut(): void {
         this.signedInRef.set(false);
-        this.listeners.onSignOut();
     }
 }


### PR DESCRIPTION
## Summary
- Switch Google One Tap to FedCM (`use_fedcm_for_prompt: true`) so the prompt fires reliably under Chrome 128+ with third-party cookies blocked — returning users now see Google's native "Signing you in…" plaque on revisit.
- Stop calling `disableAutoSelect()` on sign-out (and drop the now-unused export) so auto-select stays armed for the next visit. Trade-off: a deliberate sign-out followed by an immediate revisit will re-auth silently; users wanting to switch accounts dismiss the One Tap prompt.
- Guard `probeCookieSession` so a stale-cookie 401 racing with One Tap's successful sign-in can no longer flip `signedIn` back to `false`.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm test` (213/213)
- [ ] Manual: sign out → reload stemma.link → expect "Signing you in…" plaque, not button.
- [ ] Manual: open stemma.link with expired cookie + active Google session → expect direct app load via One Tap, no flicker back to login screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)