### PR TITLE
fix: show trees + project stemma immediately, gate Google init

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -417,14 +417,14 @@
     />
     <PromptModal bind:this={promptModal} />
     <ConfirmModal bind:this={confirmModal} />
-{:else if bootProbing}
-    <div class="boot-loading vh-100">
-        <Circle2 />
-    </div>
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
+            <Authenticate
+                {google_client_id}
+                onsignIn={handleGoogleSignIn}
+                initGoogle={!bootProbing}
+            />
         </div>
     </div>
 {/if}
@@ -515,13 +515,6 @@
         align-items: center;
         width: 100%;
         height: 100%;
-    }
-
-    .boot-loading {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        background: #f8f9fa;
     }
 
 </style>

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
-    import { onMount } from "svelte";
     import { initializeGoogleAuth, onCredential, promptInitialSignIn } from "../googleAuth";
 
     type Props = {
         google_client_id: string;
         onsignIn?: (idToken: string) => void;
+        initGoogle?: boolean;
     };
 
-    let { google_client_id, onsignIn }: Props = $props();
+    let { google_client_id, onsignIn, initGoogle = false }: Props = $props();
 
-    onMount(() => {
+    $effect(() => {
+        if (!initGoogle) return;
         const unsubscribe = onCredential((credential) => onsignIn?.(credential));
-        initializeGoogleAuth(google_client_id)
+        void initializeGoogleAuth(google_client_id)
             .then(() => promptInitialSignIn(document.getElementById("signin")))
             .catch((err) => console.error("Google Identity init failed", err));
         return unsubscribe;


### PR DESCRIPTION
## Summary
- Auth screen renders from the first frame: trees backdrop, "project stemma" title, and logo. No spinner over the trees during cookie probe.
- `Authenticate` gained an `initGoogle` prop; Google Identity Services only initializes once the cookie probe has resolved. That keeps a valid-cookie path overlay-free while preserving the One Tap auto-select when the user actually needs to sign in.

Follow-up to #254 (merged) — landed on a new branch since the previous PR was already closed.

## Test plan
- [x] `npm run check` (frontend)
- [x] `npm test` (frontend, 234 tests)
- [x] `npm test` (e2e, 7 tests)
- [ ] Manual, cookie valid: hard refresh → trees + title flash → stemma renders. No Google overlay.
- [ ] Manual, cookie invalid: hard refresh → trees + title visible immediately → Google widget appears after probe → click/auto sign in → trees stay → stemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)