### PR TITLE
fix: full-screen spinner when session exists; progress bar during login

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -81,6 +81,8 @@
     let pendingRemovedPersonIds = $state<Set<string>>(new Set());
     let pendingRemovedFamilyIds = $state<Set<string>>(new Set());
     let signedIn = $state(false);
+    let signingIn = $state(false);
+    let bootProbing = $state(true);
 
     const actions = new MutationActions({
         controller,
@@ -124,11 +126,14 @@
 
     async function handleGoogleSignIn(idToken: string) {
         fetch(`${stemma_backend_url}/warmup`).catch(() => {});
+        signingIn = true;
         try {
             await session.signIn(idToken);
         } catch (err) {
             error = err as Error;
             console.error("Sign-in failed", err);
+        } finally {
+            signingIn = false;
         }
     }
 
@@ -244,11 +249,10 @@
     }
 
     onMount(() => {
-        if (session.e2eAutoLoginEnabled) {
-            void session.signInAsE2eUser();
-        } else {
-            void probeCookieSession();
-        }
+        const boot = session.e2eAutoLoginEnabled
+            ? session.signInAsE2eUser()
+            : probeCookieSession();
+        void Promise.resolve(boot).finally(() => (bootProbing = false));
         return () => {
             for (const unsub of subscriptions) unsub();
         };
@@ -419,10 +423,15 @@
     />
     <PromptModal bind:this={promptModal} />
     <ConfirmModal bind:this={confirmModal} />
+{:else if bootProbing}
+    <div class="boot-loading vh-100">
+        <Circle2 />
+        <p class="mt-2">{$t("app.loading")}</p>
+    </div>
 {:else}
     <div class="authenticate-bg vh-100">
         <div class="authenticate-holder">
-            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} />
+            <Authenticate {google_client_id} onsignIn={handleGoogleSignIn} {signingIn} />
         </div>
     </div>
 {/if}
@@ -513,6 +522,14 @@
         align-items: center;
         width: 100%;
         height: 100%;
+    }
+
+    .boot-loading {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        background: #f8f9fa;
     }
 
 </style>

--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { initializeGoogleAuth, onCredential, promptInitialSignIn } from "../googleAuth";
+    import { initializeGoogleAuth, onCredential } from "../googleAuth";
 
     type Props = {
         google_client_id: string;
         onsignIn?: (idToken: string) => void;
+        signingIn?: boolean;
     };
 
-    let { google_client_id, onsignIn }: Props = $props();
+    let { google_client_id, onsignIn, signingIn = false }: Props = $props();
 
     onMount(() => {
         const unsubscribe = onCredential((credential) => onsignIn?.(credential));
         initializeGoogleAuth(google_client_id)
-            .then(() => promptInitialSignIn(document.getElementById("signin")))
+            .then((g) => g.accounts.id.prompt())
             .catch((err) => console.error("Google Identity init failed", err));
         return unsubscribe;
     });
@@ -26,9 +27,11 @@
     <div class="d-flex justify-content-center align-items-center flex-column">
         <h1>project stemma</h1>
         <img src="assets/logo_bw_avg.webp" alt="" width="100" height="100" />
-        <div class="mt-5 signin-slot" style="max-width:250px">
-            <div id="signin"></div>
-        </div>
+        {#if signingIn}
+            <div class="progress mt-5" style="width:250px; height:4px">
+                <div class="progress-bar progress-bar-striped progress-bar-animated w-100"></div>
+            </div>
+        {/if}
     </div>
 </div>
 
@@ -46,9 +49,5 @@
         color: ghostwhite;
         border-radius: 10px;
         padding: 40px 60px;
-    }
-
-    :global(.abcRioButton) {
-        margin: auto;
     }
 </style>

--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -11,14 +11,13 @@ type Gsi = {
             }) => void;
             prompt: () => void;
             cancel: () => void;
-            renderButton: (parent: HTMLElement, opts: Record<string, unknown>) => void;
         };
     };
 };
 
 type CredentialListener = (token: string) => void;
 
-let initPromise: Promise<void> | null = null;
+let initPromise: Promise<Gsi> | null = null;
 const listeners = new Set<CredentialListener>();
 
 function gsi(): Gsi | null {
@@ -34,7 +33,7 @@ async function awaitGsi(): Promise<Gsi> {
     return g;
 }
 
-export function initializeGoogleAuth(clientId: string): Promise<void> {
+export function initializeGoogleAuth(clientId: string): Promise<Gsi> {
     if (initPromise) return initPromise;
     initPromise = awaitGsi().then((g) => {
         g.accounts.id.initialize({
@@ -45,6 +44,7 @@ export function initializeGoogleAuth(clientId: string): Promise<void> {
             auto_select: true,
             use_fedcm_for_prompt: true,
         });
+        return g;
     });
     return initPromise;
 }
@@ -54,13 +54,6 @@ export function onCredential(listener: CredentialListener): () => void {
     return () => listeners.delete(listener);
 }
 
-export async function promptInitialSignIn(fallbackTarget: HTMLElement | null): Promise<void> {
-    const g = await awaitGsi();
-    if (fallbackTarget) g.accounts.id.renderButton(fallbackTarget, { theme: "outline", size: "large" });
-    g.accounts.id.prompt();
-}
-
 export function cancelGoogleAuth(): void {
     gsi()?.accounts.id.cancel();
 }
-


### PR DESCRIPTION
## Summary
Three distinct auth states now map to distinct UIs:

1. **Cookie probe in flight** → full-screen spinner + "Минуту…" on a neutral `#f8f9fa` background. Replaced the immediate landing flash for returning users.
2. **No/expired session** → landing (trees backdrop + "project stemma") with Google One Tap triggered via `prompt()`. The rendered `Sign in with Google` button is gone — One Tap shows natively in the browser corner and owns its own progress UI.
3. **After credential, while `model.login` runs** → an animated Bootstrap indeterminate progress bar inside the landing card. On probe success, `cancelGoogleAuth()` (`google.accounts.id.cancel()`) dismisses any in-flight One Tap dialog.

`initializeGoogleAuth` now returns `Promise<Gsi>` so callers can chain `.then(g => g.accounts.id.prompt())` directly. Removed dead `promptInitialSignIn` helper.

## Test plan
- [x] `npm run check` (frontend)
- [x] `npm test` (frontend, 234 tests)
- [x] `npm test` (e2e, 7 tests)
- [ ] Manual, valid cookie: hard refresh → spinner + "Минуту…" → stemma. No landing.
- [ ] Manual, no cookie: hard refresh → landing immediately → Google One Tap appears → auto-select fires → progress bar in card → stemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)