### PR TITLE
fix: LinkedIn-style entry — landing always, no overlay spinner

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,7 @@
     import { PinnedPeopleStorage } from "./pinnedPeopleStorage";
     import { ViewMode } from "./model";
     import { LocalizedError, t } from "./i18n";
+    import { cancelGoogleAuth } from "./googleAuth";
     import Authenticate from "./components/Authenticate.svelte";
     import FullStemma from "./components/FullStemma.svelte";
     import Sheet from "./components/Sheet.svelte";
@@ -80,7 +81,6 @@
     let pendingRemovedPersonIds = $state<Set<string>>(new Set());
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let signedIn = $state(false);
-    let bootProbing = $state(true);
 
     const actions = new MutationActions({
         controller,
@@ -232,6 +232,7 @@
         try {
             await controller.listStemmas();
             signedIn = true;
+            cancelGoogleAuth();
         } catch (err) {
             if (signedIn) return;
             if ((err as { key?: string }).key === "error.sessionExpired") {
@@ -243,10 +244,11 @@
     }
 
     onMount(() => {
-        const boot = session.e2eAutoLoginEnabled
-            ? session.signInAsE2eUser()
-            : probeCookieSession();
-        void Promise.resolve(boot).finally(() => (bootProbing = false));
+        if (session.e2eAutoLoginEnabled) {
+            void session.signInAsE2eUser();
+        } else {
+            void probeCookieSession();
+        }
         return () => {
             for (const unsub of subscriptions) unsub();
         };
@@ -420,11 +422,7 @@
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            <Authenticate
-                {google_client_id}
-                onsignIn={handleGoogleSignIn}
-                initGoogle={!bootProbing}
-            />
+            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
         </div>
     </div>
 {/if}

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import { initializeGoogleAuth, onCredential, promptInitialSignIn } from "../googleAuth";
 
     type Props = {
         google_client_id: string;
         onsignIn?: (idToken: string) => void;
-        initGoogle?: boolean;
     };
 
-    let { google_client_id, onsignIn, initGoogle = false }: Props = $props();
+    let { google_client_id, onsignIn }: Props = $props();
 
-    $effect(() => {
-        if (!initGoogle) return;
+    onMount(() => {
         const unsubscribe = onCredential((credential) => onsignIn?.(credential));
-        void initializeGoogleAuth(google_client_id)
+        initializeGoogleAuth(google_client_id)
             .then(() => promptInitialSignIn(document.getElementById("signin")))
             .catch((err) => console.error("Google Identity init failed", err));
         return unsubscribe;

--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -10,6 +10,7 @@ type Gsi = {
                 use_fedcm_for_prompt?: boolean;
             }) => void;
             prompt: () => void;
+            cancel: () => void;
             renderButton: (parent: HTMLElement, opts: Record<string, unknown>) => void;
         };
     };
@@ -57,5 +58,9 @@ export async function promptInitialSignIn(fallbackTarget: HTMLElement | null): P
     const g = await awaitGsi();
     if (fallbackTarget) g.accounts.id.renderButton(fallbackTarget, { theme: "outline", size: "large" });
     g.accounts.id.prompt();
+}
+
+export function cancelGoogleAuth(): void {
+    gsi()?.accounts.id.cancel();
 }
 


### PR DESCRIPTION
## Summary
- The auth landing (trees backdrop, "project stemma", Google sign-in widget) renders from the first frame whenever the user is not signed in. There is no longer a custom overlay spinner during cookie probe or sign-in; Google Identity Services handles its own progress UI (One Tap "Signing you in" panel, button states) while authentication is in flight.
- The cookie probe still runs on mount. When it succeeds, the app switches to the main view and calls `google.accounts.id.cancel()` so any in-flight One Tap dialog is dismissed instead of floating over the loaded stemma.
- Adds a `cancelGoogleAuth()` helper around `google.accounts.id.cancel()`.

Follow-up to #255 (already merged) — new branch since the previous PR was closed.

## Test plan
- [x] `npm run check` (frontend)
- [x] `npm test` (frontend, 234 tests)
- [x] `npm test` (e2e, 7 tests)
- [ ] Manual, valid cookie: hard refresh → landing visible briefly → main app loads, Google One Tap dismissed (no overlay over stemma).
- [ ] Manual, expired/missing cookie: landing stays, Google widget initializes, click/auto sign in → Google's own panel shows progress → stemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)