### PR TITLE
ci: cache Playwright browsers and e2e npm deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,32 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
-        cache-dependency-path: frontend/package-lock.json
+        cache-dependency-path: |
+          frontend/package-lock.json
+          e2e/package-lock.json
     - name: Install frontend deps
       run: npm ci
       working-directory: frontend
     - name: Install e2e deps
-      run: npm install
+      run: npm ci
       working-directory: e2e
+    - name: Resolve Playwright version
+      id: pw
+      run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      working-directory: e2e
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
     - name: Install Playwright browser
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps chromium
+      working-directory: e2e
+    - name: Install Playwright system deps (cache hit)
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps chromium
       working-directory: e2e
     - name: Run e2e tests
       run: npm test


### PR DESCRIPTION
## Summary
- Cache `~/.cache/ms-playwright` keyed by `@playwright/test` version — skips ~150MB chromium download on cache hit.
- Add `e2e/package-lock.json` to `setup-node` cache; switch e2e from `npm install` to `npm ci`.
- On cache hit, still run `playwright install-deps chromium` since apt state isn't cached.

## Test plan
- [x] `gh workflow view ci.yml` — workflow registers without syntax error
- [ ] First CI run after merge: confirm cache miss saves browsers; subsequent run hits cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)