### PR TITLE
fix: gate Google sign-in behind cookie probe; spinner during auth

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,7 +12,6 @@
     import { PinnedPeopleStorage } from "./pinnedPeopleStorage";
     import { ViewMode } from "./model";
     import { LocalizedError, t } from "./i18n";
-    import { initializeGoogleAuth } from "./googleAuth";
     import Authenticate from "./components/Authenticate.svelte";
     import FullStemma from "./components/FullStemma.svelte";
     import Sheet from "./components/Sheet.svelte";
@@ -82,6 +81,7 @@
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let signedIn = $state(false);
     let bootProbing = $state(true);
+    let signingIn = $state(false);
 
     const actions = new MutationActions({
         controller,
@@ -124,11 +124,15 @@
     }
 
     async function handleGoogleSignIn(idToken: string) {
+        fetch(`${stemma_backend_url}/warmup`).catch(() => {});
+        signingIn = true;
         try {
             await session.signIn(idToken);
         } catch (err) {
             error = err as Error;
             console.error("Sign-in failed", err);
+        } finally {
+            signingIn = false;
         }
     }
 
@@ -245,10 +249,7 @@
     onMount(() => {
         const boot = session.e2eAutoLoginEnabled
             ? session.signInAsE2eUser()
-            : (initializeGoogleAuth(google_client_id).catch((err) =>
-                  console.error("Google Identity init failed", err),
-              ),
-              probeCookieSession());
+            : probeCookieSession();
         void Promise.resolve(boot).finally(() => (bootProbing = false));
         return () => {
             for (const unsub of subscriptions) unsub();
@@ -423,7 +424,11 @@
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} showSignIn={!bootProbing} />
+            {#if bootProbing || signingIn}
+                <Circle2 />
+            {:else}
+                <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
+            {/if}
         </div>
     </div>
 {/if}

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -5,10 +5,9 @@
     type Props = {
         google_client_id: string;
         onsignIn?: (idToken: string) => void;
-        showSignIn?: boolean;
     };
 
-    let { google_client_id, onsignIn, showSignIn = true }: Props = $props();
+    let { google_client_id, onsignIn }: Props = $props();
 
     onMount(() => {
         const unsubscribe = onCredential((credential) => onsignIn?.(credential));
@@ -27,7 +26,7 @@
     <div class="d-flex justify-content-center align-items-center flex-column">
         <h1>project stemma</h1>
         <img src="assets/logo_bw_avg.webp" alt="" width="100" height="100" />
-        <div class="mt-5 signin-slot" class:signin-hidden={!showSignIn} style="max-width:250px">
+        <div class="mt-5 signin-slot" style="max-width:250px">
             <div id="signin"></div>
         </div>
     </div>
@@ -51,9 +50,5 @@
 
     :global(.abcRioButton) {
         margin: auto;
-    }
-
-    .signin-hidden {
-        visibility: hidden;
     }
 </style>


### PR DESCRIPTION
## Summary
- onMount now awaits `probeCookieSession()` before touching Google Identity Services. With a valid cookie, GIS is never initialized, so the "Signing you in" One Tap overlay no longer floats over the loaded stemma.
- Auth screen renders a `Circle2` spinner while probing the cookie or completing `model.login` instead of an empty background.
- `handleGoogleSignIn` fires `/warmup` the moment a Google credential arrives so the Lambda is hot by the time `AuthLoginRequest` lands.
- `Authenticate` is now only mounted when the user actually needs to sign in — dropped the `showSignIn` prop and `signin-hidden` style.

## Test plan
- [x] `npm run check` (frontend)
- [x] `npm test` (frontend, 234 tests)
- [x] `npm test` (e2e, 7 tests)
- [ ] Manual: hard refresh with a valid session cookie — stemma loads behind a spinner, no Google overlay.
- [ ] Manual: hard refresh with no/expired cookie — spinner during probe, then signin form; sign in → spinner → stemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)