### PR TITLE
Show clan surname as-is and dim the glow

### DIFF
--- a/frontend/src/clanLayer.ts
+++ b/frontend/src/clanLayer.ts
@@ -142,7 +142,7 @@ export function updateClanLayer(
     blobs.enter()
         .append("path")
         .attr("class", "clan-blob")
-        .attr("opacity", 0.32)
+        .attr("opacity", 0.22)
         .merge(blobs)
         .attr("fill", d => d.clan.color)
         .attr("d", d => pathGen(paddedHull(d.points, d.shape)) ?? "");
@@ -155,7 +155,7 @@ export function updateClanLayer(
     labels.exit().remove();
     const labelsMerged = labelEntering.merge(labels);
     labelsMerged
-        .text(d => d.clan.plural.toUpperCase())
+        .text(d => d.clan.surname.toUpperCase())
         .attr("text-anchor", "middle")
         .attr("dominant-baseline", "middle")
         .attr("font-family", "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace")
@@ -163,14 +163,14 @@ export function updateClanLayer(
         .attr("font-style", "normal")
         .attr("letter-spacing", "0.1em")
         .attr("fill", "#ffffff")
-        .attr("opacity", 0.7)
+        .attr("opacity", 0.6)
         .attr("pointer-events", "none")
         .attr("transform", d => {
             const deg = (d.shape.angle * 180) / Math.PI;
             return `translate(${d.shape.cx},${d.shape.cy}) rotate(${deg})`;
         })
         .attr("font-size", d => {
-            const len = Math.max(1, d.clan.plural.length);
+            const len = Math.max(1, d.clan.surname.length);
             const widthFit = (d.shape.rx * 0.6) / (len * 0.6);
             const heightFit = d.shape.ry * 0.25;
             return Math.max(11, Math.min(widthFit, heightFit, 36));

--- a/frontend/src/clans.test.ts
+++ b/frontend/src/clans.test.ts
@@ -1,4 +1,4 @@
-import { clanColor, computeClans, nameTokens, pluralizeSurname } from "./clans";
+import { clanColor, computeClans, nameTokens } from "./clans";
 import type { FamilyDescription, PersonDescription, Stemma } from "./model";
 
 const person = (id: string, name: string): PersonDescription => ({
@@ -35,35 +35,6 @@ describe("nameTokens", () => {
     });
 });
 
-describe("pluralizeSurname (ru)", () => {
-    test.each([
-        ["Иванов", "Ивановы"],
-        ["Иванова", "Ивановы"],
-        ["Медведев", "Медведевы"],
-        ["Медведева", "Медведевы"],
-        ["Пушкин", "Пушкины"],
-        ["Пушкина", "Пушкины"],
-        ["Достоевский", "Достоевские"],
-        ["Достоевская", "Достоевские"],
-        ["Троцкий", "Троцкие"],
-        ["Сидоровы", "Сидоровы"],
-        ["Ивановы", "Ивановы"],
-        ["Достоевские", "Достоевские"],
-        ["Гёте", "Гётеы"],
-    ])("ru: %s → %s", (s, expected) => {
-        expect(pluralizeSurname(s, "ru")).toBe(expected);
-    });
-});
-
-describe("pluralizeSurname (en)", () => {
-    test("appends s", () => {
-        expect(pluralizeSurname("Smith", "en")).toBe("Smiths");
-    });
-    test("empty stays empty", () => {
-        expect(pluralizeSurname("", "en")).toBe("");
-    });
-});
-
 describe("clanColor", () => {
     test("stable per surname", () => {
         expect(clanColor("Иванов")).toBe(clanColor("Иванов"));
@@ -90,7 +61,7 @@ describe("computeClans (≥6 carriers, ≥3-generation chain)", () => {
 
     test("six members across three generations all sharing a surname → clan", () => {
         const { people, families } = dynastySix("Сидоров");
-        const clans = computeClans(stemma(people, families), "ru");
+        const clans = computeClans(stemma(people, families));
         expect(clans).toHaveLength(1);
         expect(clans[0].surname).toBe("Сидоров");
         expect(clans[0].personIds.size).toBe(6);
@@ -104,7 +75,7 @@ describe("computeClans (≥6 carriers, ≥3-generation chain)", () => {
         const e = person("e", "Ольга Сидорова");
         // 5 carriers but only 2 generations → no clan
         const f1 = family("f1", ["a", "b"], ["c", "d", "e"]);
-        expect(computeClans(stemma([a, b, c, d, e], [f1]), "ru")).toEqual([]);
+        expect(computeClans(stemma([a, b, c, d, e], [f1]))).toEqual([]);
     });
 
     test("six carriers in only two generations → no clan (needs three)", () => {
@@ -115,7 +86,7 @@ describe("computeClans (≥6 carriers, ≥3-generation chain)", () => {
         const e = person("e", "Сын2 Сидоров");
         const f = person("f", "Сын3 Сидоров");
         const fam = family("f1", ["a", "b"], ["c", "d", "e", "f"]);
-        expect(computeClans(stemma([a, b, c, d, e, f], [fam]), "ru")).toEqual([]);
+        expect(computeClans(stemma([a, b, c, d, e, f], [fam]))).toEqual([]);
     });
 
     test("dynasty surname persists across in-laws of different surname", () => {
@@ -132,7 +103,7 @@ describe("computeClans (≥6 carriers, ≥3-generation chain)", () => {
         const f1 = family("f1", ["m", "w0"], ["a"]);
         const f2 = family("f2", ["a", "w1"], ["p"]);
         const f3 = family("f3", ["p", "w2"], ["s1", "s2", "s3"]);
-        const clans = computeClans(stemma([m, w0, a, w1, p, w2, s1, s2, s3], [f1, f2, f3]), "ru");
+        const clans = computeClans(stemma([m, w0, a, w1, p, w2, s1, s2, s3], [f1, f2, f3]));
         const rom = clans.find(c => c.surname === "Романов")!;
         expect(rom).toBeDefined();
         expect([...rom.personIds].sort()).toEqual(["a", "m", "p", "s1", "s2", "s3"]);
@@ -145,7 +116,7 @@ describe("computeClans (≥6 carriers, ≥3-generation chain)", () => {
         const d = person("d", "Дочь Мария Сидорова");
         const f1 = family("f1", ["g"], ["m"]);
         const f2 = family("f2", ["m"], ["d"]);
-        const clans = computeClans(stemma([g, m, d], [f1, f2]), "ru");
+        const clans = computeClans(stemma([g, m, d], [f1, f2]));
         expect(clans.find(c => c.surname === "Мария")).toBeUndefined();
     });
 });

--- a/frontend/src/clans.ts
+++ b/frontend/src/clans.ts
@@ -1,9 +1,7 @@
 import type { Stemma } from "./model";
-import type { Locale } from "./i18n";
 
 export type Clan = {
     surname: string;
-    plural: string;
     color: string;
     personIds: ReadonlySet<string>;
 };
@@ -68,30 +66,16 @@ export function canonicalSurname(surname: string): string {
     return s;
 }
 
-export function pluralizeSurname(surname: string, locale: Locale): string {
-    if (!surname) return "";
-    if (locale === "en") return surname + "s";
-    const s = surname;
-    if (/(овы|евы|ёвы|ины|ыны|ские|цкие)$/u.test(s)) return s;
-    if (/(ский|цкий)$/u.test(s)) return s.slice(0, -2) + "ие";
-    if (/(ская|цкая)$/u.test(s)) return s.slice(0, -2) + "ие";
-    if (/(ов|ев|ёв|ын)$/u.test(s)) return s + "ы";
-    if (/(ова|ева|ёва|ына)$/u.test(s)) return s.slice(0, -1) + "ы";
-    if (/ин$/u.test(s)) return s + "ы";
-    if (/ина$/u.test(s)) return s.slice(0, -1) + "ы";
-    return s + "ы";
-}
-
 export function clanColor(surname: string): string {
     let h = 0;
     for (let i = 0; i < surname.length; i++) {
         h = (h * 31 + surname.charCodeAt(i)) | 0;
     }
     const hue = ((h % 360) + 360) % 360;
-    return `hsl(${hue}, 65%, 55%)`;
+    return `hsl(${hue}, 38%, 72%)`;
 }
 
-export function computeClans(stemma: Stemma, locale: Locale): Clan[] {
+export function computeClans(stemma: Stemma): Clan[] {
     // Family-graph adjacency: two persons share an edge if they appear together
     // in any family (spouses, parent-child, or siblings sharing parents).
     const neighbors = new Map<string, Set<string>>();
@@ -184,7 +168,6 @@ export function computeClans(stemma: Stemma, locale: Locale): Clan[] {
             if (!spansGenerations(component, MIN_CLAN_GENERATIONS)) continue;
             clans.push({
                 surname: token,
-                plural: pluralizeSurname(token, locale),
                 color: clanColor(token),
                 personIds: component,
             });

--- a/frontend/src/components/FullStemma.svelte
+++ b/frontend/src/components/FullStemma.svelte
@@ -25,7 +25,7 @@
     import { PinnedPeopleStorage } from "../pinnedPeopleStorage";
     import { exportChartSvg } from "../svgExport";
     import { personDisplayName } from "../personDisplayName";
-    import { t, locale } from "../i18n";
+    import { t } from "../i18n";
     import { computeClans, type Clan } from "../clans";
     import { initClanLayer, updateClanLayer } from "../clanLayer";
 
@@ -103,16 +103,8 @@
             const [nodes, relations] = makeNodesAndRelations(displayPeople, families);
             const initialPositions = computeInitialLayout(stemmaIndex, people, families, window.innerWidth, window.innerHeight);
             currentNodes = nodes;
-            currentClans = computeClans({ type: "Stemma", people, families }, $locale);
+            currentClans = computeClans({ type: "Stemma", people, families });
             reconfigureGraph(nodes, relations, initialPositions);
-        }
-    });
-
-    $effect(() => {
-        if (svg && stemma) {
-            const { people, families } = viewSlice;
-            currentClans = computeClans({ type: "Stemma", people, families }, $locale);
-            if (currentNodes.length > 0) updateClanLayer(svg, currentClans, currentNodes);
         }
     });
 


### PR DESCRIPTION
## Summary
- Clan label is now the canonical surname (e.g. РОМАНОВ, ГЛЮКСБУРГ) — no pluralization in either locale. Female forms still normalize to masculine via canonicalSurname (Романова → Романов).
- Dropped pluralizeSurname and the Clan.plural field; computeClans no longer takes a locale argument.
- Muted clan glow: HSL saturation 65→38, lightness 55→72; blob opacity 0.32→0.22, label opacity 0.7→0.6.
- Removed the now-redundant locale-watching $effect in FullStemma (reconfigureGraph already recomputes clans when stemma/viewMode changes).

## Test plan
- [x] `npm test` (frontend): 231 passing.
- [x] `npm run check` (frontend): 0 errors.
- [x] Manual: opened devstack + Kings of Europe, verified labels read РОМАНОВ / ГОЛЬШТЕЙН-ГОТТОРПСКИЙ / ГРЕЧЕСКИЙ etc. instead of plural forms; glow visibly dimmer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)