### PR TITLE
fix: spinner in Google button slot while model.login is in flight

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -81,6 +81,7 @@
     let pendingRemovedPersonIds = $state<Set<string>>(new Set());
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let signedIn = $state(false);
+    let signingIn = $state(false);
 
     const actions = new MutationActions({
         controller,
@@ -124,11 +125,14 @@
 
     async function handleGoogleSignIn(idToken: string) {
         fetch(`${stemma_backend_url}/warmup`).catch(() => {});
+        signingIn = true;
         try {
             await session.signIn(idToken);
         } catch (err) {
             error = err as Error;
             console.error("Sign-in failed", err);
+        } finally {
+            signingIn = false;
         }
     }
 
@@ -422,7 +426,7 @@
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
+            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} {signingIn} />
         </div>
     </div>
 {/if}

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
     import { onMount } from "svelte";
+    import { Circle2 } from "svelte-loading-spinners";
     import { initializeGoogleAuth, onCredential, promptInitialSignIn } from "../googleAuth";
 
     type Props = {
         google_client_id: string;
         onsignIn?: (idToken: string) => void;
+        signingIn?: boolean;
     };
 
-    let { google_client_id, onsignIn }: Props = $props();
+    let { google_client_id, onsignIn, signingIn = false }: Props = $props();
 
     onMount(() => {
         const unsubscribe = onCredential((credential) => onsignIn?.(credential));
@@ -27,7 +29,13 @@
         <h1>project stemma</h1>
         <img src="assets/logo_bw_avg.webp" alt="" width="100" height="100" />
         <div class="mt-5 signin-slot" style="max-width:250px">
-            <div id="signin"></div>
+            {#if signingIn}
+                <div class="signing-in-spinner">
+                    <Circle2 size="40" />
+                </div>
+            {:else}
+                <div id="signin"></div>
+            {/if}
         </div>
     </div>
 </div>
@@ -50,5 +58,12 @@
 
     :global(.abcRioButton) {
         margin: auto;
+    }
+
+    .signing-in-spinner {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 40px;
     }
 </style>


### PR DESCRIPTION
## Summary
- After GIS delivers a credential (auto-select or manual click) and before `signedIn` flips, `model.login` is running but there is no visual feedback. The Google sign-in button slot now swaps to a `Circle2` spinner during that window (`signingIn` state in `App.svelte`, prop on `Authenticate`).
- The landing (trees backdrop + "project stemma") stays visible — no overlay. When login completes the main app takes over.

## Test plan
- [x] `npm run check` (frontend)
- [x] `npm test` (frontend, 234 tests)
- [ ] Manual: auto-select or click Google → button area shows spinner while backend processes login → stemma loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)