### PR TITLE
Drop deprecated One Tap moment methods, always render button

### DIFF
--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -1,12 +1,3 @@
-type GsiNotification = {
-    isNotDisplayed: () => boolean;
-    isSkippedMoment: () => boolean;
-    isDismissedMoment?: () => boolean;
-    getNotDisplayedReason?: () => string;
-    getSkippedReason?: () => string;
-    getDismissedReason?: () => string;
-};
-
 type GsiCredentialResponse = { credential: string };
 
 type Gsi = {
@@ -18,7 +9,7 @@ type Gsi = {
                 auto_select?: boolean;
                 use_fedcm_for_prompt?: boolean;
             }) => void;
-            prompt: (handler?: (n: GsiNotification) => void) => void;
+            prompt: () => void;
             renderButton: (parent: HTMLElement, opts: Record<string, unknown>) => void;
         };
     };
@@ -64,10 +55,7 @@ export function onCredential(listener: CredentialListener): () => void {
 
 export async function promptInitialSignIn(fallbackTarget: HTMLElement | null): Promise<void> {
     const g = await awaitGsi();
-    g.accounts.id.prompt((notification) => {
-        if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
-            if (fallbackTarget) g.accounts.id.renderButton(fallbackTarget, { theme: "outline", size: "large" });
-        }
-    });
+    if (fallbackTarget) g.accounts.id.renderButton(fallbackTarget, { theme: "outline", size: "large" });
+    g.accounts.id.prompt();
 }
 


### PR DESCRIPTION
## Summary
- `isNotDisplayed()` / `isSkippedMoment()` are deprecated under FedCM (GSI logs an explicit warning) — their values cannot be trusted to drive the fallback button render once FedCM is mandatory.
- Render the Google Sign-In button unconditionally on init (its container stays hidden via `showSignIn` while probing). Call `prompt()` without a moment handler.
- One Tap's plaque layers on top when FedCM fires; the button is the backstop when it doesn't.

## Test plan
- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm test` (213/213)
- [ ] Manual: stemma.link with FedCM enabled + active Google session → expect plaque on reload
- [ ] Manual: stemma.link with FedCM blocked → expect button visible after cookie probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)