### PR TITLE
Scale clan label to ~80% of clan area's max dimension

### DIFF
--- a/frontend/src/clanLayer.ts
+++ b/frontend/src/clanLayer.ts
@@ -171,9 +171,10 @@ export function updateClanLayer(
         })
         .attr("font-size", d => {
             const len = Math.max(1, d.clan.surname.length);
-            const widthFit = (d.shape.rx * 0.6) / (len * 0.6);
-            const heightFit = d.shape.ry * 0.25;
-            return Math.max(11, Math.min(widthFit, heightFit, 36));
+            // Label is rotated onto the major (rx) axis; target ~80% of each diameter.
+            const widthFit = (1.6 * d.shape.rx) / (len * 0.6);
+            const heightFit = 1.6 * d.shape.ry;
+            return Math.max(11, Math.min(widthFit, heightFit));
         })
         .attr("textLength", null)
         .attr("lengthAdjust", null);


### PR DESCRIPTION
## Summary
- Clan label font size now derives from the clan's bounding ellipse: width fills ~80% of the major (rx) diameter, height clamped to ~80% of the minor (ry) so a wide-thin clan doesn't get a label taller than its region.
- Removed the prior 36px upper cap so large clans get a proportionally large label.
- Min 11px floor preserved for tiny clans.

Closes #248

## Test plan
- [x] `npm test -- clanLayer` (clanShape invariants unchanged)
- [x] `npm run check`
- [ ] Manual: large clan → label spans edge-to-edge; small clan → still readable; wide-thin clan → label doesn't overflow vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)