### PR TITLE
fix: Google Sign-In button on mobile; iOS Safari FedCM fix

### DIFF
--- a/frontend/src/components/Authenticate.svelte
+++ b/frontend/src/components/Authenticate.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { initializeGoogleAuth, onCredential } from "../googleAuth";
+    import { initializeGoogleAuth, onCredential, renderGoogleButton } from "../googleAuth";
+    import { get } from "svelte/store";
+    import { locale } from "../i18n";
 
     type Props = {
         google_client_id: string;
@@ -9,6 +11,7 @@
     };
 
     let { google_client_id, onsignIn, signingIn = false }: Props = $props();
+    let buttonDiv = $state<HTMLDivElement | null>(null);
 
     onMount(() => {
         const unsubscribe = onCredential((credential) => onsignIn?.(credential));
@@ -16,6 +19,13 @@
             .then((g) => g.accounts.id.prompt())
             .catch((err) => console.error("Google Identity init failed", err));
         return unsubscribe;
+    });
+
+    $effect(() => {
+        if (buttonDiv) {
+            renderGoogleButton(buttonDiv, get(locale))
+                .catch((err) => console.error("Google Sign-In button render failed", err));
+        }
     });
 </script>
 
@@ -31,6 +41,8 @@
             <div class="progress mt-5" style="width:250px; height:4px">
                 <div class="progress-bar progress-bar-striped progress-bar-animated w-100"></div>
             </div>
+        {:else}
+            <div bind:this={buttonDiv} class="mt-4"></div>
         {/if}
     </div>
 </div>

--- a/frontend/src/googleAuth.ts
+++ b/frontend/src/googleAuth.ts
@@ -1,5 +1,15 @@
 type GsiCredentialResponse = { credential: string };
 
+type GsiButtonOptions = {
+    type?: "standard" | "icon";
+    theme?: "outline" | "filled_blue" | "filled_black";
+    size?: "large" | "medium" | "small";
+    text?: "signin_with" | "signup_with" | "continue_with" | "signin";
+    shape?: "rectangular" | "pill" | "circle" | "square";
+    width?: number;
+    locale?: string;
+};
+
 type Gsi = {
     accounts: {
         id: {
@@ -8,9 +18,11 @@ type Gsi = {
                 callback: (resp: GsiCredentialResponse) => void;
                 auto_select?: boolean;
                 use_fedcm_for_prompt?: boolean;
+                itp_support?: boolean;
             }) => void;
             prompt: () => void;
             cancel: () => void;
+            renderButton: (element: HTMLElement, options: GsiButtonOptions) => void;
         };
     };
 };
@@ -35,6 +47,7 @@ async function awaitGsi(): Promise<Gsi> {
 
 export function initializeGoogleAuth(clientId: string): Promise<Gsi> {
     if (initPromise) return initPromise;
+    const supportsFedCm = "IdentityCredential" in window;
     initPromise = awaitGsi().then((g) => {
         g.accounts.id.initialize({
             client_id: clientId,
@@ -42,11 +55,19 @@ export function initializeGoogleAuth(clientId: string): Promise<Gsi> {
                 for (const l of Array.from(listeners)) l(resp.credential);
             },
             auto_select: true,
-            use_fedcm_for_prompt: true,
+            use_fedcm_for_prompt: supportsFedCm,
+            itp_support: true,
         });
         return g;
     });
+    initPromise.catch(() => { initPromise = null; });
     return initPromise;
+}
+
+export function renderGoogleButton(element: HTMLElement, locale: string): Promise<void> {
+    return initPromise
+        ? initPromise.then((g) => g.accounts.id.renderButton(element, { type: "standard", theme: "outline", size: "large", locale }))
+        : Promise.resolve();
 }
 
 export function onCredential(listener: CredentialListener): () => void {


### PR DESCRIPTION
## Summary
- Adds explicit Google Sign-In button as fallback when One Tap auto-prompt doesn't show (iOS Safari, Android browsers)
- Gates `use_fedcm_for_prompt` on `IdentityCredential` browser support — iOS Safari doesn't support FedCM and the always-on flag was silently suppressing the prompt
- Adds `itp_support: true` for Safari ITP-compatible credential flow

## Bugs fixed (found by simplify/code-review)
- `initPromise` cached a rejected promise when GSI failed to load (ad-blocker, CSP) — auth permanently broken for the session; now resets on rejection so retries work
- `renderGoogleButton` was called once in `onMount`; after a failed sign-in `signingIn` flips back to false, the button div re-mounts but was never re-rendered — now uses `$effect` for reactive re-render
- `renderGoogleButton` unawaited rejected promise was silently swallowed — now has `.catch()`

## Test plan
- [x] `npm test` — 234 tests passed
- [x] `npm run check` — 0 errors
- [ ] Manual: open on iOS Safari — should see Google Sign-In button below logo
- [ ] Manual: trigger a sign-in failure (kill network) — button should reappear after error

🤖 Generated with [Claude Code](https://claude.com/claude-code)