### PR TITLE
fix: plain spinner during probe; keep auth screen during login

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -81,7 +81,6 @@
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let signedIn = $state(false);
     let bootProbing = $state(true);
-    let signingIn = $state(false);
 
     const actions = new MutationActions({
         controller,
@@ -125,14 +124,11 @@
 
     async function handleGoogleSignIn(idToken: string) {
         fetch(`${stemma_backend_url}/warmup`).catch(() => {});
-        signingIn = true;
         try {
             await session.signIn(idToken);
         } catch (err) {
             error = err as Error;
             console.error("Sign-in failed", err);
-        } finally {
-            signingIn = false;
         }
     }
 
@@ -421,14 +417,14 @@
     />
     <PromptModal bind:this={promptModal} />
     <ConfirmModal bind:this={confirmModal} />
+{:else if bootProbing}
+    <div class="boot-loading vh-100">
+        <Circle2 />
+    </div>
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            {#if bootProbing || signingIn}
-                <Circle2 />
-            {:else}
-                <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
-            {/if}
+            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
         </div>
     </div>
 {/if}
@@ -519,6 +515,13 @@
         align-items: center;
         width: 100%;
         height: 100%;
+    }
+
+    .boot-loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: #f8f9fa;
     }
 
 </style>


### PR DESCRIPTION
## Summary
- Boot spinner renders on a neutral `#f8f9fa` background instead of the trees backdrop. Cookie probe → plain spinner → either main app (cookie valid) or auth screen (cookie invalid).
- Removed the short-lived `signingIn` state. The auth screen stays visible while `model.login` is in flight after a Google credential; only when `signedIn` flips does the main app take over and show its own `isWorking` spinner during `listStemmas`.

Follow-up to #253 — that PR was already merged, so this lands the spinner-background tweak on a new branch.

## Test plan
- [x] `npm run check` (frontend)
- [x] `npm test` (frontend, 234 tests)
- [x] `npm test` (e2e, 7 tests)
- [ ] Manual, cookie valid: hard refresh → plain spinner → stemma. No trees, no Google overlay.
- [ ] Manual, cookie invalid: hard refresh → plain spinner → trees + project stemma + Google widget → click/auto sign in → trees stay → stemma loads with main-app spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)